### PR TITLE
fix(pool): relax nonce check

### DIFF
--- a/crates/pool/src/validation/stateful.rs
+++ b/crates/pool/src/validation/stateful.rs
@@ -180,8 +180,10 @@ fn validate(
     skip_validate: bool,
     skip_fee_check: bool,
 ) -> ValidationResult<ExecutableTxWithHash> {
-    let flags =
-        ExecutionFlags::new().with_account_validation(!skip_validate).with_fee(!skip_fee_check);
+    let flags = ExecutionFlags::new()
+        .with_account_validation(!skip_validate)
+        .with_fee(!skip_fee_check)
+        .with_nonce_check(false);
 
     match to_executor_tx(pool_tx.clone(), flags) {
         Transaction::Account(tx) => match validator.perform_validations(tx) {


### PR DESCRIPTION
A fix for a bug caused by `blockifier` bump to Cairo 2.11 at commit cbe0a258920b8423e00d26b2494f326498a114aa .

Prior to the bump, `blockifier` explicitly skip the strict nonce check in `StatefulValidator::perform_pre_validation_stage`:

https://github.com/dojoengine/sequencer/blob/d860f498d25ad1699007286be031aef35a9692e5/crates/blockifier/src/blockifier/stateful_validator.rs#L131-L148

but the bump includes breaking API changes in `blockifier` that we aren't handling correctly. The change that introduced this bug is the addition of the `strict_nonce_check` in the [`ExecutionFlags`](https://github.com/dojoengine/sequencer/blob/5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2/crates/blockifier/src/transaction/account_transaction.rs#L88) struct. With the new API, instead of setting the skip nonce check flag as an argument and passing it down the call stack, the new flag is used to set the `strict` argument in the `AccountTransaction::handle_nonce` function.

https://github.com/dojoengine/sequencer/blob/5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2/crates/blockifier/src/transaction/account_transaction.rs#L259-L276

https://github.com/dojoengine/sequencer/blob/5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2/crates/blockifier/src/transaction/account_transaction.rs#L388-L414
