### PR TITLE
feat(primitives): simplify execution types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6447,6 +6447,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "base64 0.21.7",
+ "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "cainome-cairo-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-lang-starknet-classes",
  "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,3 +230,5 @@ bitvec = "1.0.1"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", default-features = false }
+
+blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "5d737b9c9", default-features = false }

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -12,9 +12,9 @@ use katana_primitives::block::{
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::env::BlockEnv;
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::{Event, Receipt, ReceiptWithTxHash};
 use katana_primitives::state::{compute_state_diff_hash, StateUpdates, StateUpdatesWithClasses};
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{TxHash, TxWithHash};
 use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::{address, ContractAddress, Felt};
@@ -142,7 +142,7 @@ impl<EF: ExecutorFactory> Backend<EF> {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        traces: Vec<TxExecInfo>,
+        traces: Vec<TransactionExecutionInfo>,
     ) -> Result<(), BlockProductionError> {
         self.blockchain
             .provider()

--- a/crates/core/src/service/block_producer.rs
+++ b/crates/core/src/service/block_producer.rs
@@ -22,8 +22,8 @@ use katana_executor::{BlockExecutor, ExecutionResult, ExecutionStats, ExecutorFa
 use katana_pool::validation::stateful::TxValidator;
 use katana_primitives::block::{BlockHashOrNumber, ExecutableBlock, PartialHeader};
 use katana_primitives::da::L1DataAvailabilityMode;
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
 use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_provider::error::ProviderError;
@@ -77,7 +77,7 @@ pub struct MinedBlockOutcome {
 pub struct TxWithOutcome {
     pub tx: TxWithHash,
     pub receipt: Receipt,
-    pub exec_info: TxExecInfo,
+    pub exec_info: TransactionExecutionInfo,
 }
 
 type ServiceFuture<T> = Pin<Box<dyn Future<Output = BlockingTaskResult<T>> + Send + Sync>>;

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 katana-primitives.workspace = true
 katana-provider.workspace = true
 
-blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "5d737b9c9", features = [ "testing" ], optional = true }
+blockifier = { workspace = true, features = [ "testing" ], optional = true }
 quick_cache = "0.6.10"
 starknet = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/executor/src/abstraction/mod.rs
+++ b/crates/executor/src/abstraction/mod.rs
@@ -1,9 +1,9 @@
 mod executor;
 
 pub use executor::*;
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::TxWithHash;
 use katana_primitives::{ContractAddress, Felt};
 
@@ -116,13 +116,13 @@ pub struct EntryPointCall {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum ExecutionResult {
-    Success { receipt: Receipt, trace: TxExecInfo },
+    Success { receipt: Receipt, trace: TransactionExecutionInfo },
     Failed { error: ExecutionError },
 }
 
 impl ExecutionResult {
     /// Creates a new successful execution result.
-    pub fn new_success(receipt: Receipt, trace: TxExecInfo) -> Self {
+    pub fn new_success(receipt: Receipt, trace: TransactionExecutionInfo) -> Self {
         ExecutionResult::Success { receipt, trace }
     }
 
@@ -150,7 +150,7 @@ impl ExecutionResult {
     }
 
     /// Returns the execution info if it was successful. Otherwise, returns `None`.
-    pub fn trace(&self) -> Option<&TxExecInfo> {
+    pub fn trace(&self) -> Option<&TransactionExecutionInfo> {
         match self {
             ExecutionResult::Success { trace, .. } => Some(trace),
             _ => None,

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -297,7 +297,7 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
                                 state.declared_classes.insert(class_hash, class.as_ref().clone());
                             }
 
-                            crate::utils::log_resources(&trace.actual_resources);
+                            crate::utils::log_resources(&trace.receipt.resources);
                         }
 
                         ExecutionResult::Failed { error } => {

--- a/crates/executor/src/implementation/blockifier/utils.rs
+++ b/crates/executor/src/implementation/blockifier/utils.rs
@@ -134,9 +134,9 @@ pub fn transact<S: StateReader>(
             tx_state.commit();
 
             // get the trace and receipt from the execution info
-            let trace = to_exec_info(info, tx.r#type());
+            let trace = to_exec_info(info.clone(), tx.r#type());
             let receipt = build_receipt(tx.tx_ref(), fee, &trace);
-            Ok(ExecutionResult::new_success(receipt, trace))
+            Ok(ExecutionResult::new_success(receipt, info))
         }
 
         Err(e) => {

--- a/crates/executor/src/utils.rs
+++ b/crates/executor/src/utils.rs
@@ -1,25 +1,27 @@
+use katana_primitives::execution::TransactionResources;
 use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::receipt::{
     DeclareTxReceipt, DeployAccountTxReceipt, Event, InvokeTxReceipt, L1HandlerTxReceipt,
     MessageToL1, Receipt,
 };
-use katana_primitives::trace::{CallInfo, TxExecInfo, TxResources};
+use katana_primitives::trace::{CallInfo, TxExecInfo};
 use katana_primitives::transaction::TxRef;
 use tracing::trace;
 
 pub(crate) const LOG_TARGET: &str = "executor";
 
-pub fn log_resources(resources: &TxResources) {
+pub fn log_resources(resources: &TransactionResources) {
     let mut mapped_strings = Vec::new();
 
-    for (builtin, count) in &resources.vm_resources.builtin_instance_counter {
+    for (builtin, count) in &resources.computation.vm_resources.builtin_instance_counter {
         mapped_strings.push(format!("{builtin}: {count}"));
     }
 
     // Sort the strings alphabetically
     mapped_strings.sort();
-    mapped_strings.insert(0, format!("steps: {}", resources.vm_resources.n_steps));
-    mapped_strings.insert(1, format!("memory holes: {}", resources.vm_resources.n_memory_holes));
+    mapped_strings.insert(0, format!("steps: {}", resources.computation.vm_resources.n_steps));
+    mapped_strings
+        .insert(1, format!("memory holes: {}", resources.computation.vm_resources.n_memory_holes));
 
     trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Transaction resource usage.");
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true }
 base64.workspace = true
+blockifier.workspace = true
 cainome-cairo-serde.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-vm.workspace = true
@@ -46,7 +47,7 @@ pprof.workspace = true
 default = [ "serde" ]
 
 arbitrary = [ "alloy-primitives/arbitrary", "dep:arbitrary" ]
-serde = [ "alloy-primitives/serde" ]
+serde = [ "alloy-primitives/serde", "blockifier/transaction_serde" ]
 
 [[bench]]
 harness = false

--- a/crates/primitives/src/execution.rs
+++ b/crates/primitives/src/execution.rs
@@ -1,0 +1,42 @@
+pub use blockifier::execution::call_info::{CallInfo, ExecutionSummary};
+pub use blockifier::execution::entry_point::{CallEntryPoint, CallType};
+pub use blockifier::execution::stack_trace::ErrorStack;
+pub use blockifier::fee::fee_checks::FeeCheckError;
+pub use blockifier::fee::receipt::TransactionReceipt;
+pub use blockifier::fee::resources::{
+    ComputationResources, StarknetResources, TransactionResources,
+};
+pub use blockifier::transaction::objects::{RevertError, TransactionExecutionInfo};
+pub use cairo_vm::types::builtin_name::BuiltinName;
+pub use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+pub use starknet_api::contract_class::EntryPointType;
+pub use starknet_api::executable_transaction::TransactionType;
+pub use starknet_api::execution_resources::{GasAmount, GasVector};
+pub use starknet_api::transaction::fields::Fee;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TypedTransactionExecutionInfo {
+    Invoke(TransactionExecutionInfo),
+    Declare(TransactionExecutionInfo),
+    L1Handler(TransactionExecutionInfo),
+    DeployAccount(TransactionExecutionInfo),
+}
+
+impl TypedTransactionExecutionInfo {
+    /// Returns the [`TransactionExecutionInfo`]
+    pub fn info(&self) -> &TransactionExecutionInfo {
+        match self {
+            Self::Invoke(info) => info,
+            Self::Declare(info) => info,
+            Self::L1Handler(info) => info,
+            Self::DeployAccount(info) => info,
+        }
+    }
+}
+
+impl Default for TypedTransactionExecutionInfo {
+    fn default() -> Self {
+        Self::Invoke(TransactionExecutionInfo::default())
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -9,6 +9,7 @@ pub mod da;
 pub mod env;
 pub mod eth;
 pub mod event;
+pub mod execution;
 pub mod fee;
 pub mod genesis;
 pub mod message;

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -8,7 +8,7 @@ use starknet_types_core::hash::{self, StarkHash};
 use crate::contract::ContractAddress;
 use crate::fee::TxFeeInfo;
 use crate::trace::TxResources;
-use crate::transaction::TxHash;
+use crate::transaction::{TxHash, TxType};
 use crate::Felt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -173,6 +173,16 @@ impl Receipt {
             Receipt::Declare(rct) => &rct.fee,
             Receipt::L1Handler(rct) => &rct.fee,
             Receipt::DeployAccount(rct) => &rct.fee,
+        }
+    }
+
+    /// Returns the transaction tyoe of the receipt.
+    pub fn r#type(&self) -> TxType {
+        match self {
+            Receipt::Invoke(_) => TxType::Invoke,
+            Receipt::Declare(_) => TxType::Declare,
+            Receipt::L1Handler(_) => TxType::L1Handler,
+            Receipt::DeployAccount(_) => TxType::DeployAccount,
         }
     }
 }

--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -83,6 +83,17 @@ impl Tx {
             Tx::Deploy(tx) => tx.version,
         }
     }
+
+    /// Returns the type of the transaction.
+    pub fn r#type(&self) -> TxType {
+        match self {
+            Self::Invoke(_) => TxType::Invoke,
+            Self::Deploy(_) => TxType::Deploy,
+            Self::Declare(_) => TxType::Declare,
+            Self::L1Handler(_) => TxType::L1Handler,
+            Self::DeployAccount(_) => TxType::DeployAccount,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/rpc/rpc-types/src/trace.rs
+++ b/crates/rpc/rpc-types/src/trace.rs
@@ -1,79 +1,18 @@
-use katana_primitives::trace::{CallInfo, TxExecInfo};
-use katana_primitives::transaction::TxHash;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use katana_primitives::execution::{self, BuiltinName, CallInfo, TransactionExecutionInfo};
+use katana_primitives::fee::TxFeeInfo;
+use katana_primitives::transaction::{TxHash, TxType};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::{
-    CallType, ComputationResources, EntryPointType, OrderedEvent, OrderedMessage,
+    CallType, ComputationResources, DataAvailabilityResources, DataResources,
+    DeclareTransactionTrace, DeployAccountTransactionTrace, EntryPointType, ExecuteInvocation,
+    ExecutionResources, FunctionInvocation, InvokeTransactionTrace, L1HandlerTransactionTrace,
+    OrderedEvent, OrderedMessage, PriceUnit, RevertedInvocation, TransactionTrace,
 };
 
-#[derive(Debug)]
-pub struct FunctionInvocation(pub starknet::core::types::FunctionInvocation);
-
-impl From<CallInfo> for FunctionInvocation {
-    fn from(info: CallInfo) -> Self {
-        let entry_point_type = match info.entry_point_type {
-            katana_primitives::trace::EntryPointType::External => EntryPointType::External,
-            katana_primitives::trace::EntryPointType::L1Handler => EntryPointType::L1Handler,
-            katana_primitives::trace::EntryPointType::Constructor => EntryPointType::Constructor,
-        };
-
-        let call_type = match info.call_type {
-            katana_primitives::trace::CallType::Call => CallType::Call,
-            katana_primitives::trace::CallType::Delegate => CallType::Delegate,
-        };
-
-        let calls = info.inner_calls.into_iter().map(|c| FunctionInvocation::from(c).0).collect();
-
-        let events = info
-            .events
-            .into_iter()
-            .map(|e| OrderedEvent { order: e.order, data: e.data, keys: e.keys })
-            .collect();
-
-        let messages = info
-            .l2_to_l1_messages
-            .into_iter()
-            .map(|m| OrderedMessage {
-                order: m.order,
-                payload: m.payload,
-                to_address: m.to_address,
-                from_address: m.from_address.into(),
-            })
-            .collect();
-
-        let resources = info.execution_resources;
-
-        // TODO: replace execution resources type in primitive CallInfo with an already defined
-        // `TxExecutionResources`
-        let execution_resources = ComputationResources {
-            steps: resources.n_steps as u64,
-            memory_holes: Some(resources.n_memory_holes as u64),
-            range_check_builtin_applications: resources.builtin_instance_counter.range_check(),
-            pedersen_builtin_applications: resources.builtin_instance_counter.pedersen(),
-            poseidon_builtin_applications: resources.builtin_instance_counter.poseidon(),
-            ec_op_builtin_applications: resources.builtin_instance_counter.ec_op(),
-            ecdsa_builtin_applications: resources.builtin_instance_counter.ecdsa(),
-            bitwise_builtin_applications: resources.builtin_instance_counter.bitwise(),
-            keccak_builtin_applications: resources.builtin_instance_counter.keccak(),
-            segment_arena_builtin: resources.builtin_instance_counter.segment_arena(),
-        };
-
-        Self(starknet::core::types::FunctionInvocation {
-            calls,
-            events,
-            messages,
-            call_type,
-            entry_point_type,
-            execution_resources,
-            result: info.retdata,
-            calldata: info.calldata,
-            caller_address: info.caller_address.into(),
-            contract_address: info.contract_address.into(),
-            entry_point_selector: info.entry_point_selector,
-            // See <https://github.com/starkware-libs/blockifier/blob/cb464f5ac2ada88f2844d9f7d62bd6732ceb5b2c/crates/blockifier/src/execution/call_info.rs#L220>
-            class_hash: info.class_hash.expect("Class hash mut be set after execution"),
-        })
-    }
-}
+use crate::FeeEstimate;
 
 /// The type returned by the `saya_getTransactionExecutionsByBlock` RPC method.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -81,5 +20,173 @@ pub struct TxExecutionInfo {
     /// The transaction hash.
     pub hash: TxHash,
     /// The transaction execution trace.
-    pub trace: TxExecInfo,
+    pub trace: TransactionExecutionInfo,
+}
+
+pub fn to_rpc_trace(trace: TransactionExecutionInfo, tx_type: TxType) -> TransactionTrace {
+    let execution_resources = to_rpc_resources(trace.receipt.resources.computation.vm_resources);
+    let fee_transfer_invocation = trace.fee_transfer_call_info.map(to_function_invocation);
+    let validate_invocation = trace.validate_call_info.map(to_function_invocation);
+    let execute_invocation = trace.execute_call_info.map(to_function_invocation);
+    let revert_reason = trace.revert_error.map(|e| e.to_string());
+    let state_diff = None; // TODO: compute the state diff
+
+    match tx_type {
+        TxType::Invoke => {
+            let execute_invocation = if let Some(revert_reason) = revert_reason {
+                let invocation = RevertedInvocation { revert_reason };
+                ExecuteInvocation::Reverted(invocation)
+            } else {
+                let invocation = execute_invocation.expect("should exist if not reverted");
+                ExecuteInvocation::Success(invocation)
+            };
+
+            TransactionTrace::Invoke(InvokeTransactionTrace {
+                fee_transfer_invocation,
+                execution_resources,
+                validate_invocation,
+                execute_invocation,
+                state_diff,
+            })
+        }
+
+        TxType::Declare => TransactionTrace::Declare(DeclareTransactionTrace {
+            fee_transfer_invocation,
+            validate_invocation,
+            execution_resources,
+            state_diff,
+        }),
+
+        TxType::DeployAccount => {
+            let constructor_invocation = execute_invocation.expect("should exist if not reverted");
+            TransactionTrace::DeployAccount(DeployAccountTransactionTrace {
+                fee_transfer_invocation,
+                constructor_invocation,
+                validate_invocation,
+                execution_resources,
+                state_diff,
+            })
+        }
+
+        TxType::L1Handler => {
+            let function_invocation = execute_invocation.expect("should exist if not reverted");
+            TransactionTrace::L1Handler(L1HandlerTransactionTrace {
+                execution_resources,
+                function_invocation,
+                state_diff,
+            })
+        }
+
+        TxType::Deploy => {
+            unimplemented!("unsupported legacy tx type")
+        }
+    }
+}
+
+pub fn to_rpc_fee_estimate(fee: TxFeeInfo) -> FeeEstimate {
+    FeeEstimate {
+        unit: match fee.unit {
+            katana_primitives::fee::PriceUnit::Wei => PriceUnit::Wei,
+            katana_primitives::fee::PriceUnit::Fri => PriceUnit::Fri,
+        },
+        gas_price: fee.gas_price.into(),
+        overall_fee: fee.overall_fee.into(),
+        gas_consumed: fee.gas_consumed.into(),
+        data_gas_price: Default::default(),
+        data_gas_consumed: Default::default(),
+    }
+}
+
+pub fn to_rpc_resources(resources: execution::ExecutionResources) -> ExecutionResources {
+    let data_resources = to_rpc_data_resources(&resources);
+    let computation_resources = to_rpc_computation_resources(&resources);
+    ExecutionResources { data_resources, computation_resources }
+}
+
+fn to_function_invocation(info: CallInfo) -> FunctionInvocation {
+    let contract_address = info.call.storage_address;
+    let calls = info.inner_calls.into_iter().map(to_function_invocation).collect();
+
+    let entry_point_type = match info.call.entry_point_type {
+        execution::EntryPointType::External => EntryPointType::External,
+        execution::EntryPointType::L1Handler => EntryPointType::L1Handler,
+        execution::EntryPointType::Constructor => EntryPointType::Constructor,
+    };
+
+    let call_type = match info.call.call_type {
+        execution::CallType::Call => CallType::Call,
+        execution::CallType::Delegate => CallType::Delegate,
+    };
+
+    let events = info
+        .execution
+        .events
+        .into_iter()
+        .map(|e| OrderedEvent {
+            order: e.order as u64,
+            data: e.event.data.0,
+            keys: e.event.keys.into_iter().map(|k| k.0).collect(),
+        })
+        .collect();
+
+    let messages = info
+        .execution
+        .l2_to_l1_messages
+        .into_iter()
+        .map(|m| OrderedMessage {
+            order: m.order as u64,
+            payload: m.message.payload.0,
+            to_address: m.message.to_address,
+            from_address: contract_address.into(),
+        })
+        .collect();
+
+    // TODO: replace execution resources type in primitive CallInfo with an already defined
+    // `TxExecutionResources`
+    //
+    let execution_resources = to_rpc_computation_resources(&info.resources);
+
+    FunctionInvocation {
+        calls,
+        events,
+        messages,
+        call_type,
+        entry_point_type,
+        execution_resources,
+        result: info.execution.retdata.0,
+        caller_address: info.call.caller_address.into(),
+        contract_address: info.call.storage_address.into(),
+        calldata: Arc::unwrap_or_clone(info.call.calldata.0),
+        entry_point_selector: info.call.entry_point_selector.0,
+        // See <https://github.com/starkware-libs/blockifier/blob/cb464f5ac2ada88f2844d9f7d62bd6732ceb5b2c/crates/blockifier/src/execution/call_info.rs#L220>
+        class_hash: info.call.class_hash.expect("Class hash mut be set after execution").0,
+    }
+}
+
+fn to_rpc_computation_resources(resources: &execution::ExecutionResources) -> ComputationResources {
+    let builtins = &resources.builtin_instance_counter;
+    ComputationResources {
+        steps: resources.n_steps as u64,
+        memory_holes: Some(resources.n_memory_holes as u64),
+        ecdsa_builtin_applications: get_builtin_count(builtins, BuiltinName::ecdsa),
+        ec_op_builtin_applications: get_builtin_count(builtins, BuiltinName::ec_op),
+        keccak_builtin_applications: get_builtin_count(builtins, BuiltinName::keccak),
+        segment_arena_builtin: get_builtin_count(builtins, BuiltinName::segment_arena),
+        bitwise_builtin_applications: get_builtin_count(builtins, BuiltinName::bitwise),
+        pedersen_builtin_applications: get_builtin_count(builtins, BuiltinName::pedersen),
+        poseidon_builtin_applications: get_builtin_count(builtins, BuiltinName::poseidon),
+        range_check_builtin_applications: get_builtin_count(builtins, BuiltinName::range_check),
+    }
+}
+
+fn to_rpc_data_resources(_: &execution::ExecutionResources) -> DataResources {
+    let data_availability = DataAvailabilityResources { l1_gas: 0, l1_data_gas: 0 };
+    DataResources { data_availability }
+}
+
+fn get_builtin_count(
+    builtins: &HashMap<BuiltinName, usize>,
+    builtin_name: BuiltinName,
+) -> Option<u64> {
+    builtins.get(&builtin_name).map(|&x| x as u64)
 }

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,7 +1,7 @@
 use katana_primitives::block::Header;
 use katana_primitives::contract::{ContractAddress, GenericContractInfo};
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::Tx;
 use katana_primitives::Felt;
 use {postcard, zstd};
@@ -34,7 +34,7 @@ macro_rules! impl_compress_and_decompress_for_table_values {
     }
 }
 
-impl Compress for TxExecInfo {
+impl Compress for TransactionExecutionInfo {
     type Compressed = Vec<u8>;
     fn compress(self) -> Result<Self::Compressed, crate::error::CodecError> {
         let serialized = postcard::to_stdvec(&self).unwrap();
@@ -42,7 +42,7 @@ impl Compress for TxExecInfo {
     }
 }
 
-impl Decompress for TxExecInfo {
+impl Decompress for TransactionExecutionInfo {
     fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, crate::error::CodecError> {
         let compressed = bytes.as_ref();
         let serialized =

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -1,8 +1,8 @@
 use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
 use katana_primitives::class::{ClassHash, CompiledClassHash, ContractClass};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{Tx, TxHash, TxNumber};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
@@ -212,7 +212,7 @@ tables! {
     /// Stores the block number of a transaction.
     TxBlocks: (TxNumber) => BlockNumber,
     /// Stores the transaction's traces.
-    TxTraces: (TxNumber) => TxExecInfo,
+    TxTraces: (TxNumber) => TransactionExecutionInfo,
     /// Store transaction receipts
     Receipts: (TxNumber) => Receipt,
     /// Store compiled classes
@@ -359,9 +359,9 @@ mod tests {
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
     use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
+    use katana_primitives::execution::TransactionExecutionInfo;
     use katana_primitives::fee::{PriceUnit, TxFeeInfo};
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
-    use katana_primitives::trace::TxExecInfo;
     use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
     use starknet::macros::felt;
 
@@ -431,7 +431,7 @@ mod tests {
             (TxHash, felt!("0x123456789")),
             (Tx, Tx::Invoke(InvokeTx::V1(Default::default()))),
             (BlockNumber, 99),
-            (TxExecInfo, TxExecInfo::default()),
+            (TransactionExecutionInfo, TransactionExecutionInfo::default()),
             (CompiledClassHash, felt!("211")),
             (CompiledClass, CompiledClass::Legacy(Default::default())),
             (GenericContractInfo, GenericContractInfo::default()),

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -10,9 +10,9 @@ use katana_primitives::block::{
 use katana_primitives::class::{ClassHash, CompiledClassHash, ContractClass};
 use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
 use katana_primitives::env::BlockEnv;
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use katana_primitives::Felt;
 use traits::block::{BlockIdReader, BlockStatusProvider, BlockWriter};
@@ -141,7 +141,7 @@ where
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TxExecInfo>,
+        executions: Vec<TransactionExecutionInfo>,
     ) -> ProviderResult<()> {
         self.provider.insert_block_with_states_and_receipts(block, states, receipts, executions)
     }
@@ -202,21 +202,24 @@ impl<Db> TransactionTraceProvider for BlockchainProvider<Db>
 where
     Db: TransactionTraceProvider,
 {
-    fn transaction_execution(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>> {
+    fn transaction_execution(
+        &self,
+        hash: TxHash,
+    ) -> ProviderResult<Option<TransactionExecutionInfo>> {
         TransactionTraceProvider::transaction_execution(&self.provider, hash)
     }
 
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TxExecInfo>>> {
+    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>> {
         TransactionTraceProvider::transaction_executions_by_block(&self.provider, block_id)
     }
 
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TxExecInfo>> {
+    ) -> ProviderResult<Vec<TransactionExecutionInfo>> {
         TransactionTraceProvider::transaction_executions_in_range(&self.provider, range)
     }
 }

--- a/crates/storage/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/src/providers/fork/mod.rs
@@ -13,9 +13,9 @@ use katana_primitives::block::{
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::env::BlockEnv;
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
@@ -199,21 +199,24 @@ impl<Db: Database> TransactionStatusProvider for ForkedProvider<Db> {
 }
 
 impl<Db: Database> TransactionTraceProvider for ForkedProvider<Db> {
-    fn transaction_execution(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>> {
+    fn transaction_execution(
+        &self,
+        hash: TxHash,
+    ) -> ProviderResult<Option<TransactionExecutionInfo>> {
         self.provider.transaction_execution(hash)
     }
 
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TxExecInfo>>> {
+    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>> {
         self.provider.transaction_executions_by_block(block_id)
     }
 
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TxExecInfo>> {
+    ) -> ProviderResult<Vec<TransactionExecutionInfo>> {
         self.provider.transaction_executions_in_range(range)
     }
 }
@@ -243,7 +246,7 @@ impl<Db: Database> BlockWriter for ForkedProvider<Db> {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TxExecInfo>,
+        executions: Vec<TransactionExecutionInfo>,
     ) -> ProviderResult<()> {
         self.provider.insert_block_with_states_and_receipts(block, states, receipts, executions)
     }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -5,9 +5,9 @@ use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag, BlockWithTxHashes,
     FinalityStatus, Header, SealedBlockWithStatus,
 };
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::StateUpdatesWithClasses;
-use katana_primitives::trace::TxExecInfo;
 
 use super::transaction::{TransactionProvider, TransactionsProviderExt};
 use crate::ProviderResult;
@@ -148,6 +148,6 @@ pub trait BlockWriter: Send + Sync {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TxExecInfo>,
+        executions: Vec<TransactionExecutionInfo>,
     ) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/transaction.rs
+++ b/crates/storage/provider/src/traits/transaction.rs
@@ -1,8 +1,8 @@
 use std::ops::Range;
 
 use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockNumber, FinalityStatus};
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 
 use crate::ProviderResult;
@@ -56,19 +56,22 @@ pub trait TransactionStatusProvider: Send + Sync {
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait TransactionTraceProvider: Send + Sync {
     /// Returns a transaction execution given its hash.
-    fn transaction_execution(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>>;
+    fn transaction_execution(
+        &self,
+        hash: TxHash,
+    ) -> ProviderResult<Option<TransactionExecutionInfo>>;
 
     /// Returns all the transactions executions for a given block.
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TxExecInfo>>>;
+    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>>;
 
     /// Retrieves the execution traces for the given range of tx numbers.
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TxExecInfo>>;
+    ) -> ProviderResult<Vec<TransactionExecutionInfo>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]

--- a/crates/storage/provider/tests/utils.rs
+++ b/crates/storage/provider/tests/utils.rs
@@ -1,13 +1,13 @@
 use katana_primitives::block::{Block, BlockHash, FinalityStatus, Header, SealedBlockWithStatus};
+use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::fee::{PriceUnit, TxFeeInfo};
 use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
-use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxWithHash};
 use katana_primitives::Felt;
 
 pub fn generate_dummy_txs_and_receipts(
     count: usize,
-) -> (Vec<TxWithHash>, Vec<Receipt>, Vec<TxExecInfo>) {
+) -> (Vec<TxWithHash>, Vec<Receipt>, Vec<TransactionExecutionInfo>) {
     let mut txs = Vec::with_capacity(count);
     let mut receipts = Vec::with_capacity(count);
     let mut executions = Vec::with_capacity(count);
@@ -26,7 +26,7 @@ pub fn generate_dummy_txs_and_receipts(
             execution_resources: Default::default(),
             fee: TxFeeInfo { gas_consumed: 0, gas_price: 0, overall_fee: 0, unit: PriceUnit::Wei },
         }));
-        executions.push(TxExecInfo::default());
+        executions.push(TransactionExecutionInfo::default());
     }
 
     (txs, receipts, executions)
@@ -34,7 +34,7 @@ pub fn generate_dummy_txs_and_receipts(
 
 pub fn generate_dummy_blocks_and_receipts(
     count: u64,
-) -> Vec<(SealedBlockWithStatus, Vec<Receipt>, Vec<TxExecInfo>)> {
+) -> Vec<(SealedBlockWithStatus, Vec<Receipt>, Vec<TransactionExecutionInfo>)> {
     let mut blocks = Vec::with_capacity(count as usize);
     let mut parent_hash: BlockHash = 0u8.into();
 


### PR DESCRIPTION
This PR attempts to simplify and avoid redundant definitions of the transaction execution types by reusing types directly from `blockifier`.

The initial reason why we maintain a redundant copy of the transaction execution types instead of reusing types from `blockifer` is because, a long long time ago, we wanted to have support for both `starknet_in_rust` and `blockifier` [as pluggable execution engine for `katana`](https://github.com/dojoengine/dojo/pull/1564). But due to unforeseen circumstances (sad moment 😢), the support for `starknet_in_rust` in `katana` has long been [removed](https://github.com/dojoengine/dojo/pull/2200) partly because the `starknet_in_rust` project is no longer in development.

One potentially concerning issue about using `blockifier` types is it may be difficult slightly more difficult to avoid breaking the database format. Because when we bump the `blockifier` rev, it might include breaking changes to the transaction execution types that `katana` re-export. 

---

**_This change requires bumping the database version._**