### PR TITLE
feat: include gas usage in receipt resources

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,13 +9,13 @@ version.workspace = true
 [dependencies]
 katana-chain-spec.workspace = true
 katana-db.workspace = true
-katana-executor = { workspace = true, features = [ "blockifier" ] }
+katana-executor = { workspace = true }
+katana-metrics.workspace = true
 katana-pool.workspace = true
 katana-primitives = { workspace = true, features = [ "arbitrary" ] }
 katana-provider = { workspace = true, features = [ "fork", "in-memory" ] }
 katana-tasks.workspace = true
 katana-trie.workspace = true
-katana-metrics.workspace = true
 
 anyhow.workspace = true
 derive_more.workspace = true

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -10,18 +10,18 @@ version.workspace = true
 katana-primitives.workspace = true
 katana-provider.workspace = true
 
-blockifier = { workspace = true, features = [ "testing" ], optional = true }
+blockifier = { workspace = true, features = [ "testing" ] }
 quick_cache = "0.6.10"
-starknet = { workspace = true, optional = true }
+starknet.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
 # cairo-native
 cairo-native = { version = "0.4.1", optional = true }
-cairo-vm = { workspace = true, optional = true }
-parking_lot = { workspace = true, optional = true }
+cairo-vm.workspace = true
+parking_lot.workspace = true
 rayon = { workspace = true, optional = true }
-starknet_api = { workspace = true, optional = true }
+starknet_api.workspace = true
 
 [dev-dependencies]
 katana-chain-spec.workspace = true
@@ -43,23 +43,12 @@ pprof.workspace = true
 rayon.workspace = true
 
 [features]
-default = [ "blockifier" ]
-
-blockifier = [
-	"dep:blockifier",
-	"dep:cairo-vm",
-	"dep:parking_lot",
-	"dep:starknet",
-	"dep:starknet_api",
-]
 native = [ "blockifier/cairo_native", "dep:cairo-native", "dep:rayon" ]
 
 [[bench]]
 harness = false
 name = "execution"
-required-features = [ "blockifier" ]
 
 [[bench]]
 harness = false
 name = "concurrent"
-required-features = [ "blockifier" ]

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -287,7 +287,7 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
                         ExecutionResult::Success { receipt, trace } => {
                             self.stats.l1_gas_used += receipt.fee().gas_consumed;
                             self.stats.cairo_steps_used +=
-                                receipt.resources_used().vm_resources.n_steps as u128;
+                                receipt.resources_used().computation_resources.n_steps as u128;
 
                             if let Some(reason) = receipt.revert_reason() {
                                 info!(target: LOG_TARGET, hash = format!("{hash:#x}"), %reason, "Transaction reverted.");

--- a/crates/executor/src/implementation/mod.rs
+++ b/crates/executor/src/implementation/mod.rs
@@ -1,3 +1,2 @@
-#[cfg(feature = "blockifier")]
 pub mod blockifier;
 pub mod noop;

--- a/crates/executor/src/utils.rs
+++ b/crates/executor/src/utils.rs
@@ -1,10 +1,10 @@
-use katana_primitives::execution::TransactionResources;
+use blockifier::fee::receipt::TransactionReceipt;
+use katana_primitives::execution::{CallInfo, TransactionExecutionInfo, TransactionResources};
 use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::receipt::{
-    DeclareTxReceipt, DeployAccountTxReceipt, Event, InvokeTxReceipt, L1HandlerTxReceipt,
-    MessageToL1, Receipt,
+    self, DataAvailabilityResources, DeclareTxReceipt, DeployAccountTxReceipt, Event, GasUsed,
+    InvokeTxReceipt, L1HandlerTxReceipt, MessageToL1, Receipt,
 };
-use katana_primitives::trace::{CallInfo, TxExecInfo};
 use katana_primitives::transaction::TxRef;
 use tracing::trace;
 
@@ -26,11 +26,15 @@ pub fn log_resources(resources: &TransactionResources) {
     trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Transaction resource usage.");
 }
 
-pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) -> Receipt {
+pub(crate) fn build_receipt(
+    tx: TxRef<'_>,
+    fee: TxFeeInfo,
+    info: &TransactionExecutionInfo,
+) -> Receipt {
     let events = events_from_exec_info(info);
-    let revert_error = info.revert_error.clone();
     let messages_sent = l2_to_l1_messages_from_exec_info(info);
-    let actual_resources = info.actual_resources.clone();
+    let execution_resources = get_receipt_resources(&info.receipt);
+    let revert_error = info.revert_error.as_ref().map(|e| e.to_string());
 
     match tx {
         TxRef::Invoke(_) => Receipt::Invoke(InvokeTxReceipt {
@@ -38,7 +42,7 @@ pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) ->
             fee,
             revert_error,
             messages_sent,
-            execution_resources: actual_resources,
+            execution_resources,
         }),
 
         TxRef::Declare(_) => Receipt::Declare(DeclareTxReceipt {
@@ -46,7 +50,7 @@ pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) ->
             fee,
             revert_error,
             messages_sent,
-            execution_resources: actual_resources,
+            execution_resources,
         }),
 
         TxRef::L1Handler(tx) => Receipt::L1Handler(L1HandlerTxReceipt {
@@ -55,7 +59,7 @@ pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) ->
             revert_error,
             messages_sent,
             message_hash: tx.message_hash,
-            execution_resources: actual_resources,
+            execution_resources,
         }),
 
         TxRef::DeployAccount(tx) => Receipt::DeployAccount(DeployAccountTxReceipt {
@@ -63,13 +67,30 @@ pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) ->
             fee,
             revert_error,
             messages_sent,
-            execution_resources: actual_resources,
+            execution_resources,
             contract_address: tx.contract_address(),
         }),
     }
 }
 
-pub fn events_from_exec_info(info: &TxExecInfo) -> Vec<Event> {
+fn get_receipt_resources(receipt: &TransactionReceipt) -> receipt::ExecutionResources {
+    let computation_resources = receipt.resources.computation.vm_resources.clone();
+
+    let gas = GasUsed {
+        l2_gas: receipt.gas.l2_gas.0,
+        l1_gas: receipt.gas.l1_gas.0,
+        l1_data_gas: receipt.gas.l1_data_gas.0,
+    };
+
+    let da_resources = DataAvailabilityResources {
+        l1_gas: receipt.da_gas.l1_gas.0,
+        l1_data_gas: receipt.da_gas.l1_data_gas.0,
+    };
+
+    receipt::ExecutionResources { da_resources, computation_resources, gas }
+}
+
+fn events_from_exec_info(info: &TransactionExecutionInfo) -> Vec<Event> {
     let mut events: Vec<Event> = vec![];
 
     if let Some(ref call) = info.validate_call_info {
@@ -87,7 +108,7 @@ pub fn events_from_exec_info(info: &TxExecInfo) -> Vec<Event> {
     events
 }
 
-pub fn l2_to_l1_messages_from_exec_info(info: &TxExecInfo) -> Vec<MessageToL1> {
+fn l2_to_l1_messages_from_exec_info(info: &TransactionExecutionInfo) -> Vec<MessageToL1> {
     let mut messages = vec![];
 
     if let Some(ref info) = info.validate_call_info {
@@ -106,138 +127,31 @@ pub fn l2_to_l1_messages_from_exec_info(info: &TxExecInfo) -> Vec<MessageToL1> {
 }
 
 fn get_events_recur(info: &CallInfo) -> Vec<Event> {
-    let mut events: Vec<Event> = vec![];
+    let from_address = info.call.storage_address.into();
+    let mut events = Vec::new();
 
-    events.extend(info.events.iter().map(|e| Event {
-        from_address: info.contract_address,
-        data: e.data.clone(),
-        keys: e.keys.clone(),
+    events.extend(info.execution.events.iter().map(|e| {
+        let data = e.event.data.0.clone();
+        let keys = e.event.keys.iter().map(|k| k.0).collect();
+        Event { from_address, data, keys }
     }));
 
-    info.inner_calls.iter().for_each(|call| {
-        events.extend(get_events_recur(call));
-    });
+    info.inner_calls.iter().for_each(|call| events.extend(get_events_recur(call)));
 
     events
 }
 
 fn get_l2_to_l1_messages_recur(info: &CallInfo) -> Vec<MessageToL1> {
-    let mut messages = vec![];
+    let from_address = info.call.storage_address.into();
+    let mut messages = Vec::new();
 
-    messages.extend(info.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-        from_address: m.from_address,
-        to_address: m.to_address,
-        payload: m.payload.clone(),
+    messages.extend(info.execution.l2_to_l1_messages.iter().map(|m| {
+        let payload = m.message.payload.0.clone();
+        let to_address = m.message.to_address;
+        MessageToL1 { from_address, to_address, payload }
     }));
 
-    info.inner_calls.iter().for_each(|call| {
-        messages.extend(get_l2_to_l1_messages_recur(call));
-    });
+    info.inner_calls.iter().for_each(|call| messages.extend(get_l2_to_l1_messages_recur(call)));
 
     messages
-}
-
-#[cfg(test)]
-mod tests {
-    use katana_primitives::event::OrderedEvent;
-    use katana_primitives::message::OrderedL2ToL1Message;
-    use katana_primitives::receipt::{Event, MessageToL1};
-    use katana_primitives::trace::CallInfo;
-    use starknet::macros::felt;
-
-    fn call_info() -> CallInfo {
-        let inner_calls = vec![CallInfo {
-            contract_address: felt!("0x111").into(),
-            events: vec![
-                OrderedEvent { order: 1, data: vec![1u8.into()], keys: vec![10u8.into()] },
-                OrderedEvent { order: 4, data: vec![2u8.into()], keys: vec![20u8.into()] },
-            ],
-            l2_to_l1_messages: vec![OrderedL2ToL1Message {
-                order: 0,
-                from_address: felt!("0x111").into(),
-                to_address: felt!("0x200"),
-                payload: vec![1u8.into()],
-            }],
-            ..Default::default()
-        }];
-
-        CallInfo {
-            contract_address: felt!("0x100").into(),
-            events: vec![OrderedEvent { order: 0, data: vec![1u8.into()], keys: vec![2u8.into()] }],
-            l2_to_l1_messages: vec![
-                OrderedL2ToL1Message {
-                    order: 0,
-                    from_address: felt!("0x100").into(),
-                    to_address: felt!("0x200"),
-                    payload: vec![1u8.into()],
-                },
-                OrderedL2ToL1Message {
-                    order: 1,
-                    from_address: felt!("0x100").into(),
-                    to_address: felt!("0x201"),
-                    payload: vec![2u8.into()],
-                },
-            ],
-            inner_calls,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn get_events_from_exec_info() {
-        let info = call_info();
-        let events = super::get_events_recur(&info);
-
-        let expected_events = vec![
-            Event {
-                from_address: info.contract_address,
-                data: vec![1u8.into()],
-                keys: vec![2u8.into()],
-            },
-            Event {
-                from_address: info.inner_calls[0].contract_address,
-                data: vec![1u8.into()],
-                keys: vec![10u8.into()],
-            },
-            Event {
-                from_address: info.inner_calls[0].contract_address,
-                data: vec![2u8.into()],
-                keys: vec![20u8.into()],
-            },
-        ];
-
-        similar_asserts::assert_eq!(events, expected_events)
-    }
-
-    #[test]
-    fn get_l2_to_l1_messages_from_exec_info() {
-        let info = call_info();
-        let events = super::get_l2_to_l1_messages_recur(&info);
-
-        // TODO: Maybe remove `from_address` from `MessageToL1`?
-        //
-        // The from address is not constrained to be the same as the contract address
-        // of the call info beca use we already set it when converting TxExecInfo from its executor
-        // specific counterparts. Which is different compare to the events where it doesn't have
-        // from address field in `OrderedEvent`.
-        let expected_messages = vec![
-            MessageToL1 {
-                from_address: info.contract_address,
-                to_address: info.l2_to_l1_messages[0].to_address,
-                payload: info.l2_to_l1_messages[0].payload.clone(),
-            },
-            MessageToL1 {
-                from_address: info.contract_address,
-                to_address: info.l2_to_l1_messages[1].to_address,
-                payload: info.l2_to_l1_messages[1].payload.clone(),
-            },
-            MessageToL1 {
-                from_address: info.inner_calls[0].contract_address,
-                to_address: info.inner_calls[0].l2_to_l1_messages[0].to_address,
-                payload: info.inner_calls[0].l2_to_l1_messages[0].payload.clone(),
-            },
-        ];
-
-        similar_asserts::assert_eq!(events, expected_messages)
-    }
 }

--- a/crates/executor/tests/executor.rs
+++ b/crates/executor/tests/executor.rs
@@ -277,7 +277,7 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
                 actual_total_gas += fee.gas_consumed;
             }
             if let Some(rec) = res.receipt() {
-                actual_total_steps += rec.resources_used().vm_resources.n_steps as u128;
+                actual_total_steps += rec.resources_used().computation_resources.n_steps as u128;
             }
             tx.clone()
         })
@@ -324,19 +324,14 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
     );
 }
 
-#[cfg(feature = "blockifier")]
-mod blockifier {
-    use fixtures::blockifier::factory;
-    use katana_executor::implementation::blockifier::BlockifierFactory;
+use fixtures::factory;
+use katana_executor::implementation::blockifier::BlockifierFactory;
 
-    use super::*;
-
-    #[rstest::rstest]
-    fn test_executor_with_valid_blocks(
-        factory: BlockifierFactory,
-        #[from(state_provider)] state: Box<dyn StateProvider>,
-        #[from(valid_blocks)] blocks: [ExecutableBlock; 3],
-    ) {
-        test_executor_with_valid_blocks_impl(factory, state, blocks)
-    }
+#[rstest::rstest]
+fn test_executor_with_valid_blocks(
+    factory: BlockifierFactory,
+    #[from(state_provider)] state: Box<dyn StateProvider>,
+    #[from(valid_blocks)] blocks: [ExecutableBlock; 3],
+) {
+    test_executor_with_valid_blocks_impl(factory, state, blocks)
 }

--- a/crates/executor/tests/fixtures/mod.rs
+++ b/crates/executor/tests/fixtures/mod.rs
@@ -268,15 +268,10 @@ pub fn executor_factory<EF: ExecutorFactory>(
     factory
 }
 
-#[cfg(feature = "blockifier")]
-pub mod blockifier {
-    use katana_executor::implementation::blockifier::BlockifierFactory;
-    use katana_executor::{BlockLimits, ExecutionFlags};
+use katana_executor::implementation::blockifier::BlockifierFactory;
+use katana_executor::BlockLimits;
 
-    use super::{cfg, flags, CfgEnv};
-
-    #[rstest::fixture]
-    pub fn factory(cfg: CfgEnv, #[with(true)] flags: ExecutionFlags) -> BlockifierFactory {
-        BlockifierFactory::new(cfg, flags, BlockLimits::default())
-    }
+#[rstest::fixture]
+pub fn factory(cfg: CfgEnv, #[with(true)] flags: ExecutionFlags) -> BlockifierFactory {
+    BlockifierFactory::new(cfg, flags, BlockLimits::default())
 }

--- a/crates/executor/tests/simulate.rs
+++ b/crates/executor/tests/simulate.rs
@@ -77,21 +77,16 @@ fn test_simulate_tx_impl<EF: ExecutorFactory>(
     assert!(states.classes.is_empty(), "no new classes should be declared");
 }
 
-#[cfg(feature = "blockifier")]
-mod blockifier {
-    use fixtures::blockifier::factory;
-    use katana_executor::implementation::blockifier::BlockifierFactory;
+use fixtures::factory;
+use katana_executor::implementation::blockifier::BlockifierFactory;
 
-    use super::*;
-
-    #[apply(simulate_tx)]
-    fn test_simulate_tx(
-        #[with(factory::default())] executor_factory: BlockifierFactory,
-        block_env: BlockEnv,
-        state_provider: Box<dyn StateProvider>,
-        #[case] tx: ExecutableTxWithHash,
-        #[case] flags: ExecutionFlags,
-    ) {
-        test_simulate_tx_impl(executor_factory, block_env, state_provider, tx, flags);
-    }
+#[apply(simulate_tx)]
+fn test_simulate_tx(
+    #[with(factory::default())] executor_factory: BlockifierFactory,
+    block_env: BlockEnv,
+    state_provider: Box<dyn StateProvider>,
+    #[case] tx: ExecutableTxWithHash,
+    #[case] flags: ExecutionFlags,
+) {
+    test_simulate_tx_impl(executor_factory, block_env, state_provider, tx, flags);
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true }
 base64.workspace = true
-blockifier.workspace = true
+blockifier = { workspace = true, features = [ "testing" ] } # some Clone derives are gated behind 'testing' feature
 cainome-cairo-serde.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-vm.workspace = true
@@ -46,7 +46,11 @@ pprof.workspace = true
 [features]
 default = [ "serde" ]
 
-arbitrary = [ "alloy-primitives/arbitrary", "dep:arbitrary" ]
+arbitrary = [
+	"alloy-primitives/arbitrary",
+	"cairo-vm/test_utils",
+	"dep:arbitrary",
+]
 serde = [ "alloy-primitives/serde", "blockifier/transaction_serde" ]
 
 [[bench]]

--- a/crates/primitives/src/contract.rs
+++ b/crates/primitives/src/contract.rs
@@ -116,3 +116,15 @@ pub struct GenericContractInfo {
     /// The hash of the contract class.
     pub class_hash: ClassHash,
 }
+
+impl From<starknet_api::core::ContractAddress> for ContractAddress {
+    fn from(value: starknet_api::core::ContractAddress) -> Self {
+        Self(Felt::from(value))
+    }
+}
+
+impl From<ContractAddress> for starknet_api::core::ContractAddress {
+    fn from(value: ContractAddress) -> Self {
+        Self::try_from(value.0).expect("valid address")
+    }
+}

--- a/crates/primitives/src/execution.rs
+++ b/crates/primitives/src/execution.rs
@@ -1,3 +1,5 @@
+use std::collections::{hash_map, HashMap};
+
 pub use blockifier::execution::call_info::{CallInfo, ExecutionSummary};
 pub use blockifier::execution::entry_point::{CallEntryPoint, CallType};
 pub use blockifier::execution::stack_trace::ErrorStack;
@@ -8,7 +10,7 @@ pub use blockifier::fee::resources::{
 };
 pub use blockifier::transaction::objects::{RevertError, TransactionExecutionInfo};
 pub use cairo_vm::types::builtin_name::BuiltinName;
-pub use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+pub use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmResources;
 pub use starknet_api::contract_class::EntryPointType;
 pub use starknet_api::executable_transaction::TransactionType;
 pub use starknet_api::execution_resources::{GasAmount, GasVector};
@@ -38,5 +40,137 @@ impl TypedTransactionExecutionInfo {
 impl Default for TypedTransactionExecutionInfo {
     fn default() -> Self {
         Self::Invoke(TransactionExecutionInfo::default())
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[serde(transparent)]
+pub struct BuiltinCounters(HashMap<BuiltinName, usize>);
+
+impl BuiltinCounters {
+    /// Returns the number of instances of the `output` builtin, if any.
+    pub fn output(&self) -> Option<u64> {
+        self.builtin(BuiltinName::output)
+    }
+
+    /// Returns the number of instances of the `range_check` builtin, if any.
+    pub fn range_check(&self) -> Option<u64> {
+        self.builtin(BuiltinName::range_check)
+    }
+
+    /// Returns the number of instances of the `pedersen` builtin, if any.
+    pub fn pedersen(&self) -> Option<u64> {
+        self.builtin(BuiltinName::pedersen)
+    }
+
+    /// Returns the number of instances of the `ecdsa` builtin, if any.
+    pub fn ecdsa(&self) -> Option<u64> {
+        self.builtin(BuiltinName::ecdsa)
+    }
+
+    /// Returns the number of instances of the `keccak` builtin, if any.
+    pub fn keccak(&self) -> Option<u64> {
+        self.builtin(BuiltinName::keccak)
+    }
+
+    /// Returns the number of instances of the `bitwise` builtin, if any.
+    pub fn bitwise(&self) -> Option<u64> {
+        self.builtin(BuiltinName::bitwise)
+    }
+
+    /// Returns the number of instances of the `ec_op` builtin, if any.
+    pub fn ec_op(&self) -> Option<u64> {
+        self.builtin(BuiltinName::ec_op)
+    }
+
+    /// Returns the number of instances of the `poseidon` builtin, if any.
+    pub fn poseidon(&self) -> Option<u64> {
+        self.builtin(BuiltinName::poseidon)
+    }
+
+    /// Returns the number of instances of the `segment_arena` builtin, if any.
+    pub fn segment_arena(&self) -> Option<u64> {
+        self.builtin(BuiltinName::segment_arena)
+    }
+
+    /// Returns the number of instances of the `range_check96` builtin, if any.
+    pub fn range_check96(&self) -> Option<u64> {
+        self.builtin(BuiltinName::range_check96)
+    }
+
+    /// Returns the number of instances of the `add_mod` builtin, if any.
+    pub fn add_mod(&self) -> Option<u64> {
+        self.builtin(BuiltinName::add_mod)
+    }
+
+    /// Returns the number of instances of the `mul_mod` builtin, if any.
+    pub fn mul_mod(&self) -> Option<u64> {
+        self.builtin(BuiltinName::mul_mod)
+    }
+
+    fn builtin(&self, builtin: BuiltinName) -> Option<u64> {
+        self.0.get(&builtin).map(|&x| x as u64)
+    }
+}
+
+impl From<BuiltinCounters> for HashMap<BuiltinName, usize> {
+    fn from(value: BuiltinCounters) -> Self {
+        value.0
+    }
+}
+
+impl<T: Into<usize>> From<HashMap<BuiltinName, T>> for BuiltinCounters {
+    fn from(map: HashMap<BuiltinName, T>) -> Self {
+        // Filter out the builtins with 0 count.
+        BuiltinCounters(
+            map.into_iter()
+                .filter_map(|(builtin, count)| {
+                    let count = count.into();
+                    (count != 0).then_some((builtin, count))
+                })
+                .collect(),
+        )
+    }
+}
+
+impl IntoIterator for BuiltinCounters {
+    type Item = (BuiltinName, usize);
+    type IntoIter = hash_map::IntoIter<BuiltinName, usize>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a BuiltinCounters {
+    type Item = (&'a BuiltinName, &'a usize);
+    type IntoIter = hash_map::Iter<'a, BuiltinName, usize>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{BuiltinCounters, BuiltinName};
+
+    #[test]
+    fn test_builtin_counters_from_hashmap_removes_zero_entries() {
+        let mut map = HashMap::new();
+        map.insert(BuiltinName::output, 1usize);
+        map.insert(BuiltinName::range_check, 0);
+        map.insert(BuiltinName::pedersen, 2);
+        map.insert(BuiltinName::ecdsa, 0);
+
+        let counters = BuiltinCounters::from(map);
+
+        assert_eq!(counters.range_check(), None);
+        assert_eq!(counters.pedersen(), Some(2));
+        assert_eq!(counters.ecdsa(), None);
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -14,7 +14,6 @@ pub mod fee;
 pub mod genesis;
 pub mod message;
 pub mod receipt;
-pub mod trace;
 pub mod transaction;
 pub mod version;
 

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -20,27 +20,28 @@ katana-rpc-types-builder.workspace = true
 katana-tasks.workspace = true
 
 anyhow.workspace = true
-ark-ec = { version = "0.4.2", optional = true }
-cainome = { workspace = true, optional = true }
 futures.workspace = true
 http.workspace = true
 jsonrpsee = { workspace = true, features = [ "server" ] }
 metrics.workspace = true
-num-bigint = { workspace = true, optional = true }
-parking_lot.workspace = true
-reqwest = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
 serde_json.workspace = true
 starknet.workspace = true
-starknet-crypto.workspace = true
-# Use a specific revision of stark-vrf to avoid unwanted breaking changes.
-stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git", rev = "96d6d2a", optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 url.workspace = true
+
+ark-ec = { version = "0.4.2", optional = true }
+cainome = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
+parking_lot = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+starknet-crypto = { workspace = true, optional = true }
+# Use a specific revision of stark-vrf to avoid unwanted breaking changes.
+stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git", rev = "96d6d2a", optional = true }
 
 [dev-dependencies]
 katana-chain-spec.workspace = true
@@ -53,6 +54,7 @@ katana-utils.workspace = true
 alloy = { git = "https://github.com/alloy-rs/alloy", features = [ "contract", "network", "node-bindings", "provider-http", "providers", "signer-local" ] }
 alloy-primitives = { workspace = true, features = [ "serde" ] }
 assert_matches.workspace = true
+cainome.workspace = true
 cairo-lang-starknet-classes.workspace = true
 dojo-utils.workspace = true
 indexmap.workspace = true
@@ -71,6 +73,7 @@ cartridge = [
 	"dep:ark-ec",
 	"dep:cainome",
 	"dep:num-bigint",
+	"dep:parking_lot",
 	"dep:reqwest",
 	"dep:serde",
 	"dep:stark-vrf",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -77,5 +77,6 @@ cartridge = [
 	"dep:reqwest",
 	"dep:serde",
 	"dep:stark-vrf",
+	"dep:starknet-crypto",
 	"katana-rpc-api/cartridge",
 ]


### PR DESCRIPTION
Include transaction gas usage in the receipt to better resemble what's expected by the [RPC specs](https://github.com/starkware-libs/starknet-specs/blob/a2d10fc6cbaddbe2d3cf6ace5174dd0a306f4885/api/starknet_api_openrpc.json#L3611-L3630).

One consideration that I made when creating the new `ExecutionResources` type for the receipt, is to avoid doing multiple db tables lookup when building the receipt. If the gas usage isn't attached to the receipt, we'd need to get that from the `TransactionExecutionInfo` which would require doing a `TxTrace` table lookup. So, this basically saves us to only perform one table lookup per transaction.

Another, this PR also further promotes `blockifier` as a first-class citizen, integrating it deeply into `katana`. It is no longer feature-gated and has been integrated extensively as part of `primitives`. The goal of this is to simplify and remove technical debt in `katana`.

Ref: #93 

---

**_IMPORTANT: This change breaks database format_.**
