### PR TITLE
refactor: block state and rpc

### DIFF
--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use starknet::providers::jsonrpc::models::{BlockId, BlockTag};
 
 use crate::{
-    starknet::{transaction::ExternalFunctionCall, StarknetConfig, StarknetWrapper},
+    starknet::{
+        block::StarknetBlock, transaction::ExternalFunctionCall, StarknetConfig, StarknetWrapper,
+    },
     util::{field_element_to_starkfelt, starkfelt_to_u128},
 };
 
@@ -123,9 +125,10 @@ impl Sequencer for KatanaSequencer {
         Ok((tx_hash, contract_address))
     }
 
-    fn add_account_transaction(&mut self, transaction: AccountTransaction) {
+    fn add_account_transaction(&mut self, transaction: AccountTransaction) -> Result<()> {
         self.starknet
-            .handle_transaction(Transaction::AccountTransaction(transaction));
+            .handle_transaction(Transaction::AccountTransaction(transaction))
+            .map_err(|e| e.into())
     }
 
     fn class_hash_at(
@@ -154,31 +157,27 @@ impl Sequencer for KatanaSequencer {
         self.starknet.block_context.block_number
     }
 
-    fn block(&self, block_id: BlockId) -> Result<Block, blockifier::state::errors::StateError> {
-        let block_number = match block_id {
-            BlockId::Number(number) => BlockNumber(number),
-            BlockId::Hash(hash) => *self
+    fn block(&self, block_id: BlockId) -> Option<StarknetBlock> {
+        match block_id {
+            BlockId::Number(number) => self
+                .starknet
+                .blocks
+                .num_to_block
+                .get(&BlockNumber(number))
+                .cloned(),
+
+            BlockId::Hash(hash) => self
                 .starknet
                 .blocks
                 .hash_to_num
                 .get(&BlockHash(field_element_to_starkfelt(&hash)))
-                .ok_or(blockifier::state::errors::StateError::StateReadError(
-                    "block not found".to_string(),
-                ))?,
-            BlockId::Tag(tag) => {
-                let current_height = self.starknet.blocks.current_height;
-                match tag {
-                    BlockTag::Latest => current_height.prev().unwrap(),
-                    BlockTag::Pending => current_height,
-                }
-            }
-        };
+                .and_then(|n| self.starknet.blocks.num_to_block.get(n).cloned()),
 
-        let block = self.starknet.blocks.num_to_block.get(&block_number).ok_or(
-            blockifier::state::errors::StateError::StateReadError("block not found".to_string()),
-        )?;
-
-        Ok(block.clone().0)
+            BlockId::Tag(tag) => match tag {
+                BlockTag::Latest => self.starknet.blocks.latest(),
+                BlockTag::Pending => self.starknet.blocks.pending_block.clone(),
+            },
+        }
     }
 
     fn nonce_at(
@@ -217,7 +216,7 @@ pub trait Sequencer {
 
     fn block_number(&self) -> BlockNumber;
 
-    fn block(&self, block_id: BlockId) -> Result<Block, blockifier::state::errors::StateError>;
+    fn block(&self, block_id: BlockId) -> Option<StarknetBlock>;
 
     fn transaction(&self, hash: &TransactionHash)
         -> Option<starknet_api::transaction::Transaction>;
@@ -249,5 +248,5 @@ pub trait Sequencer {
         signature: TransactionSignature,
     ) -> anyhow::Result<(TransactionHash, ContractAddress)>;
 
-    fn add_account_transaction(&mut self, transaction: AccountTransaction);
+    fn add_account_transaction(&mut self, transaction: AccountTransaction) -> Result<()>;
 }

--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -96,10 +96,10 @@ impl KatanaSequencer {
             BlockId::Tag(tag) => {
                 let current_height = self.starknet.blocks.current_block_number();
 
-                Some(match tag {
-                    BlockTag::Latest => current_height,
-                    BlockTag::Pending => current_height.next(),
-                })
+                match tag {
+                    BlockTag::Pending => None,
+                    BlockTag::Latest => Some(current_height),
+                }
             }
         }
     }
@@ -152,7 +152,6 @@ impl Sequencer for KatanaSequencer {
     fn add_account_transaction(&mut self, transaction: AccountTransaction) -> Result<()> {
         self.starknet
             .handle_transaction(Transaction::AccountTransaction(transaction))
-            .map_err(|e| e.into())
     }
 
     fn class_hash_at(
@@ -183,24 +182,11 @@ impl Sequencer for KatanaSequencer {
 
     fn block(&self, block_id: BlockId) -> Option<StarknetBlock> {
         match block_id {
-            BlockId::Number(number) => self
-                .starknet
-                .blocks
-                .num_to_block
-                .get(&BlockNumber(number))
-                .cloned(),
+            BlockId::Tag(BlockTag::Pending) => self.starknet.blocks.pending_block.clone(),
 
-            BlockId::Hash(hash) => self
-                .starknet
-                .blocks
-                .hash_to_num
-                .get(&BlockHash(field_element_to_starkfelt(&hash)))
-                .and_then(|n| self.starknet.blocks.num_to_block.get(n).cloned()),
-
-            BlockId::Tag(tag) => match tag {
-                BlockTag::Latest => self.starknet.blocks.latest(),
-                BlockTag::Pending => self.starknet.blocks.pending_block.clone(),
-            },
+            id => self
+                .block_number_from_block_id(id)
+                .and_then(|n| self.starknet.blocks.by_number(n)),
         }
     }
 

--- a/crates/katana-core/src/starknet/block.rs
+++ b/crates/katana-core/src/starknet/block.rs
@@ -61,6 +61,10 @@ impl StarknetBlock {
         }
     }
 
+    pub fn header(&self) -> &BlockHeader {
+        &self.inner.header
+    }
+
     pub fn insert_transaction(&mut self, transaction: Transaction) {
         self.inner.body.transactions.push(transaction);
     }
@@ -112,7 +116,7 @@ pub struct StarknetBlocks {
 }
 
 impl StarknetBlocks {
-    pub fn append_block(&mut self, mut block: StarknetBlock) -> Result<()> {
+    pub fn append_block(&mut self, block: StarknetBlock) -> Result<()> {
         let block_number = block.block_number();
         let expected_block_number = BlockNumber(self.num_to_block.len() as u64);
 

--- a/crates/katana-core/src/starknet/block.rs
+++ b/crates/katana-core/src/starknet/block.rs
@@ -1,15 +1,31 @@
 use std::collections::HashMap;
 
+use anyhow::{ensure, Result};
 use starknet_api::{
-    block::{Block, BlockBody, BlockHash, BlockHeader, BlockNumber, BlockTimestamp, GasPrice},
+    block::{
+        Block, BlockBody, BlockHash, BlockHeader, BlockNumber, BlockStatus, BlockTimestamp,
+        GasPrice,
+    },
     core::{ContractAddress, GlobalRoot},
     hash::{pedersen_hash_array, StarkFelt},
     stark_felt,
     transaction::{Transaction, TransactionOutput},
 };
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct StarknetBlock(pub Block);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StarknetBlock {
+    pub inner: Block,
+    pub status: Option<BlockStatus>,
+}
+
+impl Default for StarknetBlock {
+    fn default() -> Self {
+        Self {
+            status: None,
+            inner: Default::default(),
+        }
+    }
+}
 
 impl StarknetBlock {
     #[allow(clippy::too_many_arguments)]
@@ -23,61 +39,65 @@ impl StarknetBlock {
         timestamp: BlockTimestamp,
         transactions: Vec<Transaction>,
         transaction_outputs: Vec<TransactionOutput>,
+        status: Option<BlockStatus>,
     ) -> Self {
-        Self(Block {
-            header: BlockHeader {
-                block_hash,
-                parent_hash,
-                block_number,
-                gas_price,
-                state_root,
-                sequencer,
-                timestamp,
+        Self {
+            inner: Block {
+                header: BlockHeader {
+                    block_hash,
+                    parent_hash,
+                    block_number,
+                    gas_price,
+                    state_root,
+                    sequencer,
+                    timestamp,
+                },
+                body: BlockBody {
+                    transactions,
+                    transaction_outputs,
+                },
             },
-            body: BlockBody {
-                transactions,
-                transaction_outputs,
-            },
-        })
+            status,
+        }
     }
 
     pub fn insert_transaction(&mut self, transaction: Transaction) {
-        self.0.body.transactions.push(transaction);
+        self.inner.body.transactions.push(transaction);
     }
 
     pub fn transactions(&self) -> &[Transaction] {
-        &self.0.body.transactions
+        &self.inner.body.transactions
     }
 
     pub fn transaction_by_index(&self, transaction_id: usize) -> Option<Transaction> {
-        self.0.body.transactions.get(transaction_id).cloned()
+        self.inner.body.transactions.get(transaction_id).cloned()
     }
 
     pub fn block_hash(&self) -> BlockHash {
-        self.0.header.block_hash
+        self.inner.header.block_hash
     }
 
     pub fn block_number(&self) -> BlockNumber {
-        self.0.header.block_number
+        self.inner.header.block_number
     }
 
     pub fn parent_hash(&self) -> BlockHash {
-        self.0.header.parent_hash
+        self.inner.header.parent_hash
     }
 
     pub fn compute_block_hash(&self) -> BlockHash {
         BlockHash(pedersen_hash_array(&[
-            stark_felt!(self.0.header.block_number.0), // block number
-            stark_felt!(0),                            // global_state_root
-            self.0.header.state_root.0,                // sequencer_address
-            *self.0.header.sequencer.0.key(),          // block_timestamp
-            stark_felt!(self.0.header.timestamp.0),    // transaction_count
-            stark_felt!(self.0.body.transactions.len() as u64), // transaction_commitment
-            stark_felt!(0),                            // event_count
-            stark_felt!(0),                            // event_commitment
-            stark_felt!(0),                            // protocol_version
-            stark_felt!(0),                            // extra_data
-            stark_felt!(self.parent_hash().0),         // parent_block_hash
+            stark_felt!(self.inner.header.block_number.0), // block number
+            stark_felt!(0),                                // global_state_root
+            self.inner.header.state_root.0,                // sequencer_address
+            *self.inner.header.sequencer.0.key(),          // block_timestamp
+            stark_felt!(self.inner.header.timestamp.0),    // transaction_count
+            stark_felt!(self.inner.body.transactions.len() as u64), // transaction_commitment
+            stark_felt!(0),                                // event_count
+            stark_felt!(0),                                // event_commitment
+            stark_felt!(0),                                // protocol_version
+            stark_felt!(0),                                // extra_data
+            stark_felt!(self.parent_hash().0),             // parent_block_hash
         ]))
     }
 }
@@ -85,23 +105,32 @@ impl StarknetBlock {
 // TODO: add state archive
 #[derive(Debug, Default)]
 pub struct StarknetBlocks {
-    pub current_height: BlockNumber,
+    // pub current_height: BlockNumber,
     pub hash_to_num: HashMap<BlockHash, BlockNumber>,
     pub num_to_block: HashMap<BlockNumber, StarknetBlock>,
     pub pending_block: Option<StarknetBlock>,
 }
 
 impl StarknetBlocks {
-    pub fn append_block(&mut self, block: StarknetBlock) {
+    pub fn append_block(&mut self, mut block: StarknetBlock) -> Result<()> {
         let block_number = block.block_number();
+        let expected_block_number = BlockNumber(self.num_to_block.len() as u64);
+
+        ensure!(
+            expected_block_number == block_number,
+            "unable to append block; expected block number {expected_block_number}, actual {block_number}"
+        );
+
         self.hash_to_num.insert(block.block_hash(), block_number);
         self.num_to_block.insert(block_number, block);
+
+        Ok(())
     }
 
-    pub fn lastest(&self) -> Option<StarknetBlock> {
-        self.current_height
+    pub fn latest(&self) -> Option<StarknetBlock> {
+        BlockNumber(self.num_to_block.len() as u64)
             .prev()
-            .and_then(|block_number| self.num_to_block.get(&block_number).cloned())
+            .and_then(|num| self.num_to_block.get(&num).cloned())
     }
 
     pub fn by_hash(&self, block_hash: BlockHash) -> Option<StarknetBlock> {
@@ -122,5 +151,9 @@ impl StarknetBlocks {
         self.num_to_block
             .get(&number)
             .and_then(|block| block.transaction_by_index(index))
+    }
+
+    pub fn total_blocks(&self) -> usize {
+        self.num_to_block.len()
     }
 }

--- a/crates/katana-core/src/starknet/block.rs
+++ b/crates/katana-core/src/starknet/block.rs
@@ -13,19 +13,10 @@ use starknet_api::{
     transaction::{Transaction, TransactionOutput},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct StarknetBlock {
     pub inner: Block,
     pub status: Option<BlockStatus>,
-}
-
-impl Default for StarknetBlock {
-    fn default() -> Self {
-        Self {
-            status: None,
-            inner: Default::default(),
-        }
-    }
 }
 
 impl StarknetBlock {

--- a/crates/katana-core/src/starknet/mod.rs
+++ b/crates/katana-core/src/starknet/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, time::SystemTime};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use blockifier::{
@@ -35,7 +35,6 @@ use crate::{
     constants::DEFAULT_PREFUNDED_ACCOUNT_BALANCE,
     state::DictStateReader,
     util::{
-        blockifier_contract_class_from_flattened_sierra_class,
         convert_blockifier_tx_to_starknet_api_tx, convert_state_diff_to_rpc_state_diff,
         get_current_timestamp,
     },

--- a/crates/katana-core/src/starknet/mod.rs
+++ b/crates/katana-core/src/starknet/mod.rs
@@ -84,7 +84,7 @@ impl StarknetWrapper {
     }
 
     // execute the tx
-    pub fn handle_transaction(&mut self, transaction: Transaction) {
+    pub fn handle_transaction(&mut self, transaction: Transaction) -> Result<()> {
         let api_tx = convert_blockifier_tx_to_starknet_api_tx(&transaction);
 
         info!(
@@ -116,7 +116,7 @@ impl StarknetWrapper {
                     .insert_transaction(api_tx);
 
                 self.store_transaction(starknet_tx);
-                self.generate_latest_block();
+                self.generate_latest_block()?;
 
                 self.generate_pending_block();
             }
@@ -132,13 +132,15 @@ impl StarknetWrapper {
                 self.store_transaction(tx);
             }
         }
+
+        Ok(())
     }
 
     // Creates a new block that contains all the pending txs
     // Will update the txs status to accepted
     // Append the block to the chain
     // Update the block context
-    pub fn generate_latest_block(&mut self) -> StarknetBlock {
+    pub fn generate_latest_block(&mut self) -> Result<StarknetBlock> {
         let mut new_block = if let Some(ref pending) = self.blocks.pending_block {
             pending.clone()
         } else {
@@ -168,11 +170,11 @@ impl StarknetWrapper {
 
         // reset the pending block
         self.blocks.pending_block = None;
-        self.blocks.append_block(new_block.clone());
+        self.blocks.append_block(new_block.clone())?;
         self.update_block_context();
         self.update_latest_state();
 
-        new_block
+        Ok(new_block)
     }
 
     pub fn generate_pending_block(&mut self) {

--- a/crates/katana-core/src/starknet/mod.rs
+++ b/crates/katana-core/src/starknet/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     state::DictStateReader,
     util::{
         blockifier_contract_class_from_flattened_sierra_class,
-        convert_blockifier_tx_to_starknet_api_tx,
+        convert_blockifier_tx_to_starknet_api_tx, get_current_timestamp,
     },
 };
 use block::{StarknetBlock, StarknetBlocks};
@@ -139,42 +139,44 @@ impl StarknetWrapper {
     // Append the block to the chain
     // Update the block context
     pub fn generate_latest_block(&mut self) -> StarknetBlock {
-        let mut latest_block = if let Some(ref pending) = self.blocks.pending_block {
+        let mut new_block = if let Some(ref pending) = self.blocks.pending_block {
             pending.clone()
         } else {
-            self.create_empty_block()
+            self.create_new_empty_block()
         };
 
-        let block_hash = latest_block.compute_block_hash();
-        latest_block.0.header.block_hash = block_hash;
+        let block_hash = new_block.compute_block_hash();
+        new_block.inner.header.block_hash = block_hash;
 
-        for pending_tx in latest_block.transactions() {
+        for pending_tx in new_block.transactions() {
             let tx_hash = pending_tx.transaction_hash();
+
+            // Update the tx block hash and number in the tx store //
 
             if let Some(tx) = self.transactions.transactions.get_mut(&tx_hash) {
                 tx.block_hash = Some(block_hash);
                 tx.status = TransactionStatus::AcceptedOnL2;
-                tx.block_number = Some(latest_block.block_number());
+                tx.block_number = Some(new_block.block_number());
             }
         }
 
         info!(
-            "New block generated | Block hash: {} | Block number: {}",
-            latest_block.block_hash(),
-            latest_block.block_number()
+            "⛏️ New block generated | Block hash: {} | Block number: {}",
+            new_block.block_hash(),
+            new_block.block_number()
         );
 
         // reset the pending block
         self.blocks.pending_block = None;
-        self.blocks.append_block(latest_block.clone());
+        self.blocks.append_block(new_block.clone());
         self.update_block_context();
         self.update_latest_state();
 
-        latest_block
+        new_block
     }
 
     pub fn generate_pending_block(&mut self) {
-        self.blocks.pending_block = Some(self.create_empty_block());
+        self.blocks.pending_block = Some(self.create_new_empty_block());
     }
 
     // TODO: perform call based on specific block state
@@ -205,18 +207,14 @@ impl StarknetWrapper {
         unimplemented!("StarknetWrapper::state")
     }
 
-    fn create_empty_block(&self) -> StarknetBlock {
-        let timestamp = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|t| BlockTimestamp(t.as_secs()))
-            .expect("should get unix timestamp");
+    fn create_new_empty_block(&self) -> StarknetBlock {
+        let block_number = self.block_context.block_number;
 
-        let block_number = self.blocks.current_height;
         let parent_hash = if block_number.0 == 0 {
             BlockHash(stark_felt!(0))
         } else {
             self.blocks
-                .lastest()
+                .latest()
                 .map(|last_block| last_block.block_hash())
                 .unwrap()
         };
@@ -228,9 +226,10 @@ impl StarknetWrapper {
             GasPrice(self.block_context.gas_price),
             GlobalRoot(stark_felt!(0)),
             self.block_context.sequencer_address,
-            timestamp,
+            BlockTimestamp(get_current_timestamp().as_secs()),
             vec![],
             vec![],
+            None,
         )
     }
 
@@ -245,15 +244,8 @@ impl StarknetWrapper {
     }
 
     fn update_block_context(&mut self) {
-        let next_block_number = BlockNumber(self.blocks.current_height.0 + 1);
-        let timestamp = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        self.blocks.current_height = next_block_number;
-        self.block_context.block_number = next_block_number;
-        self.block_context.block_timestamp = BlockTimestamp(timestamp);
+        self.block_context.block_number = self.block_context.block_number.next();
+        self.block_context.block_timestamp = BlockTimestamp(get_current_timestamp().as_secs());
     }
 
     fn update_latest_state(&mut self) {

--- a/crates/katana-core/src/util.rs
+++ b/crates/katana-core/src/util.rs
@@ -1,4 +1,8 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
 use anyhow::{anyhow, Result};
 use blockifier::{
@@ -20,11 +24,16 @@ use starknet_api::{
     StarknetApiError,
 };
 
-use anyhow::Ok;
 use blockifier::execution::contract_class::{
     casm_contract_into_contract_class, ContractClass as BlockifierContractClass,
 };
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
+
+pub fn get_current_timestamp() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("should get current UNIX timestamp")
+}
 
 pub fn get_contract_class(contract_path: &str) -> ContractClass {
     let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), contract_path].iter().collect();

--- a/crates/katana-core/tests/starknet.rs
+++ b/crates/katana-core/tests/starknet.rs
@@ -46,7 +46,7 @@ fn test_creating_blocks() {
 
     let block0 = starknet.blocks.by_number(BlockNumber(0)).unwrap();
     let block1 = starknet.blocks.by_number(BlockNumber(1)).unwrap();
-    let last_block = starknet.blocks.lastest().unwrap();
+    let last_block = starknet.blocks.latest().unwrap();
 
     assert_eq!(block0.transactions(), &[]);
     assert_eq!(block0.block_number(), BlockNumber(0));

--- a/crates/katana-core/tests/starknet.rs
+++ b/crates/katana-core/tests/starknet.rs
@@ -31,18 +31,28 @@ fn test_creating_blocks() {
     starknet.generate_pending_block();
 
     assert_eq!(
-        starknet.blocks.current_height,
-        BlockNumber(0),
+        starknet.blocks.total_blocks(),
+        0,
         "pending block should not be added to the chain"
     );
 
-    starknet.generate_latest_block();
-    starknet.generate_latest_block();
-    starknet.generate_latest_block();
+    assert_eq!(
+        starknet.block_context.block_number,
+        BlockNumber(0),
+        "pending block should not increment block context number"
+    );
+
+    starknet.generate_latest_block().unwrap();
+    starknet.generate_latest_block().unwrap();
+    starknet.generate_latest_block().unwrap();
 
     assert_eq!(starknet.blocks.hash_to_num.len(), 3);
     assert_eq!(starknet.blocks.num_to_block.len(), 3);
-    assert_eq!(starknet.blocks.current_height, BlockNumber(3));
+    assert_eq!(
+        starknet.block_context.block_number,
+        BlockNumber(3),
+        "current block context number should be 3"
+    );
 
     let block0 = starknet.blocks.by_number(BlockNumber(0)).unwrap();
     let block1 = starknet.blocks.by_number(BlockNumber(1)).unwrap();
@@ -76,14 +86,16 @@ fn test_add_transaction() {
         stark_felt!(0x0)                         // Calldata: num.
     ];
 
-    starknet.handle_transaction(Transaction::AccountTransaction(AccountTransaction::Invoke(
-        InvokeTransaction::V1(InvokeTransactionV1 {
-            sender_address: a.account_address,
-            calldata: execute_calldata,
-            transaction_hash: TransactionHash(stark_felt!("0x6969")),
-            ..Default::default()
-        }),
-    )));
+    starknet
+        .handle_transaction(Transaction::AccountTransaction(AccountTransaction::Invoke(
+            InvokeTransaction::V1(InvokeTransactionV1 {
+                sender_address: a.account_address,
+                calldata: execute_calldata,
+                transaction_hash: TransactionHash(stark_felt!("0x6969")),
+                ..Default::default()
+            }),
+        )))
+        .unwrap();
 
     //
     // SEND INVOKE TRANSACTION
@@ -98,7 +110,7 @@ fn test_add_transaction() {
 
     assert!(tx.is_some(), "transaction must be stored");
     assert_eq!(tx.unwrap().block_number, Some(BlockNumber(0)));
-    assert_eq!(starknet.blocks.current_height, BlockNumber(1));
+    assert_eq!(starknet.blocks.total_blocks(), 1);
     assert!(
         block.transaction_by_index(0).is_some(),
         "transaction must be included in the block"
@@ -145,7 +157,7 @@ fn test_add_reverted_transaction() {
         }),
     ));
 
-    starknet.handle_transaction(transaction);
+    starknet.handle_transaction(transaction).unwrap();
 
     let tx = starknet.transactions.transactions.get(&transaction_hash);
 
@@ -158,7 +170,7 @@ fn test_add_reverted_transaction() {
     assert_eq!(tx.unwrap().block_number, None);
     assert_eq!(tx.unwrap().status, TransactionStatus::Rejected);
     assert_eq!(
-        starknet.blocks.current_height,
+        starknet.block_context.block_number,
         BlockNumber(0),
         "block height must not increase"
     );

--- a/crates/katana-rpc/src/lib.rs
+++ b/crates/katana-rpc/src/lib.rs
@@ -132,11 +132,10 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
             .read()
             .await
             .block(block_id.clone())
-            .map_err(|_| Error::from(KatanaApiError::BlockNotFound))?;
+            .ok_or(Error::from(KatanaApiError::BlockNotFound))?;
 
         block
-            .body
-            .transactions
+            .transactions()
             .len()
             .try_into()
             .map_err(|_| Error::from(KatanaApiError::InternalServerError))
@@ -163,17 +162,17 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
             .read()
             .await
             .block(block_id.clone())
-            .map_err(|_| Error::from(KatanaApiError::BlockNotFound))?;
+            .ok_or(Error::from(KatanaApiError::BlockNotFound))?;
 
         let sequencer_address = FieldElement::from_hex_be(SEQUENCER_ADDRESS).unwrap();
         let transactions = block
-            .body
-            .transactions
+            .transactions()
             .iter()
             .map(|tx| stark_felt_to_field_element(tx.transaction_hash().0).unwrap())
             .collect::<Vec<_>>();
-        let timestamp = block.header.timestamp.0;
-        let parent_hash = stark_felt_to_field_element(block.header.parent_hash.0).unwrap();
+
+        let timestamp = block.header().timestamp.0;
+        let parent_hash = stark_felt_to_field_element(block.header().parent_hash.0).unwrap();
 
         if BlockId::Tag(BlockTag::Pending) == block_id {
             return Ok(MaybePendingBlockWithTxHashes::PendingBlock(
@@ -187,9 +186,9 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
         }
 
         Ok(MaybePendingBlockWithTxHashes::Block(BlockWithTxHashes {
-            new_root: stark_felt_to_field_element(block.header.state_root.0).unwrap(),
-            block_hash: stark_felt_to_field_element(block.header.block_hash.0).unwrap(),
-            block_number: block.header.block_number.0,
+            new_root: stark_felt_to_field_element(block.header().state_root.0).unwrap(),
+            block_hash: stark_felt_to_field_element(block.header().block_hash.0).unwrap(),
+            block_number: block.header().block_number.0,
             status: BlockStatus::AcceptedOnL2,
             transactions,
             sequencer_address,
@@ -208,11 +207,10 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
             .read()
             .await
             .block(block_id.clone())
-            .map_err(|_| Error::from(KatanaApiError::BlockNotFound))?;
+            .ok_or(Error::from(KatanaApiError::BlockNotFound))?;
 
         let transaction = block
-            .body
-            .transactions
+            .transactions()
             .get(index)
             .ok_or(Error::from(KatanaApiError::InvalidTxnIndex))?;
 

--- a/crates/katana-rpc/src/lib.rs
+++ b/crates/katana-rpc/src/lib.rs
@@ -225,17 +225,16 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
             .read()
             .await
             .block(block_id.clone())
-            .map_err(|_| Error::from(KatanaApiError::BlockNotFound))?;
+            .ok_or(Error::from(KatanaApiError::BlockNotFound))?;
 
         let sequencer_address = FieldElement::from_hex_be(SEQUENCER_ADDRESS).unwrap();
         let transactions = block
-            .body
-            .transactions
+            .transactions()
             .iter()
             .map(|tx| convert_inner_to_rpc_tx(tx.clone()).unwrap())
             .collect::<Vec<_>>();
-        let timestamp = block.header.timestamp.0;
-        let parent_hash = stark_felt_to_field_element(block.header.parent_hash.0).unwrap();
+        let timestamp = block.header().timestamp.0;
+        let parent_hash = stark_felt_to_field_element(block.header().parent_hash.0).unwrap();
 
         if BlockId::Tag(BlockTag::Pending) == block_id {
             return Ok(MaybePendingBlockWithTxs::PendingBlock(
@@ -249,9 +248,9 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
         }
 
         Ok(MaybePendingBlockWithTxs::Block(BlockWithTxs {
-            new_root: stark_felt_to_field_element(block.header.state_root.0).unwrap(),
-            block_hash: stark_felt_to_field_element(block.header.block_hash.0).unwrap(),
-            block_number: block.header.block_number.0,
+            new_root: stark_felt_to_field_element(block.header().state_root.0).unwrap(),
+            block_hash: stark_felt_to_field_element(block.block_hash().0).unwrap(),
+            block_number: block.block_number().0,
             status: BlockStatus::AcceptedOnL2,
             transactions,
             sequencer_address,


### PR DESCRIPTION
- return pending block when using `BlockId` because pending block is still not included in the list of blocks, so it doesn't have a block number yet.