### PR TITLE
fix(provider): use RW transaction only when on remote fallback

### DIFF
--- a/crates/executor/src/implementation/blockifier/state.rs
+++ b/crates/executor/src/implementation/blockifier/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -121,10 +122,18 @@ impl<'a> StateProvider for CachedState<'a> {
 impl<'a> StateProofProvider for CachedState<'a> {}
 impl<'a> StateRootProvider for CachedState<'a> {}
 
-#[derive(Debug)]
 pub struct StateProviderDb<'a> {
     provider: Box<dyn StateProvider + 'a>,
     compiled_class_cache: ClassCache,
+}
+
+impl<'a> Debug for StateProviderDb<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateProviderDb")
+            .field("provider", &"..")
+            .field("compiled_class_cache", &self.compiled_class_cache)
+            .finish()
+    }
 }
 
 impl<'a> Deref for StateProviderDb<'a> {

--- a/crates/pool/src/validation/stateful.rs
+++ b/crates/pool/src/validation/stateful.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use katana_executor::implementation::blockifier::blockifier::blockifier::stateful_validator::{
@@ -32,14 +33,12 @@ pub struct TxValidator {
     permit: Arc<Mutex<()>>,
 }
 
-#[derive(Debug)]
 struct Inner {
     // execution context
     cfg_env: CfgEnv,
     block_env: BlockEnv,
     execution_flags: ExecutionFlags,
     state: Arc<Box<dyn StateProvider>>,
-
     pool_nonces: HashMap<ContractAddress, Nonce>,
 }
 
@@ -80,6 +79,18 @@ impl TxValidator {
             Some(nonce) => Ok(Some(*nonce)),
             None => Ok(this.state.nonce(address)?),
         }
+    }
+}
+
+impl Debug for Inner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Inner")
+            .field("cfg_env", &self.cfg_env)
+            .field("block_env", &self.block_env)
+            .field("execution_flags", &self.execution_flags)
+            .field("state", &"..")
+            .field("pool_nonces", &self.pool_nonces)
+            .finish()
     }
 }
 

--- a/crates/rpc/rpc/tests/dev.rs
+++ b/crates/rpc/rpc/tests/dev.rs
@@ -11,7 +11,8 @@ async fn test_next_block_timestamp_in_past() {
     let provider = backend.blockchain.provider();
 
     // Create a jsonrpsee client for the DevApi
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     let block_num = provider.latest_number().unwrap();
     let mut block_env = provider.block_env_at(block_num.into()).unwrap().unwrap();
@@ -38,7 +39,8 @@ async fn test_set_next_block_timestamp_in_future() {
     let provider = backend.blockchain.provider();
 
     // Create a jsonrpsee client for the DevApi
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     let block_num = provider.latest_number().unwrap();
     let mut block_env = provider.block_env_at(block_num.into()).unwrap().unwrap();
@@ -65,7 +67,8 @@ async fn test_increase_next_block_timestamp() {
     let provider = backend.blockchain.provider();
 
     // Create a jsonrpsee client for the DevApi
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     let block_num = provider.latest_number().unwrap();
     let mut block_env = provider.block_env_at(block_num.into()).unwrap().unwrap();
@@ -97,7 +100,8 @@ async fn test_increase_next_block_timestamp() {
 async fn test_dev_api_enabled() {
     let sequencer = TestNode::new().await;
 
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     let accounts = client.predeployed_accounts().await.unwrap();
     assert!(!accounts.is_empty(), "predeployed accounts should not be empty");

--- a/crates/rpc/rpc/tests/proofs.rs
+++ b/crates/rpc/rpc/tests/proofs.rs
@@ -31,7 +31,8 @@ async fn proofs_limit() {
     let sequencer = TestNode::new().await;
 
     // We need to use the jsonrpsee client because `starknet-rs` doesn't yet support RPC 0
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     // Because we're using the default configuration for instantiating the node, the RPC limit is
     // set to 100. The total keys is 35 + 35 + 35 = 105.
@@ -83,7 +84,8 @@ async fn genesis_states() {
     let genesis_states = chain_spec.state_updates();
 
     // We need to use the jsonrpsee client because `starknet-rs` doesn't yet support RPC 0.8.0
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     // Check class declarations
     let genesis_classes =
@@ -197,7 +199,8 @@ async fn classes_proofs() {
         declare(&account, "tests/test_data/test_sierra_contract.json").await;
 
     // We need to use the jsonrpsee client because `starknet-rs` doesn't yet support RPC 0.8.0
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     {
         let class_hash = class_hash1;

--- a/crates/rpc/rpc/tests/starknet.rs
+++ b/crates/rpc/rpc/tests/starknet.rs
@@ -637,7 +637,8 @@ async fn get_events_no_pending() -> Result<()> {
     let sequencer = TestNode::new_with_config(config).await;
 
     // create a json rpc client to interact with the dev api.
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     let provider = sequencer.starknet_provider();
     let account = sequencer.account();
@@ -723,7 +724,8 @@ async fn get_events_with_pending() -> Result<()> {
     let sequencer = TestNode::new_with_config(config).await;
 
     // create a json rpc client to interact with the dev api.
-    let client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let client = HttpClientBuilder::default().build(url).unwrap();
 
     let provider = sequencer.starknet_provider();
     let account = sequencer.account();
@@ -814,7 +816,8 @@ async fn trace() -> Result<()> {
 
     let provider = sequencer.starknet_provider();
     let account = sequencer.account();
-    let rpc_client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string())?;
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let rpc_client = HttpClientBuilder::default().build(url).unwrap();
 
     // setup contract to interact with (can be any existing contract that can be interacted with)
     let contract = Erc20Contract::new(DEFAULT_ETH_FEE_TOKEN_ADDRESS.into(), &account);
@@ -985,7 +988,8 @@ async fn fetch_pending_blocks() {
     let sequencer = TestNode::new_with_config(config).await;
 
     // create a json rpc client to interact with the dev api.
-    let dev_client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let dev_client = HttpClientBuilder::default().build(url).unwrap();
     let provider = sequencer.starknet_provider();
     let account = sequencer.account();
 
@@ -1086,7 +1090,8 @@ async fn fetch_pending_blocks_in_instant_mode() {
     let sequencer = TestNode::new().await;
 
     // create a json rpc client to interact with the dev api.
-    let dev_client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string()).unwrap();
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let dev_client = HttpClientBuilder::default().build(url).unwrap();
     let provider = sequencer.starknet_provider();
     let account = sequencer.account();
 

--- a/crates/rpc/rpc/tests/starknet.rs
+++ b/crates/rpc/rpc/tests/starknet.rs
@@ -864,7 +864,9 @@ async fn block_traces() -> Result<()> {
 
     let provider = sequencer.starknet_provider();
     let account = sequencer.account();
-    let rpc_client = HttpClientBuilder::default().build(sequencer.rpc_addr().to_string())?;
+
+    let url = format!("http://{}", sequencer.rpc_addr());
+    let rpc_client = HttpClientBuilder::default().build(url)?;
 
     // setup contract to interact with (can be any existing contract that can be interacted with)
     let contract = Erc20Contract::new(DEFAULT_ETH_FEE_TOKEN_ADDRESS.into(), &account);

--- a/crates/storage/db/src/trie/mod.rs
+++ b/crates/storage/db/src/trie/mod.rs
@@ -55,7 +55,7 @@ pub struct GlobalTrie<'a, Tx: DbTxRef<'a>> {
 
 impl<'a, Tx> GlobalTrie<'a, Tx>
 where
-    Tx: DbTxRef<'a> + Debug,
+    Tx: DbTxRef<'a>,
 {
     /// Returns the contracts trie.
     pub fn contracts_trie(
@@ -91,7 +91,7 @@ pub struct HistoricalGlobalTrie<'a, Tx: DbTxRef<'a>> {
 
 impl<'a, Tx> HistoricalGlobalTrie<'a, Tx>
 where
-    Tx: DbTxRef<'a> + Debug,
+    Tx: DbTxRef<'a>,
 {
     /// Returns the historical contracts trie.
     pub fn contracts_trie(
@@ -135,10 +135,10 @@ where
 impl<'a, Tb, Tx> fmt::Debug for TrieDb<'a, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxRef<'a> + fmt::Debug,
+    Tx: DbTxRef<'a>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TrieDbMut").field("tx", &self.tx).finish()
+        f.debug_struct("TrieDbMut").field("tx", &"..").finish()
     }
 }
 
@@ -155,7 +155,7 @@ where
 impl<'a, Tb, Tx> BonsaiDatabase for TrieDb<'a, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxRef<'a> + fmt::Debug,
+    Tx: DbTxRef<'a>,
 {
     type Batch = ();
     type DatabaseError = Error;
@@ -223,10 +223,10 @@ where
 impl<'tx, Tb, Tx> fmt::Debug for TrieDbMut<'tx, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxMutRef<'tx> + fmt::Debug,
+    Tx: DbTxMutRef<'tx>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TrieDbMut").field("tx", &self.tx).finish()
+        f.debug_struct("TrieDbMut").field("tx", &"..").finish()
     }
 }
 
@@ -243,7 +243,7 @@ where
 impl<'tx, Tb, Tx> BonsaiDatabase for TrieDbMut<'tx, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxMutRef<'tx> + fmt::Debug,
+    Tx: DbTxMutRef<'tx>,
 {
     type Batch = ();
     type DatabaseError = Error;
@@ -328,10 +328,13 @@ where
 impl<'tx, Tb, Tx> BonsaiPersistentDatabase<CommitId> for TrieDbMut<'tx, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxMutRef<'tx> + fmt::Debug + 'tx,
+    Tx: DbTxMutRef<'tx> + 'tx,
 {
     type DatabaseError = Error;
-    type Transaction<'a> = SnapshotTrieDb<'tx, Tb, Tx>  where Self: 'a;
+    type Transaction<'a>
+        = SnapshotTrieDb<'tx, Tb, Tx>
+    where
+        Self: 'a;
 
     fn snapshot(&mut self, id: CommitId) {
         let block_number: BlockNumber = id.into();

--- a/crates/storage/db/src/trie/snapshot.rs
+++ b/crates/storage/db/src/trie/snapshot.rs
@@ -25,10 +25,10 @@ where
 impl<'a, Tb, Tx> fmt::Debug for SnapshotTrieDb<'a, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxRef<'a> + fmt::Debug,
+    Tx: DbTxRef<'a>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SnapshotTrieDb").field("tx", &self.tx).finish()
+        f.debug_struct("SnapshotTrieDb").field("tx", &"..").finish()
     }
 }
 
@@ -59,7 +59,7 @@ where
 impl<'tx, Tb, Tx> BonsaiDatabase for SnapshotTrieDb<'tx, Tb, Tx>
 where
     Tb: Trie,
-    Tx: DbTxRef<'tx> + fmt::Debug,
+    Tx: DbTxRef<'tx>,
 {
     type Batch = ();
     type DatabaseError = Error;

--- a/crates/storage/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/src/providers/db/mod.rs
@@ -57,6 +57,11 @@ impl<Db: Database> DbProvider<Db> {
     pub fn new(db: Db) -> Self {
         Self(db)
     }
+
+    /// Returns a reference to the underlying [`Database`] implementation.
+    pub fn db(&self) -> &Db {
+        &self.0
+    }
 }
 
 impl DbProvider<DbEnv> {

--- a/crates/storage/provider/src/providers/db/state.rs
+++ b/crates/storage/provider/src/providers/db/state.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use katana_db::abstraction::{Database, DbCursorMut, DbDupSortCursor, DbTx, DbTxMut};
 use katana_db::models::contract::ContractInfoChangeList;
 use katana_db::models::list::BlockList;
@@ -125,7 +123,7 @@ where
 
 impl<Tx> StateProvider for LatestStateProvider<Tx>
 where
-    Tx: DbTx + fmt::Debug + Send + Sync,
+    Tx: DbTx + Send + Sync,
 {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
         let info = self.0.get::<tables::ContractInfo>(address)?;
@@ -156,7 +154,7 @@ where
 
 impl<Tx> StateProofProvider for LatestStateProvider<Tx>
 where
-    Tx: DbTx + fmt::Debug + Send + Sync,
+    Tx: DbTx + Send + Sync,
 {
     fn class_multiproof(&self, classes: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
         let mut trie = TrieDbFactory::new(&self.0).latest().classes_trie();
@@ -186,7 +184,7 @@ where
 
 impl<Tx> StateRootProvider for LatestStateProvider<Tx>
 where
-    Tx: DbTx + fmt::Debug + Send + Sync,
+    Tx: DbTx + Send + Sync,
 {
     fn classes_root(&self) -> ProviderResult<Felt> {
         let trie = TrieDbFactory::new(&self.0).latest().classes_trie();
@@ -261,7 +259,7 @@ where
 
 impl<Tx> StateProvider for HistoricalStateProvider<Tx>
 where
-    Tx: DbTx + fmt::Debug + Send + Sync,
+    Tx: DbTx + Send + Sync,
 {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
         let change_list = self.tx.get::<tables::ContractInfoChangeSet>(address)?;
@@ -342,7 +340,7 @@ where
 
 impl<Tx> StateProofProvider for HistoricalStateProvider<Tx>
 where
-    Tx: DbTx + fmt::Debug + Send + Sync,
+    Tx: DbTx + Send + Sync,
 {
     fn class_multiproof(&self, classes: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
         let proofs = TrieDbFactory::new(&self.tx)
@@ -381,7 +379,7 @@ where
 
 impl<Tx> StateRootProvider for HistoricalStateProvider<Tx>
 where
-    Tx: DbTx + fmt::Debug + Send + Sync,
+    Tx: DbTx + Send + Sync,
 {
     fn classes_root(&self) -> ProviderResult<katana_primitives::Felt> {
         let root = TrieDbFactory::new(&self.tx)

--- a/crates/storage/provider/src/providers/db/state.rs
+++ b/crates/storage/provider/src/providers/db/state.rs
@@ -97,11 +97,6 @@ impl<Tx: DbTx> LatestStateProvider<Tx> {
     pub fn new(tx: Tx) -> Self {
         Self(tx)
     }
-
-    /// Returns a reference to the underlying transaction.
-    pub fn tx(&self) -> &Tx {
-        &self.0
-    }
 }
 
 impl<Tx> ContractClassProvider for LatestStateProvider<Tx>

--- a/crates/storage/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/src/providers/fork/mod.rs
@@ -39,8 +39,8 @@ mod trie;
 
 #[derive(Debug)]
 pub struct ForkedProvider<Db: Database = DbEnv> {
-    provider: DbProvider<Db>,
     backend: BackendClient,
+    provider: Arc<DbProvider<Db>>,
 }
 
 impl<Db: Database> ForkedProvider<Db> {
@@ -50,11 +50,8 @@ impl<Db: Database> ForkedProvider<Db> {
         provider: Arc<JsonRpcClient<HttpTransport>>,
     ) -> Self {
         let backend = Backend::new(provider, block_id).expect("failed to create backend");
-        Self { provider: DbProvider::new(db), backend }
-    }
-
-    pub fn db(&self) -> &Db {
-        &self.provider.0
+        let provider = Arc::new(DbProvider::new(db));
+        Self { provider, backend }
     }
 
     pub fn backend(&self) -> &BackendClient {
@@ -69,7 +66,8 @@ impl ForkedProvider<DbEnv> {
         provider: Arc<JsonRpcClient<HttpTransport>>,
     ) -> Self {
         let backend = Backend::new(provider, block_id).expect("failed to create backend");
-        Self { provider: DbProvider::new_ephemeral(), backend }
+        let provider = Arc::new(DbProvider::new_ephemeral());
+        Self { provider, backend }
     }
 }
 

--- a/crates/storage/provider/src/providers/fork/state.rs
+++ b/crates/storage/provider/src/providers/fork/state.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
-use std::fmt;
+use std::sync::Arc;
 
-use katana_db::abstraction::{Database, DbTxMut};
+use katana_db::abstraction::{Database, DbTx, DbTxMut};
 use katana_db::models::contract::{ContractClassChange, ContractNonceChange};
 use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 use katana_db::tables;
@@ -14,6 +14,7 @@ use katana_primitives::{ContractAddress, Felt};
 use super::db::{self};
 use super::ForkedProvider;
 use crate::error::ProviderError;
+use crate::providers::db::DbProvider;
 use crate::traits::block::BlockNumberProvider;
 use crate::traits::contract::{ContractClassProvider, ContractClassWriter};
 use crate::traits::state::{
@@ -21,11 +22,15 @@ use crate::traits::state::{
 };
 use crate::ProviderResult;
 
-impl<Db: Database> StateFactoryProvider for ForkedProvider<Db> {
+impl<Db> StateFactoryProvider for ForkedProvider<Db>
+where
+    Db: Database + 'static,
+{
     fn latest(&self) -> ProviderResult<Box<dyn StateProvider>> {
-        let tx = self.db().tx_mut()?;
+        let tx = self.provider.db().tx()?;
+        let db = self.provider.clone();
         let provider = db::state::LatestStateProvider::new(tx);
-        Ok(Box::new(LatestStateProvider { backend: self.backend.clone(), provider }))
+        Ok(Box::new(LatestStateProvider { db, backend: self.backend.clone(), provider }))
     }
 
     fn historical(
@@ -47,28 +52,31 @@ impl<Db: Database> StateFactoryProvider for ForkedProvider<Db> {
         };
 
         let Some(block) = block_number else { return Ok(None) };
-        let tx = self.db().tx_mut()?;
+
+        let db = self.provider.clone();
+        let tx = db.db().tx()?;
         let client = self.backend.clone();
 
-        Ok(Some(Box::new(HistoricalStateProvider::new(tx, block, client))))
+        Ok(Some(Box::new(HistoricalStateProvider::new(db, tx, block, client))))
     }
 }
 
 #[derive(Debug)]
-struct LatestStateProvider<Tx: DbTxMut> {
+struct LatestStateProvider<Db: Database> {
+    db: Arc<DbProvider<Db>>,
     backend: BackendClient,
-    provider: db::state::LatestStateProvider<Tx>,
+    provider: db::state::LatestStateProvider<Db::Tx>,
 }
 
-impl<Tx> ContractClassProvider for LatestStateProvider<Tx>
+impl<Db> ContractClassProvider for LatestStateProvider<Db>
 where
-    Tx: DbTxMut + Send + Sync,
+    Db: Database,
 {
     fn class(&self, hash: ClassHash) -> ProviderResult<Option<ContractClass>> {
         if let Some(class) = self.provider.class(hash)? {
             Ok(Some(class))
         } else if let Some(class) = self.backend.get_class_at(hash)? {
-            self.provider.tx().put::<tables::Classes>(hash, class.clone())?;
+            self.db.db().tx_mut()?.put::<tables::Classes>(hash, class.clone())?;
             Ok(Some(class))
         } else {
             Ok(None)
@@ -82,7 +90,7 @@ where
         if let Some(compiled_hash) = self.provider.compiled_class_hash_of_class_hash(hash)? {
             Ok(Some(compiled_hash))
         } else if let Some(compiled_hash) = self.backend.get_compiled_class_hash(hash)? {
-            self.provider.tx().put::<tables::CompiledClassHashes>(hash, compiled_hash)?;
+            self.db.db().tx_mut()?.put::<tables::CompiledClassHashes>(hash, compiled_hash)?;
             Ok(Some(compiled_hash))
         } else {
             Ok(None)
@@ -90,9 +98,9 @@ where
     }
 }
 
-impl<Tx> StateProvider for LatestStateProvider<Tx>
+impl<Db> StateProvider for LatestStateProvider<Db>
 where
-    Tx: DbTxMut + fmt::Debug + Send + Sync,
+    Db: Database,
 {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
         if let Some(nonce) = self.provider.nonce(address)? {
@@ -104,7 +112,7 @@ where
                 .ok_or(ProviderError::MissingContractClassHash { address })?;
 
             let entry = GenericContractInfo { nonce, class_hash };
-            self.provider.tx().put::<tables::ContractInfo>(address, entry)?;
+            self.db.db().tx_mut()?.put::<tables::ContractInfo>(address, entry)?;
 
             Ok(Some(nonce))
         } else {
@@ -125,7 +133,7 @@ where
                 .ok_or(ProviderError::MissingContractNonce { address })?;
 
             let entry = GenericContractInfo { class_hash, nonce };
-            self.provider.tx().put::<tables::ContractInfo>(address, entry)?;
+            self.db.db().tx_mut()?.put::<tables::ContractInfo>(address, entry)?;
 
             Ok(Some(class_hash))
         } else {
@@ -142,7 +150,7 @@ where
             Ok(Some(value))
         } else if let Some(value) = self.backend.get_storage(address, key)? {
             let entry = StorageEntry { key, value };
-            self.provider.tx().put::<tables::ContractStorage>(address, entry)?;
+            self.db.db().tx_mut()?.put::<tables::ContractStorage>(address, entry)?;
             Ok(Some(value))
         } else {
             Ok(None)
@@ -150,9 +158,9 @@ where
     }
 }
 
-impl<Tx> StateProofProvider for LatestStateProvider<Tx>
+impl<Db> StateProofProvider for LatestStateProvider<Db>
 where
-    Tx: DbTxMut + fmt::Debug + Send + Sync,
+    Db: Database,
 {
     fn class_multiproof(&self, classes: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
         self.provider.class_multiproof(classes)
@@ -174,9 +182,9 @@ where
     }
 }
 
-impl<Tx> StateRootProvider for LatestStateProvider<Tx>
+impl<Db> StateRootProvider for LatestStateProvider<Db>
 where
-    Tx: DbTxMut + fmt::Debug + Send + Sync,
+    Db: Database,
 {
     fn classes_root(&self) -> ProviderResult<Felt> {
         self.provider.classes_root()
@@ -192,27 +200,33 @@ where
 }
 
 #[derive(Debug)]
-struct HistoricalStateProvider<Tx: DbTxMut> {
+struct HistoricalStateProvider<Db: Database> {
+    db: Arc<DbProvider<Db>>,
     backend: BackendClient,
-    provider: db::state::HistoricalStateProvider<Tx>,
+    provider: db::state::HistoricalStateProvider<Db::Tx>,
 }
 
-impl<Tx: DbTxMut> HistoricalStateProvider<Tx> {
-    pub fn new(tx: Tx, block: BlockNumber, backend: BackendClient) -> Self {
+impl<Db: Database> HistoricalStateProvider<Db> {
+    pub fn new(
+        db: Arc<DbProvider<Db>>,
+        tx: Db::Tx,
+        block: BlockNumber,
+        backend: BackendClient,
+    ) -> Self {
         let provider = db::state::HistoricalStateProvider::new(tx, block);
-        Self { backend, provider }
+        Self { db, backend, provider }
     }
 }
 
-impl<Tx> ContractClassProvider for HistoricalStateProvider<Tx>
+impl<Db> ContractClassProvider for HistoricalStateProvider<Db>
 where
-    Tx: DbTxMut + Send + Sync,
+    Db: Database,
 {
     fn class(&self, hash: ClassHash) -> ProviderResult<Option<ContractClass>> {
         if let Some(class) = self.provider.class(hash)? {
             Ok(Some(class))
         } else if let Some(class) = self.backend.get_class_at(hash)? {
-            self.provider.tx().put::<tables::Classes>(hash, class.clone())?;
+            self.db.db().tx_mut()?.put::<tables::Classes>(hash, class.clone())?;
             Ok(Some(class))
         } else {
             Ok(None)
@@ -226,7 +240,7 @@ where
         if let Some(compiled_hash) = self.provider.compiled_class_hash_of_class_hash(hash)? {
             Ok(Some(compiled_hash))
         } else if let Some(compiled_hash) = self.backend.get_compiled_class_hash(hash)? {
-            self.provider.tx().put::<tables::CompiledClassHashes>(hash, compiled_hash)?;
+            self.db.db().tx_mut()?.put::<tables::CompiledClassHashes>(hash, compiled_hash)?;
             Ok(Some(compiled_hash))
         } else {
             Ok(None)
@@ -234,9 +248,9 @@ where
     }
 }
 
-impl<Tx> StateProvider for HistoricalStateProvider<Tx>
+impl<Db> StateProvider for HistoricalStateProvider<Db>
 where
-    Tx: DbTxMut + fmt::Debug + Send + Sync,
+    Db: Database,
 {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
         if let Some(nonce) = self.provider.nonce(address)? {
@@ -245,7 +259,7 @@ where
             let block = self.provider.block();
             let entry = ContractNonceChange { contract_address: address, nonce };
 
-            self.provider.tx().put::<tables::NonceChangeHistory>(block, entry)?;
+            self.db.db().tx_mut()?.put::<tables::NonceChangeHistory>(block, entry)?;
             Ok(Some(nonce))
         } else {
             Ok(None)
@@ -262,7 +276,7 @@ where
             let block = self.provider.block();
             let entry = ContractClassChange { contract_address: address, class_hash };
 
-            self.provider.tx().put::<tables::ClassChangeHistory>(block, entry)?;
+            self.db.db().tx_mut()?.put::<tables::ClassChangeHistory>(block, entry)?;
             Ok(Some(class_hash))
         } else {
             Ok(None)
@@ -284,9 +298,9 @@ where
             let mut block_list = block_list.unwrap_or_default();
             block_list.insert(block);
 
-            self.provider.tx().put::<tables::StorageChangeSet>(key.clone(), block_list)?;
+            self.db.db().tx_mut()?.put::<tables::StorageChangeSet>(key.clone(), block_list)?;
             let change_entry = ContractStorageEntry { key, value };
-            self.provider.tx().put::<tables::StorageChangeHistory>(block, change_entry)?;
+            self.db.db().tx_mut()?.put::<tables::StorageChangeHistory>(block, change_entry)?;
 
             Ok(Some(value))
         } else {
@@ -295,9 +309,9 @@ where
     }
 }
 
-impl<Tx> StateProofProvider for HistoricalStateProvider<Tx>
+impl<Db> StateProofProvider for HistoricalStateProvider<Db>
 where
-    Tx: DbTxMut + fmt::Debug + Send + Sync,
+    Db: Database,
 {
     fn class_multiproof(&self, classes: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
         self.provider.class_multiproof(classes)
@@ -319,9 +333,9 @@ where
     }
 }
 
-impl<Tx> StateRootProvider for HistoricalStateProvider<Tx>
+impl<Db> StateRootProvider for HistoricalStateProvider<Db>
 where
-    Tx: DbTxMut + fmt::Debug + Send + Sync,
+    Db: Database,
 {
     fn classes_root(&self) -> ProviderResult<Felt> {
         self.provider.classes_root()

--- a/crates/storage/provider/src/providers/in_memory/state.rs
+++ b/crates/storage/provider/src/providers/in_memory/state.rs
@@ -23,77 +23,7 @@ pub struct StateSnapshot<Db> {
 const DEFAULT_HISTORY_LIMIT: usize = 500;
 const MIN_HISTORY_LIMIT: usize = 10;
 
-/// Represents the complete state of a single block.
-///
-/// It should store at N - 1 states, where N is the latest block number.
-#[derive(Debug)]
-pub struct HistoricalStates {
-    /// The states at a certain block based on the block number
-    states: HashMap<BlockNumber, Arc<dyn StateProvider>>,
-    /// How many states to store at most
-    in_memory_limit: usize,
-    /// minimum amount of states we keep in memory
-    min_in_memory_limit: usize,
-    /// all states present, used to enforce `in_memory_limit`
-    present: VecDeque<BlockNumber>,
-}
-
-impl HistoricalStates {
-    pub fn new(limit: usize) -> Self {
-        Self {
-            in_memory_limit: limit,
-            states: Default::default(),
-            present: Default::default(),
-            min_in_memory_limit: limit.min(MIN_HISTORY_LIMIT),
-        }
-    }
-
-    /// Returns the state for the given `block_hash` if present
-    pub fn get(&self, block_num: &BlockNumber) -> Option<&Arc<dyn StateProvider>> {
-        self.states.get(block_num)
-    }
-
-    /// Inserts a new (block_hash -> state) pair
-    ///
-    /// When the configured limit for the number of states that can be stored in memory is reached,
-    /// the oldest state is removed.
-    ///
-    /// Since we keep a snapshot of the entire state as history, the size of the state will increase
-    /// with the transactions processed. To counter this, we gradually decrease the cache limit with
-    /// the number of states/blocks until we reached the `min_limit`.
-    pub fn insert(&mut self, block_num: BlockNumber, state: Box<dyn StateProvider>) {
-        if self.present.len() >= self.in_memory_limit {
-            // once we hit the max limit we gradually decrease it
-            self.in_memory_limit =
-                self.in_memory_limit.saturating_sub(1).max(self.min_in_memory_limit);
-        }
-
-        self.enforce_limits();
-        self.states.insert(block_num, Arc::new(state));
-        self.present.push_back(block_num);
-    }
-
-    /// Enforces configured limits
-    fn enforce_limits(&mut self) {
-        // enforce memory limits
-        while self.present.len() >= self.in_memory_limit {
-            // evict the oldest block in memory
-            if let Some(block_num) = self.present.pop_front() {
-                self.states.remove(&block_num);
-            }
-        }
-    }
-}
-
-impl Default for HistoricalStates {
-    fn default() -> Self {
-        // enough in memory to store `DEFAULT_HISTORY_LIMIT` blocks in memory
-        Self::new(DEFAULT_HISTORY_LIMIT)
-    }
-}
-
 pub(super) type InMemoryStateDb = CacheStateDb<()>;
-// pub(super) type InMemorySnapshot = StateSnapshot<()>;
 
 impl Default for InMemoryStateDb {
     fn default() -> Self {

--- a/crates/storage/provider/src/traits/state.rs
+++ b/crates/storage/provider/src/traits/state.rs
@@ -40,9 +40,7 @@ pub trait StateRootProvider: Send + Sync {
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]
-pub trait StateProvider:
-    ContractClassProvider + StateProofProvider + StateRootProvider + std::fmt::Debug
-{
+pub trait StateProvider: ContractClassProvider + StateProofProvider + StateRootProvider {
     /// Returns the nonce of a contract.
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>>;
 

--- a/crates/storage/provider/tests/class.rs
+++ b/crates/storage/provider/tests/class.rs
@@ -150,7 +150,7 @@ mod historical {
 
     #[cfg(feature = "fork")]
     mod fork {
-        use fixtures::fork_provider_with_spawned_fork_network;
+        use fixtures::fork::fork_provider_with_spawned_fork_network;
         use katana_provider::providers::fork::ForkedProvider;
 
         use super::*;

--- a/crates/storage/provider/tests/contract.rs
+++ b/crates/storage/provider/tests/contract.rs
@@ -54,8 +54,10 @@ mod latest {
 
     #[cfg(feature = "fork")]
     mod fork {
-        use fixtures::fork_provider_with_spawned_fork_network;
+        use fixtures::fork::fork_provider_with_spawned_fork_network;
         use katana_provider::providers::fork::ForkedProvider;
+
+        use super::*;
 
         #[apply(test_latest_contract_info_read)]
         fn read_storage_from_fork_provider(
@@ -137,9 +139,11 @@ mod historical {
 
     #[cfg(feature = "fork")]
     mod fork {
-        use fixtures::fork_provider_with_spawned_fork_network;
+        use fixtures::fork::fork_provider_with_spawned_fork_network;
         use katana_provider::providers::fork::ForkedProvider;
         use katana_provider::BlockchainProvider;
+
+        use super::*;
 
         #[apply(test_historical_storage_read)]
         fn read_storage_from_fork_provider(

--- a/crates/storage/provider/tests/contract.rs
+++ b/crates/storage/provider/tests/contract.rs
@@ -139,6 +139,7 @@ mod historical {
     mod fork {
         use fixtures::fork_provider_with_spawned_fork_network;
         use katana_provider::providers::fork::ForkedProvider;
+        use katana_provider::BlockchainProvider;
 
         #[apply(test_historical_storage_read)]
         fn read_storage_from_fork_provider(

--- a/crates/storage/provider/tests/fixtures.rs
+++ b/crates/storage/provider/tests/fixtures.rs
@@ -22,13 +22,18 @@ lazy_static! {
 }
 
 #[cfg(feature = "fork")]
-mod fork {
+pub mod fork {
+
+    use std::sync::Arc;
+
     use katana_provider::providers::fork::ForkedProvider;
     use katana_runner::KatanaRunner;
     use lazy_static::lazy_static;
     use starknet::providers::jsonrpc::HttpTransport;
     use starknet::providers::JsonRpcClient;
     use url::Url;
+
+    use super::*;
 
     lazy_static! {
         pub static ref FORKED_PROVIDER: (KatanaRunner, Arc<JsonRpcClient<HttpTransport>>) = {

--- a/crates/storage/provider/tests/storage.rs
+++ b/crates/storage/provider/tests/storage.rs
@@ -53,7 +53,10 @@ mod latest {
 
     #[cfg(feature = "fork")]
     mod fork {
+        use fixtures::fork::fork_provider_with_spawned_fork_network;
         use katana_provider::providers::fork::ForkedProvider;
+
+        use super::*;
 
         #[apply(test_latest_storage_read)]
         fn read_storage_from_fork_provider_with_spawned_fork_network(
@@ -145,7 +148,10 @@ mod historical {
 
     #[cfg(feature = "fork")]
     mod fork {
-        use fixtures::fork_provider_with_spawned_fork_network;
+        use fixtures::fork::fork_provider_with_spawned_fork_network;
+        use katana_provider::providers::fork::ForkedProvider;
+
+        use super::*;
 
         #[apply(test_historical_storage_read)]
         fn read_storage_from_fork_provider_with_spawned_fork_network(


### PR DESCRIPTION
Prevent deadlocking on trying to create fork `StateProvider` due to the fact that the `TxValidator` maintains a long term reference to the underlying state provider. If we use RW transaction for the state provider, this will cause deadlock as we can't create any new state provider because there can only be a single database RW transaction at a time.