### PR TITLE
refactor(rpc): define outside execution types internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6562,7 +6562,6 @@ dependencies = [
 name = "katana-rpc-api"
 version = "1.5.2"
 dependencies = [
- "account_sdk",
  "anyhow",
  "jsonrpsee",
  "katana-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,7 +6508,6 @@ dependencies = [
 name = "katana-rpc"
 version = "1.5.2"
 dependencies = [
- "account_sdk",
  "alloy",
  "alloy-primitives",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6447,6 +6447,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "base64 0.21.7",
+ "cainome-cairo-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-lang-starknet-classes",
  "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion",
@@ -6583,6 +6584,8 @@ version = "1.5.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "cainome 0.5.1",
+ "cainome-cairo-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "derive_more 0.99.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,9 +103,6 @@ cairo-lang-utils = "2.11.2"
 # only under the `test_utils` feature. So we expose through this feature.
 cairo-vm = { version = "1.0.2", features = [ "test_utils" ] }
 
-# Controller PR revision until merged.
-# https://github.com/cartridge-gg/controller/pull/1454
-account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "dbbe0353d64de743739d425f8aab91ca3ac0e16f" }
 anyhow = "1.0.89"
 arbitrary = { version = "1.3.2", features = [ "derive" ] }
 assert_fs = "1.1"
@@ -208,7 +205,6 @@ wasm-tonic-build = { version = "0.12", default-features = false, features = [ "p
 criterion = "0.5.1"
 pprof = { version = "0.13.0", features = [ "criterion", "flamegraph" ] }
 
-# Slot integration. Dojo don't need to manually include `account_sdk` as dependency as `slot` already re-exports it.
 slot = { git = "https://github.com/cartridge-gg/slot", rev = "1298a30" }
 
 # alloy core

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -7,5 +7,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-account_sdk.workspace = true
+# Controller PR revision until merged.
+# https://github.com/cartridge-gg/controller/pull/1454
+account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "dbbe0353d64de743739d425f8aab91ca3ac0e16f" }
 katana-primitives.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true }
 base64.workspace = true
+cainome-cairo-serde.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-vm.workspace = true
 derive_more.workspace = true

--- a/crates/primitives/src/contract.rs
+++ b/crates/primitives/src/contract.rs
@@ -84,6 +84,21 @@ impl From<BigUint> for ContractAddress {
     }
 }
 
+impl cainome_cairo_serde::CairoSerde for ContractAddress {
+    type RustType = Self;
+
+    fn cairo_serialize(rust: &Self::RustType) -> Vec<Felt> {
+        vec![rust.0]
+    }
+
+    fn cairo_deserialize(
+        felts: &[Felt],
+        offset: usize,
+    ) -> cainome_cairo_serde::Result<Self::RustType> {
+        Ok(Self::from(<Felt as cainome_cairo_serde::CairoSerde>::cairo_deserialize(felts, offset)?))
+    }
+}
+
 #[macro_export]
 macro_rules! address {
     ($value:expr) => {

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -13,7 +13,6 @@ katana-primitives.workspace = true
 katana-provider.workspace = true
 katana-rpc-types.workspace = true
 
-account_sdk = { workspace = true, optional = true }
 anyhow.workspace = true
 jsonrpsee = { workspace = true, features = [ "macros", "server" ] }
 rstest.workspace = true
@@ -23,5 +22,5 @@ starknet.workspace = true
 thiserror.workspace = true
 
 [features]
-cartridge = [ "dep:account_sdk" ]
+cartridge = [  ]
 client = [ "jsonrpsee/client" ]

--- a/crates/rpc/rpc-api/src/cartridge.rs
+++ b/crates/rpc/rpc-api/src/cartridge.rs
@@ -1,7 +1,8 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use katana_primitives::{ContractAddress, Felt};
-use katana_rpc_types::{outside_execution::OutsideExecution, transaction::InvokeTxResult};
+use katana_rpc_types::outside_execution::OutsideExecution;
+use katana_rpc_types::transaction::InvokeTxResult;
 
 /// Cartridge API to support paymaster in local Katana development.
 /// This API is not aimed to be used in slot.

--- a/crates/rpc/rpc-api/src/cartridge.rs
+++ b/crates/rpc/rpc-api/src/cartridge.rs
@@ -1,8 +1,7 @@
-use account_sdk::account::outside_execution::OutsideExecution;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use katana_primitives::{ContractAddress, Felt};
-use katana_rpc_types::transaction::InvokeTxResult;
+use katana_rpc_types::{outside_execution::OutsideExecution, transaction::InvokeTxResult};
 
 /// Cartridge API to support paymaster in local Katana development.
 /// This API is not aimed to be used in slot.

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -11,6 +11,8 @@ katana-primitives.workspace = true
 katana-trie.workspace = true
 
 anyhow.workspace = true
+cainome.workspace = true
+cainome-cairo-serde.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-lang-utils.workspace = true
 derive_more.workspace = true

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block;
 pub mod class;
 pub mod event;
 pub mod message;
+pub mod outside_execution;
 pub mod receipt;
 pub mod state_update;
 pub mod trace;

--- a/crates/rpc/rpc-types/src/outside_execution.rs
+++ b/crates/rpc/rpc-types/src/outside_execution.rs
@@ -7,8 +7,7 @@
 //! Based on [SNIP-9](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md).
 
 use cainome::cairo_serde_derive::CairoSerde;
-use katana_primitives::ContractAddress;
-use katana_primitives::Felt;
+use katana_primitives::{ContractAddress, Felt};
 use serde::{Deserialize, Serialize};
 
 /// A single call to be executed as part of an outside execution.

--- a/crates/rpc/rpc-types/src/outside_execution.rs
+++ b/crates/rpc/rpc-types/src/outside_execution.rs
@@ -1,0 +1,71 @@
+//! Outside execution types for Starknet accounts.
+//!
+//! Outside execution (meta-transactions) allows protocols to submit transactions
+//! on behalf of user accounts with their signatures. This enables delayed orders,
+//! fee subsidy, and other advanced transaction patterns.
+//!
+//! Based on [SNIP-9](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md).
+
+use cainome::cairo_serde_derive::CairoSerde;
+use katana_primitives::ContractAddress;
+use katana_primitives::Felt;
+use serde::{Deserialize, Serialize};
+
+/// A single call to be executed as part of an outside execution.
+#[derive(Clone, CairoSerde, Serialize, Deserialize, PartialEq, Debug)]
+pub struct Call {
+    /// Contract address to call.
+    pub to: ContractAddress,
+    /// Function selector to invoke.
+    pub selector: Felt,
+    /// Arguments to pass to the function.
+    pub calldata: Vec<Felt>,
+}
+
+/// Outside execution version 2 (SNIP-9 standard).
+#[derive(Clone, CairoSerde, Serialize, Deserialize, PartialEq, Debug)]
+pub struct OutsideExecutionV2 {
+    /// Address allowed to initiate execution ('ANY_CALLER' for unrestricted).
+    pub caller: ContractAddress,
+    /// Unique nonce to prevent signature reuse.
+    pub nonce: Felt,
+    /// Timestamp after which execution is valid.
+    pub execute_after: u64,
+    /// Timestamp before which execution is valid.
+    pub execute_before: u64,
+    /// Calls to execute in order.
+    pub calls: Vec<Call>,
+}
+
+/// Non-standard extension of the [`OutsideExecutionV2`] supported by the Cartridge Controller.
+#[derive(Clone, CairoSerde, Serialize, Deserialize, PartialEq, Debug)]
+pub struct OutsideExecutionV3 {
+    /// Address allowed to initiate execution ('ANY_CALLER' for unrestricted).
+    pub caller: ContractAddress,
+    /// Nonce with channel (nonce, channel).
+    pub nonce: (Felt, u128),
+    /// Timestamp after which execution is valid.
+    pub execute_after: u64,
+    /// Timestamp before which execution is valid.
+    pub execute_before: u64,
+    /// Calls to execute in order.
+    pub calls: Vec<Call>,
+}
+
+#[derive(Clone, CairoSerde, Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum OutsideExecution {
+    /// SNIP-9 standard version.
+    V2(OutsideExecutionV2),
+    /// Cartridge/Controller extended version.
+    V3(OutsideExecutionV3),
+}
+
+impl OutsideExecution {
+    pub fn caller(&self) -> ContractAddress {
+        match self {
+            OutsideExecution::V2(v2) => v2.caller,
+            OutsideExecution::V3(v3) => v3.caller,
+        }
+    }
+}

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -34,7 +34,6 @@ serde_json.workspace = true
 starknet.workspace = true
 starknet-crypto.workspace = true
 # Use a specific revision of stark-vrf to avoid unwanted breaking changes.
-account_sdk = { workspace = true, optional = true }
 stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git", rev = "96d6d2a", optional = true }
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -21,6 +21,7 @@ katana-tasks.workspace = true
 
 anyhow.workspace = true
 ark-ec = { version = "0.4.2", optional = true }
+cainome = { workspace = true, optional = true }
 futures.workspace = true
 http.workspace = true
 jsonrpsee = { workspace = true, features = [ "server" ] }
@@ -34,7 +35,6 @@ starknet.workspace = true
 starknet-crypto.workspace = true
 # Use a specific revision of stark-vrf to avoid unwanted breaking changes.
 account_sdk = { workspace = true, optional = true }
-cainome = { workspace = true, optional = true }
 stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git", rev = "96d6d2a", optional = true }
 thiserror.workspace = true
 tokio.workspace = true
@@ -54,7 +54,6 @@ katana-utils.workspace = true
 alloy = { git = "https://github.com/alloy-rs/alloy", features = [ "contract", "network", "node-bindings", "provider-http", "providers", "signer-local" ] }
 alloy-primitives = { workspace = true, features = [ "serde" ] }
 assert_matches.workspace = true
-cainome.workspace = true
 cairo-lang-starknet-classes.workspace = true
 dojo-utils.workspace = true
 indexmap.workspace = true
@@ -70,7 +69,6 @@ tokio.workspace = true
 
 [features]
 cartridge = [
-	"dep:account_sdk",
 	"dep:ark-ec",
 	"dep:cainome",
 	"dep:num-bigint",

--- a/crates/rpc/rpc/src/cartridge/mod.rs
+++ b/crates/rpc/rpc/src/cartridge/mod.rs
@@ -48,7 +48,6 @@ pub mod vrf;
 
 use std::sync::Arc;
 
-use account_sdk::account::outside_execution::OutsideExecution;
 use anyhow::anyhow;
 use cainome::cairo_serde::CairoSerde;
 use jsonrpsee::core::{async_trait, RpcResult};
@@ -67,6 +66,7 @@ use katana_primitives::{ContractAddress, Felt};
 use katana_provider::traits::state::{StateFactoryProvider, StateProvider};
 use katana_rpc_api::cartridge::CartridgeApiServer;
 use katana_rpc_api::error::starknet::StarknetApiError;
+use katana_rpc_types::outside_execution::OutsideExecution;
 use katana_rpc_types::transaction::InvokeTxResult;
 use katana_tasks::TokioTaskSpawner;
 use serde::Deserialize;
@@ -212,8 +212,8 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
             }
 
             let mut inner_calldata =
-                <OutsideExecution as CairoSerde>::cairo_serialize(&outside_execution);
-            inner_calldata.extend(<Vec<Felt> as CairoSerde>::cairo_serialize(&signature));
+                OutsideExecution::cairo_serialize(&outside_execution);
+            inner_calldata.extend(Vec::<Felt>::cairo_serialize(&signature));
 
             let execute_from_outside_call = Call { to: address.into(), selector: entrypoint, calldata: inner_calldata };
 


### PR DESCRIPTION
Defines the outside execution types used in the `Cartridge` RPC API as internally owned types to avoid reliance on the `account_sdk` crate to ease maintenance. 

One issue that I've found is whenever we bump `starknet-rs`, there may be a conflict with `account_sdk`. 