### PR TITLE
fix(docker): install linker for `cairo-native`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
 
 FROM ubuntu:24.04 as base
 
+# Required by cairo-native 
+RUN apt-get update && apt install -y binutils clang-19
+
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /usr/bin/curl /usr/bin/curl
 


### PR DESCRIPTION
these packages are required by `cairo-native` to perform the compilation of sierra to native code. this means, all the docker images prior to this PR will not be able to work properly and will fail with this error:

```
thread 'cache-native-compiler-0' panicked at crates/executor/src/implementation/blockifier/cache.rs:98:30:
called `Result::unwrap()` on an `Err` value: IoError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Rayon: detected unexpected panic; aborting
```