### PR TITLE
fix: return chain id as hex

### DIFF
--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -20,8 +20,6 @@ use starknet_api::{
 };
 use std::sync::Mutex;
 
-use starknet::core::types::{FieldElement, FromByteSliceError};
-
 pub struct KatanaSequencer {
     pub block_context: BlockContext,
     pub state: Mutex<CachedState<DictStateReader>>,

--- a/crates/katana-rpc/src/lib.rs
+++ b/crates/katana-rpc/src/lib.rs
@@ -48,7 +48,7 @@ impl KatanaRpc {
 #[async_trait]
 impl KatanaApiServer for KatanaRpc {
     async fn chain_id(&self) -> Result<String, Error> {
-        Ok(self.sequencer.block_context.chain_id.to_string())
+        Ok(self.sequencer.block_context.chain_id.as_hex())
     }
 
     async fn get_nonce(&self, contract_address: String) -> Result<String, Error> {

--- a/crates/katana-rpc/src/lib.rs
+++ b/crates/katana-rpc/src/lib.rs
@@ -121,6 +121,7 @@ impl KatanaApiServer for KatanaRpc {
 #[cfg(test)]
 mod tests {
     use katana_core::sequencer::KatanaSequencer;
+    use starknet_api::core::ChainId;
 
     use crate::{api::KatanaApiServer, KatanaRpc};
 
@@ -128,7 +129,7 @@ mod tests {
     async fn chain_id_is_ok() {
         let rpc = KatanaRpc::new(KatanaSequencer::new());
         let chain_id = rpc.chain_id().await.unwrap();
-        assert_eq!(chain_id, "KATANA");
+        assert_eq!(chain_id, ChainId("KATANA".to_string()).as_hex());
     }
 
     #[tokio::test]


### PR DESCRIPTION
`starknet-rs` expects `chain id` response as hex.