### PR TITLE
ci: add release and release-dispatch

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,44 @@
+name: release-dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+        type: string
+
+jobs:
+  propose-release:
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup toolchain"
+        uses: "actions-rs/toolchain@v1"
+        with:
+          toolchain: "stable"
+
+      - run: |
+          VERSION=${{ inputs.version }}
+          VERSION=${VERSION#v}
+          cargo install cargo-release
+          cargo release version $VERSION --execute --no-confirm && cargo release replace --execute --no-confirm
+
+      - id: version_info
+        run: |
+          cargo install cargo-get
+          echo "version=$(cargo get workspace.package.version)" >> $GITHUB_OUTPUT
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.CREATE_PR_TOKEN }}
+          title: "release(prepare): v${{ steps.version_info.outputs.version }}"
+          commit-message: "release(prepare): v${{ steps.version_info.outputs.version }}"
+          branch: prepare-release
+          base: main
+          delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,193 @@
+name: release
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  prepare:
+    # The prepare-release branch names comes from the release-dispatch.yml workflow.
+    if: (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'prepare-release') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release_info.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get version
+        id: release_info
+        run: |
+          cargo install cargo-get
+          echo "tag_name=v$(cargo get workspace.package.version)" >> $GITHUB_OUTPUT
+
+  release:
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
+    needs: prepare
+    runs-on: ${{ matrix.job.os }}
+    env:
+      PLATFORM_NAME: ${{ matrix.job.platform }}
+      TARGET: ${{ matrix.job.target }}
+      ARCH: ${{ matrix.job.arch }}
+    strategy:
+      matrix:
+        job:
+          # The OS is used for the runner
+          # The platform is a generic platform name
+          # The target is used by Cargo
+          # The arch is either 386, arm64 or amd64
+          # The svm target platform to use for the binary https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
+          - os: ubuntu-latest-8-cores
+            platform: linux
+            target: x86_64-unknown-linux-gnu
+            arch: amd64
+          - os: ubuntu-latest-8-cores-arm64
+            platform: linux
+            target: aarch64-unknown-linux-gnu
+            arch: arm64
+            svm_target_platform: linux-aarch64
+          - os: macos-latest-xlarge
+            platform: darwin
+            target: x86_64-apple-darwin
+            arch: amd64
+          - os: macos-latest
+            platform: darwin
+            target: aarch64-apple-darwin
+            arch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@master
+        name: Rust Toolchain Setup
+        with:
+          targets: ${{ matrix.job.target }}
+          toolchain: "nightly-2024-12-16"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Apple M1 setup
+        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+
+      - name: Linux ARM setup
+        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-aarch64-linux-gnu libssl-dev
+          # We build jemalloc with 64KB pagesize so that it works for all linux/arm64 pagesize variants
+          # See: https://github.com/jemalloc/jemalloc/issues/467
+          echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+
+      - name: Build binaries
+        run: |
+          cargo --version
+          cargo build --release --workspace --all-features --exclude snos-integration-test  --target ${{ matrix.job.target }}
+
+      - name: Archive binaries
+        id: artifacts
+        env:
+          VERSION_NAME: ${{ needs.prepare.outputs.tag_name }}
+        run: |
+          if [ "$PLATFORM_NAME" == "linux" ]; then
+            tar -czvf "katana_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release katana
+            echo "file_name=katana_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+          elif [ "$PLATFORM_NAME" == "darwin" ]; then
+            # We need to use gtar here otherwise the archive is corrupt.
+            # See: https://github.com/actions/virtual-environments/issues/2619
+            gtar -czvf "katana_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release katana
+            echo "file_name=katana_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      # We move binaries so they match $TARGETPLATFORM in the Docker build
+      - name: Move Binaries
+        if: ${{ env.PLATFORM_NAME == 'linux' }}
+        run: |
+          mkdir -p $PLATFORM_NAME/$ARCH
+          mv target/$TARGET/release/katana $PLATFORM_NAME/$ARCH
+        shell: bash
+
+      - name: Upload docker binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.job.target }}
+          path: ${{ env.PLATFORM_NAME }}
+          retention-days: 1
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.job.target }}
+          path: ${{ steps.artifacts.outputs.file_name }}
+          retention-days: 1
+
+  create-draft-release:
+    runs-on: ubuntu-20.04-4-cores
+    needs: [prepare, release]
+    env:
+      GITHUB_USER: ${{ github.repository_owner }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+      - id: version_info
+        run: |
+          cargo install cargo-get
+          echo "version=v$(cargo get workspace.package.version)" >> $GITHUB_OUTPUT
+      - name: Display structure of downloaded files
+        run: ls -R artifacts
+      - run: gh release create ${{ steps.version_info.outputs.version }} ./artifacts/* --generate-notes --draft
+
+  docker-build-and-push:
+    runs-on: ubuntu-20.04-4-cores
+    needs: [prepare, release]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-*
+          path: binaries/linux
+          merge-multiple: true
+
+      - name: List downloaded files
+        run: |
+          ls -R binaries
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile-bins
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.tag_name }}
+          platforms: linux/amd64,linux/arm64
+          build-contexts: |
+            binaries=binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       PLATFORM_NAME: ${{ matrix.job.platform }}
       TARGET: ${{ matrix.job.target }}
       ARCH: ${{ matrix.job.arch }}
+      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
     strategy:
       matrix:
         job:
@@ -73,6 +76,17 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: Install LLVM dependencies for Linux
+        if: ${{ matrix.job.platform == 'linux' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y g++ llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
+
+      - name: Install LLVM dependencies for macOS
+        if: ${{ matrix.job.platform == 'darwin' }}
+        run: |
+          brew install llvm@19 --quiet
+
       - name: Apple M1 setup
         if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
         run: |
@@ -91,7 +105,7 @@ jobs:
       - name: Build binaries
         run: |
           cargo --version
-          cargo build --release --workspace --all-features --exclude snos-integration-test  --target ${{ matrix.job.target }}
+          cargo build -p katana --features native --target ${{ matrix.job.target }}
 
       - name: Archive binaries
         id: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         name: Rust Toolchain Setup
         with:
           targets: ${{ matrix.job.target }}
-          toolchain: "nightly-2024-12-16"
+          toolchain: "1.83.0"
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Add the release dispatch and release workflows.

The idea of those is to have a behavior similar to dojo where:
1. A new release can be proposed by a user that has the right access to this repo.
2. The release dispatch will create a PR with the proposed version bumped.
3. Once merged, the `release` workflow will take over by producing the artifacts and pushing the docker image and opening a draft PR.
4. When the draft PR is edited as latest or preview, a new tag is automatically created.

The advantage of this workflow is that even if the `release-dispatch` is merged, but some changes must be made before the release is actually done, the `release` flow can be canceled, and restarted manually from `main` with any addition required.