### PR TITLE
refactor(utils): define tx waiter internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,13 +6025,13 @@ dependencies = [
  "clap_complete",
  "comfy-table",
  "const_format",
- "dojo-utils",
  "inquire",
  "katana-chain-spec",
  "katana-cli",
  "katana-db",
  "katana-primitives",
  "katana-rpc-types",
+ "katana-utils",
  "piltover",
  "rand 0.8.5",
  "rstest 0.18.2",
@@ -6681,6 +6681,8 @@ name = "katana-utils"
 version = "1.5.2"
 dependencies = [
  "anyhow",
+ "assert_matches",
+ "futures",
  "katana-chain-spec",
  "katana-core",
  "katana-executor",
@@ -6688,6 +6690,8 @@ dependencies = [
  "katana-primitives",
  "katana-provider",
  "starknet 0.12.0",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -12,6 +12,7 @@ katana-cli.workspace = true
 katana-db.workspace = true
 katana-primitives.workspace = true
 katana-rpc-types.workspace = true
+katana-utils.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
@@ -21,7 +22,6 @@ clap.workspace = true
 clap_complete.workspace = true
 comfy-table = "7.1.1"
 const_format = "0.2.33"
-dojo-utils.workspace = true
 inquire = "0.7.5"
 piltover = { git = "https://github.com/keep-starknet-strange/piltover.git", rev = "161cb3f" }
 rand.workspace = true

--- a/crates/rpc/rpc/tests/forking.rs
+++ b/crates/rpc/rpc/tests/forking.rs
@@ -56,7 +56,7 @@ async fn setup_test_inner(no_mining: bool) -> (TestNode, impl Provider, LocalTes
         for _ in 1..=10 {
             let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
             let res = contract.transfer(&Felt::ONE, &amount).send().await.unwrap();
-            dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await.unwrap();
+            katana_utils::TxWaiter::new(res.transaction_hash, &provider).await.unwrap();
 
             // events in pending block doesn't have block hash and number, so we can safely put
             // dummy values here.
@@ -67,8 +67,7 @@ async fn setup_test_inner(no_mining: bool) -> (TestNode, impl Provider, LocalTes
         for i in 1..=10 {
             let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
             let res = contract.transfer(&Felt::ONE, &amount).send().await.unwrap();
-            let _ =
-                dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await.unwrap();
+            let _ = katana_utils::TxWaiter::new(res.transaction_hash, &provider).await.unwrap();
 
             let block_num = FORK_BLOCK_NUMBER + i;
 

--- a/crates/rpc/rpc/tests/messaging.rs
+++ b/crates/rpc/rpc/tests/messaging.rs
@@ -7,14 +7,13 @@ use alloy::providers::ProviderBuilder;
 use alloy::sol;
 use anyhow::Result;
 use cainome::rs::abigen;
-use dojo_utils::TransactionWaiter;
 use katana_messaging::MessagingConfig;
 use katana_primitives::felt;
 use katana_primitives::utils::transaction::{
     compute_l1_handler_tx_hash, compute_l1_to_l2_message_hash,
 };
 use katana_rpc_types::receipt::ReceiptBlock;
-use katana_utils::TestNode;
+use katana_utils::{TestNode, TxWaiter};
 use rand::Rng;
 use starknet::accounts::{Account, ConnectedAccount};
 use starknet::contract::ContractFactory;
@@ -84,7 +83,7 @@ async fn test_messaging() {
         let res = katana_account.declare_v2(contract.into(), compiled_hash).send().await.unwrap();
 
         // The waiter already checks that the transaction is accepted and succeeded on L2.
-        TransactionWaiter::new(res.transaction_hash, katana_account.provider())
+        TxWaiter::new(res.transaction_hash, katana_account.provider())
             .await
             .expect("declare tx failed");
 
@@ -106,7 +105,7 @@ async fn test_messaging() {
             .expect("Unable to deploy contract");
 
         // The waiter already checks that the transaction is accepted and succeeded on L2.
-        TransactionWaiter::new(res.transaction_hash, katana_account.provider())
+        TxWaiter::new(res.transaction_hash, katana_account.provider())
             .await
             .expect("deploy tx failed");
 
@@ -243,7 +242,7 @@ async fn estimate_message_fee() -> Result<()> {
     let class_hash = contract.class_hash();
 
     let res = account.declare_v2(contract.into(), compiled_hash).send().await?;
-    TransactionWaiter::new(res.transaction_hash, account.provider()).await?;
+    TxWaiter::new(res.transaction_hash, account.provider()).await?;
 
     // Deploy the contract using UDC
     let res = ContractFactory::new(class_hash, &account)
@@ -251,7 +250,7 @@ async fn estimate_message_fee() -> Result<()> {
         .send()
         .await?;
 
-    TransactionWaiter::new(res.transaction_hash, account.provider()).await?;
+    TxWaiter::new(res.transaction_hash, account.provider()).await?;
 
     // Compute the contract address of the l1 handler contract
     let l1handler_address = get_contract_address(Felt::ZERO, class_hash, &[], Felt::ZERO);

--- a/crates/rpc/rpc/tests/proofs.rs
+++ b/crates/rpc/rpc/tests/proofs.rs
@@ -286,7 +286,7 @@ async fn declare(
         .await
         .expect("failed to send declare tx");
 
-    dojo_utils::TransactionWaiter::new(res.transaction_hash, account.provider())
+    katana_utils::TxWaiter::new(res.transaction_hash, account.provider())
         .await
         .expect("failed to wait on tx");
 

--- a/crates/rpc/rpc/tests/simulate.rs
+++ b/crates/rpc/rpc/tests/simulate.rs
@@ -45,7 +45,7 @@ async fn simulate_nonce_validation(#[values(None, Some(1000))] block_time: Optio
     // send a valid transaction first to increment the nonce (so that we can test nonce < current
     // nonce later)
     let res = contract.transfer(&recipient, &amount).send().await.unwrap();
-    dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await.unwrap();
+    katana_utils::TxWaiter::new(res.transaction_hash, &provider).await.unwrap();
 
     // simulate with current nonce (the expected nonce)
     let nonce =

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -14,4 +14,8 @@ katana-primitives.workspace = true
 katana-provider.workspace = true
 
 anyhow.workspace = true
+assert_matches.workspace = true
+futures.workspace = true
 starknet.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = [ "time" ] }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod node;
+mod tx_waiter;
 
 pub use node::TestNode;
+pub use tx_waiter::*;

--- a/crates/utils/src/tx_waiter.rs
+++ b/crates/utils/src/tx_waiter.rs
@@ -1,0 +1,466 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::FutureExt;
+use starknet::core::types::{
+    ExecutionResult, Felt, ReceiptBlock, StarknetError, TransactionFinalityStatus,
+    TransactionReceipt, TransactionReceiptWithBlockInfo, TransactionStatus,
+};
+use starknet::providers::{Provider, ProviderError};
+use tokio::time::{Instant, Interval};
+
+type GetTxStatusResult = Result<TransactionStatus, ProviderError>;
+type GetTxReceiptResult = Result<TransactionReceiptWithBlockInfo, ProviderError>;
+
+type GetTxStatusFuture<'a> = Pin<Box<dyn Future<Output = GetTxStatusResult> + Send + 'a>>;
+type GetTxReceiptFuture<'a> = Pin<Box<dyn Future<Output = GetTxReceiptResult> + Send + 'a>>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TxWaitingError {
+    #[error("request timed out")]
+    Timeout,
+
+    #[error("transaction reverted with reason: {0}")]
+    TransactionReverted(String),
+
+    #[error("transaction rejected")]
+    TransactionRejected,
+
+    #[error(transparent)]
+    Provider(ProviderError),
+}
+
+/// Utility for waiting on a transaction.
+///
+/// The waiter will poll for the transaction receipt every `interval` miliseconds until it achieves
+/// the desired status or until `timeout` is reached.
+///
+/// The waiter can be configured to wait for a specific finality status (e.g, `ACCEPTED_ON_L2`), by
+/// default, it only waits until the transaction is included in the _pending_ block. It can also be
+/// set to check if the transaction is executed successfully or not (reverted).
+///
+/// # Examples
+///
+/// ```ignore
+/// use url::Url;
+/// use starknet::providers::jsonrpc::HttpTransport;
+/// use starknet::providers::JsonRpcClient;
+/// use starknet::core::types::TransactionFinalityStatus;
+///
+/// let provider = JsonRpcClient::new(HttpTransport::new(Url::parse("http://localhost:5000").unwrap()));
+///
+/// let tx_hash = Felt::from(0xbadbeefu64);
+/// let receipt = TxWaiter::new(tx_hash, &provider).with_tx_status(TransactionFinalityStatus::AcceptedOnL2).await.unwrap();
+/// ```
+#[must_use = "TxWaiter does nothing unless polled"]
+pub struct TxWaiter<'a, P: Provider> {
+    /// The hash of the transaction to wait for.
+    tx_hash: Felt,
+    /// The transaction finality status to wait for.
+    ///
+    /// If not set, then it will wait until it is `ACCEPTED_ON_L2` whether it is reverted or not.
+    tx_finality_status: Option<TransactionFinalityStatus>,
+    /// A flag to indicate that the waited transaction must either be successfully executed or not.
+    ///
+    /// If it's set to `true`, then the transaction execution result must be `SUCCEEDED` otherwise
+    /// an error will be returned. However, if set to `false`, then the execution status will not
+    /// be considered when waiting for the transaction, meaning `REVERTED` transaction will not
+    /// return an error.
+    must_succeed: bool,
+    /// Poll the transaction every `interval` milliseconds. Milliseconds are used so that
+    /// we can be more precise with the polling interval. Defaults to 2.5 seconds.
+    interval: Interval,
+    /// The maximum amount of time to wait for the transaction to achieve the desired status. An
+    /// error will be returned if it is unable to finish within the `timeout` duration. Defaults to
+    /// 300 seconds.
+    timeout: Duration,
+    /// The provider to use for polling the transaction.
+    provider: &'a P,
+    /// The future that gets the transaction status.
+    tx_status_request_fut: Option<GetTxStatusFuture<'a>>,
+    /// The future that gets the transaction receipt.
+    tx_receipt_request_fut: Option<GetTxReceiptFuture<'a>>,
+    /// The time when the transaction waiter was first polled.
+    started_at: Option<Instant>,
+}
+
+impl<'a, P: Provider> TxWaiter<'a, P> {
+    /// The default timeout for a transaction to be accepted or reverted on L2.
+    /// The inclusion (which can be accepted or reverted) is ~5seconds in ideal cases.
+    /// We keep some margin for times that could be affected by network congestion or
+    /// block STM worst cases.
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+    /// Interval for use with 3rd party provider without burning the API rate limit.
+    const DEFAULT_INTERVAL: Duration = Duration::from_millis(2500);
+
+    pub fn new(tx: Felt, provider: &'a P) -> Self {
+        Self {
+            provider,
+            tx_hash: tx,
+            started_at: None,
+            must_succeed: true,
+            tx_finality_status: None,
+            tx_status_request_fut: None,
+            tx_receipt_request_fut: None,
+            timeout: Self::DEFAULT_TIMEOUT,
+            interval: tokio::time::interval_at(
+                Instant::now() + Self::DEFAULT_INTERVAL,
+                Self::DEFAULT_INTERVAL,
+            ),
+        }
+    }
+
+    pub fn with_interval(self, milisecond: u64) -> Self {
+        let interval = Duration::from_millis(milisecond);
+        Self { interval: tokio::time::interval_at(Instant::now() + interval, interval), ..self }
+    }
+
+    pub fn with_tx_status(self, status: TransactionFinalityStatus) -> Self {
+        Self { tx_finality_status: Some(status), ..self }
+    }
+
+    pub fn with_timeout(self, timeout: Duration) -> Self {
+        Self { timeout, ..self }
+    }
+
+    // Helper function to evaluate if the transaction receipt should be accepted yet or not, based
+    // on the waiter's parameters. Used in the `Future` impl.
+    fn evaluate_receipt_from_params(
+        receipt: TransactionReceiptWithBlockInfo,
+        expected_finality_status: Option<TransactionFinalityStatus>,
+        must_succeed: bool,
+    ) -> Option<Result<TransactionReceiptWithBlockInfo, TxWaitingError>> {
+        match &receipt.block {
+            ReceiptBlock::Pending => {
+                // pending receipt doesn't include finality status, so we cant check it.
+                if expected_finality_status.is_some() {
+                    return None;
+                }
+
+                if !must_succeed {
+                    return Some(Ok(receipt));
+                }
+
+                match execution_status_from_receipt(&receipt.receipt) {
+                    ExecutionResult::Succeeded => Some(Ok(receipt)),
+                    ExecutionResult::Reverted { reason } => {
+                        Some(Err(TxWaitingError::TransactionReverted(reason.clone())))
+                    }
+                }
+            }
+
+            ReceiptBlock::Block { .. } => {
+                if let Some(expected_status) = expected_finality_status {
+                    match finality_status_from_receipt(&receipt.receipt) {
+                        TransactionFinalityStatus::AcceptedOnL2
+                            if expected_status == TransactionFinalityStatus::AcceptedOnL1 =>
+                        {
+                            None
+                        }
+
+                        _ => {
+                            if !must_succeed {
+                                return Some(Ok(receipt));
+                            }
+
+                            match execution_status_from_receipt(&receipt.receipt) {
+                                ExecutionResult::Succeeded => Some(Ok(receipt)),
+                                ExecutionResult::Reverted { reason } => {
+                                    Some(Err(TxWaitingError::TransactionReverted(reason.clone())))
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    Some(Ok(receipt))
+                }
+            }
+        }
+    }
+}
+
+impl<P: Provider + Send> Future for TxWaiter<'_, P> {
+    type Output = Result<TransactionReceiptWithBlockInfo, TxWaitingError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        if this.started_at.is_none() {
+            this.started_at = Some(Instant::now());
+        }
+
+        loop {
+            if let Some(started_at) = this.started_at {
+                if started_at.elapsed() > this.timeout {
+                    return Poll::Ready(Err(TxWaitingError::Timeout));
+                }
+            }
+
+            if let Some(mut fut) = this.tx_status_request_fut.take() {
+                match fut.poll_unpin(cx) {
+                    Poll::Ready(res) => match res {
+                        Ok(status) => match status {
+                            TransactionStatus::AcceptedOnL2(_)
+                            | TransactionStatus::AcceptedOnL1(_) => {
+                                this.tx_receipt_request_fut = Some(Box::pin(
+                                    this.provider.get_transaction_receipt(this.tx_hash),
+                                ));
+                            }
+
+                            TransactionStatus::Rejected => {
+                                return Poll::Ready(Err(TxWaitingError::TransactionRejected));
+                            }
+
+                            TransactionStatus::Received => {}
+                        },
+
+                        Err(ProviderError::StarknetError(
+                            StarknetError::TransactionHashNotFound,
+                        )) => {}
+
+                        Err(e) => {
+                            return Poll::Ready(Err(TxWaitingError::Provider(e)));
+                        }
+                    },
+
+                    Poll::Pending => {
+                        this.tx_status_request_fut = Some(fut);
+                        return Poll::Pending;
+                    }
+                }
+            }
+
+            if let Some(mut fut) = this.tx_receipt_request_fut.take() {
+                match fut.poll_unpin(cx) {
+                    Poll::Pending => {
+                        this.tx_receipt_request_fut = Some(fut);
+                        return Poll::Pending;
+                    }
+
+                    Poll::Ready(res) => match res {
+                        Err(ProviderError::StarknetError(
+                            StarknetError::TransactionHashNotFound,
+                        )) => {}
+
+                        Err(e) => {
+                            return Poll::Ready(Err(TxWaitingError::Provider(e)));
+                        }
+
+                        Ok(res) => {
+                            if let Some(res) = Self::evaluate_receipt_from_params(
+                                res,
+                                this.tx_finality_status,
+                                this.must_succeed,
+                            ) {
+                                return Poll::Ready(res);
+                            }
+                        }
+                    },
+                }
+            }
+
+            if this.interval.poll_tick(cx).is_ready() {
+                this.tx_status_request_fut =
+                    Some(Box::pin(this.provider.get_transaction_status(this.tx_hash)));
+            } else {
+                break;
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<P: Provider> std::fmt::Debug for TxWaiter<'_, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TxWaiter")
+            .field("tx_hash", &self.tx_hash)
+            .field("tx_finality_status", &self.tx_finality_status)
+            .field("must_succeed", &self.must_succeed)
+            .field("interval", &self.interval)
+            .field("timeout", &self.timeout)
+            .field("provider", &"..")
+            .field("tx_status_request_fut", &"..")
+            .field("tx_receipt_request_fut", &"..")
+            .field("started_at", &self.started_at)
+            .finish()
+    }
+}
+
+fn execution_status_from_receipt(receipt: &TransactionReceipt) -> &ExecutionResult {
+    match receipt {
+        TransactionReceipt::Invoke(receipt) => &receipt.execution_result,
+        TransactionReceipt::Deploy(receipt) => &receipt.execution_result,
+        TransactionReceipt::Declare(receipt) => &receipt.execution_result,
+        TransactionReceipt::L1Handler(receipt) => &receipt.execution_result,
+        TransactionReceipt::DeployAccount(receipt) => &receipt.execution_result,
+    }
+}
+
+fn finality_status_from_receipt(receipt: &TransactionReceipt) -> TransactionFinalityStatus {
+    match receipt {
+        TransactionReceipt::Invoke(receipt) => receipt.finality_status,
+        TransactionReceipt::Deploy(receipt) => receipt.finality_status,
+        TransactionReceipt::Declare(receipt) => receipt.finality_status,
+        TransactionReceipt::L1Handler(receipt) => receipt.finality_status,
+        TransactionReceipt::DeployAccount(receipt) => receipt.finality_status,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use starknet::core::types::ExecutionResult::{Reverted, Succeeded};
+    use starknet::core::types::TransactionFinalityStatus::{self, AcceptedOnL1, AcceptedOnL2};
+    use starknet::core::types::{
+        ComputationResources, DataAvailabilityResources, DataResources, ExecutionResources,
+        ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, ReceiptBlock,
+        TransactionReceipt, TransactionReceiptWithBlockInfo,
+    };
+    use starknet::macros::felt;
+    use starknet::providers::jsonrpc::HttpTransport;
+    use starknet::providers::JsonRpcClient;
+
+    use super::{Duration, TxWaiter};
+    use crate::{TestNode, TxWaitingError};
+
+    async fn create_test_sequencer() -> (TestNode, JsonRpcClient<HttpTransport>) {
+        let sequencer = TestNode::new().await;
+        let provider = sequencer.starknet_provider();
+        (sequencer, provider)
+    }
+
+    const EXECUTION_RESOURCES: ExecutionResources = ExecutionResources {
+        computation_resources: ComputationResources {
+            steps: 0,
+            memory_holes: None,
+            ec_op_builtin_applications: Some(0),
+            ecdsa_builtin_applications: Some(0),
+            keccak_builtin_applications: Some(0),
+            bitwise_builtin_applications: Some(0),
+            pedersen_builtin_applications: Some(0),
+            poseidon_builtin_applications: Some(0),
+            range_check_builtin_applications: Some(0),
+            segment_arena_builtin: Some(0),
+        },
+        data_resources: DataResources {
+            data_availability: DataAvailabilityResources { l1_gas: 0, l1_data_gas: 0 },
+        },
+    };
+
+    fn mock_receipt(
+        finality_status: TransactionFinalityStatus,
+        execution_result: ExecutionResult,
+    ) -> TransactionReceiptWithBlockInfo {
+        let receipt = TransactionReceipt::Invoke(InvokeTransactionReceipt {
+            finality_status,
+            execution_result,
+            events: Default::default(),
+            actual_fee: FeePayment { amount: Default::default(), unit: PriceUnit::Wei },
+            messages_sent: Default::default(),
+            transaction_hash: Default::default(),
+            execution_resources: EXECUTION_RESOURCES,
+        });
+
+        TransactionReceiptWithBlockInfo {
+            receipt,
+            block: ReceiptBlock::Block {
+                block_hash: Default::default(),
+                block_number: Default::default(),
+            },
+        }
+    }
+
+    fn mock_pending_receipt(execution_result: ExecutionResult) -> TransactionReceiptWithBlockInfo {
+        let receipt = TransactionReceipt::Invoke(InvokeTransactionReceipt {
+            execution_result,
+            events: Default::default(),
+            finality_status: TransactionFinalityStatus::AcceptedOnL2,
+            actual_fee: FeePayment { amount: Default::default(), unit: PriceUnit::Wei },
+            messages_sent: Default::default(),
+            transaction_hash: Default::default(),
+            execution_resources: EXECUTION_RESOURCES,
+        });
+
+        TransactionReceiptWithBlockInfo { receipt, block: ReceiptBlock::Pending }
+    }
+
+    #[tokio::test]
+    async fn should_timeout_on_nonexistant_transaction() {
+        let (_sequencer, provider) = create_test_sequencer().await;
+
+        let hash = felt!("0x1234");
+        let result =
+            TxWaiter::new(hash, &provider).with_timeout(Duration::from_secs(1)).await.unwrap_err();
+
+        assert_matches!(result, TxWaitingError::Timeout);
+    }
+
+    macro_rules! eval_receipt {
+        ($receipt:expr, $must_succeed:expr) => {
+            TxWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                $receipt,
+                None,
+                $must_succeed,
+            )
+        };
+
+        ($receipt:expr, $expected_status:expr, $must_succeed:expr) => {
+            TxWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                $receipt,
+                Some($expected_status),
+                $must_succeed,
+            )
+        };
+    }
+
+    #[test]
+    fn wait_for_no_finality_status() {
+        let receipt = mock_receipt(AcceptedOnL2, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), false).unwrap().is_ok());
+    }
+
+    #[test]
+    fn wait_for_finality_status_with_no_succeed() {
+        let receipt = mock_receipt(AcceptedOnL2, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL2, false).unwrap().is_ok());
+
+        let receipt = mock_receipt(AcceptedOnL2, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL1, true).is_none());
+
+        let receipt = mock_receipt(AcceptedOnL1, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL2, false).unwrap().is_ok());
+
+        let receipt = mock_receipt(AcceptedOnL1, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL1, false).unwrap().is_ok());
+    }
+
+    #[test]
+    fn wait_for_finality_status_with_must_succeed() {
+        let receipt = mock_receipt(AcceptedOnL2, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL2, true).unwrap().is_ok());
+
+        let receipt = mock_receipt(AcceptedOnL1, Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL2, true).unwrap().is_ok());
+
+        let receipt = mock_receipt(AcceptedOnL1, Reverted { reason: Default::default() });
+        let evaluation = eval_receipt!(receipt.clone(), AcceptedOnL1, true).unwrap();
+        assert_matches!(evaluation, Err(TxWaitingError::TransactionReverted(_)));
+    }
+
+    #[test]
+    fn wait_for_pending_tx() {
+        let receipt = mock_pending_receipt(Succeeded);
+        assert!(eval_receipt!(receipt.clone(), AcceptedOnL2, true).is_none());
+
+        let receipt = mock_pending_receipt(Reverted { reason: Default::default() });
+        assert!(eval_receipt!(receipt.clone(), false).unwrap().is_ok());
+
+        let receipt = mock_pending_receipt(Reverted { reason: Default::default() });
+        let evaluation = eval_receipt!(receipt.clone(), true).unwrap();
+        assert_matches!(evaluation, Err(TxWaitingError::TransactionReverted(_)));
+    }
+}


### PR DESCRIPTION
Avoid `starknet-rs` version conflicts. Having it internally allow for easier maintenance when bumping the `starknet-rs` version for the whole workspace.

Similar purpose to #90 .