### PR TITLE
feat(primitives): typed tx trace

### DIFF
--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -12,7 +12,7 @@ use katana_primitives::block::{
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::env::BlockEnv;
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::{Event, Receipt, ReceiptWithTxHash};
 use katana_primitives::state::{compute_state_diff_hash, StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxWithHash};
@@ -93,10 +93,10 @@ impl<EF: ExecutorFactory> Backend<EF> {
 
         // only include successful transactions in the block
         for (tx, res) in execution_output.transactions {
-            if let ExecutionResult::Success { receipt, trace, .. } = res {
+            if let ExecutionResult::Success { receipt, trace } = res {
+                traces.push(TypedTransactionExecutionInfo::new(receipt.r#type(), trace));
                 receipts.push(ReceiptWithTxHash::new(tx.hash, receipt));
                 transactions.push(tx);
-                traces.push(trace);
             }
         }
 
@@ -142,7 +142,7 @@ impl<EF: ExecutorFactory> Backend<EF> {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        traces: Vec<TransactionExecutionInfo>,
+        traces: Vec<TypedTransactionExecutionInfo>,
     ) -> Result<(), BlockProductionError> {
         self.blockchain
             .provider()
@@ -256,10 +256,10 @@ impl<EF: ExecutorFactory> Backend<EF> {
 
         // only include successful transactions in the block
         for (tx, res) in output.transactions {
-            if let ExecutionResult::Success { receipt, trace, .. } = res {
+            if let ExecutionResult::Success { receipt, trace } = res {
+                traces.push(TypedTransactionExecutionInfo::new(receipt.r#type(), trace));
                 receipts.push(ReceiptWithTxHash::new(tx.hash, receipt));
                 transactions.push(tx);
-                traces.push(trace);
             }
         }
 

--- a/crates/primitives/src/execution.rs
+++ b/crates/primitives/src/execution.rs
@@ -16,6 +16,8 @@ pub use starknet_api::executable_transaction::TransactionType;
 pub use starknet_api::execution_resources::{GasAmount, GasVector};
 pub use starknet_api::transaction::fields::Fee;
 
+use crate::transaction::TxType;
+
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TypedTransactionExecutionInfo {
@@ -26,6 +28,17 @@ pub enum TypedTransactionExecutionInfo {
 }
 
 impl TypedTransactionExecutionInfo {
+    /// Constructs a new [`TypedTransactionExecutionInfo`].
+    pub fn new(r#type: TxType, execution_info: TransactionExecutionInfo) -> Self {
+        match r#type {
+            TxType::Declare => Self::Declare(execution_info),
+            TxType::Invoke => Self::Invoke(execution_info),
+            TxType::DeployAccount => Self::DeployAccount(execution_info),
+            TxType::L1Handler => Self::L1Handler(execution_info),
+            TxType::Deploy => unimplemented!("deploy tx is unsupported"),
+        }
+    }
+
     /// Returns the [`TransactionExecutionInfo`]
     pub fn info(&self) -> &TransactionExecutionInfo {
         match self {
@@ -34,6 +47,33 @@ impl TypedTransactionExecutionInfo {
             Self::L1Handler(info) => info,
             Self::DeployAccount(info) => info,
         }
+    }
+
+    /// Returns the transaction tyoe of the execution info.
+    pub fn r#type(&self) -> TxType {
+        match self {
+            Self::Invoke(_) => TxType::Invoke,
+            Self::Declare(_) => TxType::Declare,
+            Self::L1Handler(_) => TxType::L1Handler,
+            Self::DeployAccount(_) => TxType::DeployAccount,
+        }
+    }
+}
+
+impl From<TypedTransactionExecutionInfo> for TransactionExecutionInfo {
+    fn from(value: TypedTransactionExecutionInfo) -> Self {
+        match value {
+            TypedTransactionExecutionInfo::Invoke(info) => info,
+            TypedTransactionExecutionInfo::Declare(info) => info,
+            TypedTransactionExecutionInfo::L1Handler(info) => info,
+            TypedTransactionExecutionInfo::DeployAccount(info) => info,
+        }
+    }
+}
+
+impl From<(TxType, TransactionExecutionInfo)> for TypedTransactionExecutionInfo {
+    fn from(value: (TxType, TransactionExecutionInfo)) -> Self {
+        Self::new(value.0, value.1)
     }
 }
 

--- a/crates/rpc/rpc-types/src/trace.rs
+++ b/crates/rpc/rpc-types/src/trace.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use katana_primitives::execution::{
-    self, BuiltinName, CallInfo, GasVector, TransactionExecutionInfo,
+    self, BuiltinName, CallInfo, GasVector, TransactionExecutionInfo, TypedTransactionExecutionInfo,
 };
 use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::transaction::{TxHash, TxType};
@@ -25,7 +25,10 @@ pub struct TxExecutionInfo {
     pub trace: TransactionExecutionInfo,
 }
 
-pub fn to_rpc_trace(trace: TransactionExecutionInfo, tx_type: TxType) -> TransactionTrace {
+pub fn to_rpc_trace(trace: TypedTransactionExecutionInfo) -> TransactionTrace {
+    let tx_type = trace.r#type();
+    let trace: TransactionExecutionInfo = trace.into();
+
     let execution_resources = to_rpc_resources(trace.receipt);
     let fee_transfer_invocation = trace.fee_transfer_call_info.map(to_function_invocation);
     let validate_invocation = trace.validate_call_info.map(to_function_invocation);

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,6 +1,6 @@
 use katana_primitives::block::Header;
 use katana_primitives::contract::{ContractAddress, GenericContractInfo};
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::Tx;
 use katana_primitives::Felt;
@@ -34,7 +34,7 @@ macro_rules! impl_compress_and_decompress_for_table_values {
     }
 }
 
-impl Compress for TransactionExecutionInfo {
+impl Compress for TypedTransactionExecutionInfo {
     type Compressed = Vec<u8>;
     fn compress(self) -> Result<Self::Compressed, crate::error::CodecError> {
         let serialized = postcard::to_stdvec(&self).unwrap();
@@ -42,7 +42,7 @@ impl Compress for TransactionExecutionInfo {
     }
 }
 
-impl Decompress for TransactionExecutionInfo {
+impl Decompress for TypedTransactionExecutionInfo {
     fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, crate::error::CodecError> {
         let compressed = bytes.as_ref();
         let serialized =

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -1,7 +1,7 @@
 use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
 use katana_primitives::class::{ClassHash, CompiledClassHash, ContractClass};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::{Tx, TxHash, TxNumber};
 
@@ -212,7 +212,7 @@ tables! {
     /// Stores the block number of a transaction.
     TxBlocks: (TxNumber) => BlockNumber,
     /// Stores the transaction's traces.
-    TxTraces: (TxNumber) => TransactionExecutionInfo,
+    TxTraces: (TxNumber) => TypedTransactionExecutionInfo,
     /// Store transaction receipts
     Receipts: (TxNumber) => Receipt,
     /// Store compiled classes
@@ -359,7 +359,7 @@ mod tests {
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
     use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
-    use katana_primitives::execution::TransactionExecutionInfo;
+    use katana_primitives::execution::TypedTransactionExecutionInfo;
     use katana_primitives::fee::{PriceUnit, TxFeeInfo};
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
     use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
@@ -431,7 +431,7 @@ mod tests {
             (TxHash, felt!("0x123456789")),
             (Tx, Tx::Invoke(InvokeTx::V1(Default::default()))),
             (BlockNumber, 99),
-            (TransactionExecutionInfo, TransactionExecutionInfo::default()),
+            (TypedTransactionExecutionInfo, TypedTransactionExecutionInfo::default()),
             (CompiledClassHash, felt!("211")),
             (CompiledClass, CompiledClass::Legacy(Default::default())),
             (GenericContractInfo, GenericContractInfo::default()),

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -10,7 +10,7 @@ use katana_primitives::block::{
 use katana_primitives::class::{ClassHash, CompiledClassHash, ContractClass};
 use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
 use katana_primitives::env::BlockEnv;
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
@@ -141,7 +141,7 @@ where
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TransactionExecutionInfo>,
+        executions: Vec<TypedTransactionExecutionInfo>,
     ) -> ProviderResult<()> {
         self.provider.insert_block_with_states_and_receipts(block, states, receipts, executions)
     }
@@ -205,21 +205,21 @@ where
     fn transaction_execution(
         &self,
         hash: TxHash,
-    ) -> ProviderResult<Option<TransactionExecutionInfo>> {
+    ) -> ProviderResult<Option<TypedTransactionExecutionInfo>> {
         TransactionTraceProvider::transaction_execution(&self.provider, hash)
     }
 
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>> {
+    ) -> ProviderResult<Option<Vec<TypedTransactionExecutionInfo>>> {
         TransactionTraceProvider::transaction_executions_by_block(&self.provider, block_id)
     }
 
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionExecutionInfo>> {
+    ) -> ProviderResult<Vec<TypedTransactionExecutionInfo>> {
         TransactionTraceProvider::transaction_executions_in_range(&self.provider, range)
     }
 }

--- a/crates/storage/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/src/providers/db/mod.rs
@@ -27,7 +27,7 @@ use katana_primitives::contract::{
     ContractAddress, GenericContractInfo, Nonce, StorageKey, StorageValue,
 };
 use katana_primitives::env::BlockEnv;
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
@@ -561,7 +561,7 @@ impl<Db: Database> TransactionTraceProvider for DbProvider<Db> {
     fn transaction_execution(
         &self,
         hash: TxHash,
-    ) -> ProviderResult<Option<TransactionExecutionInfo>> {
+    ) -> ProviderResult<Option<TypedTransactionExecutionInfo>> {
         let db_tx = self.0.tx()?;
         if let Some(num) = db_tx.get::<tables::TxNumbers>(hash)? {
             let execution = db_tx
@@ -578,7 +578,7 @@ impl<Db: Database> TransactionTraceProvider for DbProvider<Db> {
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>> {
+    ) -> ProviderResult<Option<Vec<TypedTransactionExecutionInfo>>> {
         if let Some(index) = self.block_body_indices(block_id)? {
             let traces = self.transaction_executions_in_range(index.into())?;
             Ok(Some(traces))
@@ -590,7 +590,7 @@ impl<Db: Database> TransactionTraceProvider for DbProvider<Db> {
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionExecutionInfo>> {
+    ) -> ProviderResult<Vec<TypedTransactionExecutionInfo>> {
         let db_tx = self.0.tx()?;
 
         let total = range.end - range.start;
@@ -665,7 +665,7 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TransactionExecutionInfo>,
+        executions: Vec<TypedTransactionExecutionInfo>,
     ) -> ProviderResult<()> {
         self.0.update(move |db_tx| -> ProviderResult<()> {
             let block_hash = block.block.hash;
@@ -862,7 +862,7 @@ mod tests {
         Block, BlockHashOrNumber, FinalityStatus, Header, SealedBlockWithStatus,
     };
     use katana_primitives::contract::ContractAddress;
-    use katana_primitives::execution::TransactionExecutionInfo;
+    use katana_primitives::execution::TypedTransactionExecutionInfo;
     use katana_primitives::fee::{PriceUnit, TxFeeInfo};
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
     use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
@@ -962,7 +962,7 @@ mod tests {
                     unit: PriceUnit::Wei,
                 },
             })],
-            vec![TransactionExecutionInfo::default()],
+            vec![TypedTransactionExecutionInfo::default()],
         )
         .expect("failed to insert block");
 
@@ -1049,7 +1049,7 @@ mod tests {
                     unit: PriceUnit::Wei,
                 },
             })],
-            vec![TransactionExecutionInfo::default()],
+            vec![TypedTransactionExecutionInfo::default()],
         )
         .expect("failed to insert block");
 
@@ -1070,7 +1070,7 @@ mod tests {
                     unit: PriceUnit::Wei,
                 },
             })],
-            vec![TransactionExecutionInfo::default()],
+            vec![TypedTransactionExecutionInfo::default()],
         )
         .expect("failed to insert block");
 

--- a/crates/storage/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/src/providers/fork/mod.rs
@@ -13,7 +13,7 @@ use katana_primitives::block::{
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::env::BlockEnv;
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
@@ -202,21 +202,21 @@ impl<Db: Database> TransactionTraceProvider for ForkedProvider<Db> {
     fn transaction_execution(
         &self,
         hash: TxHash,
-    ) -> ProviderResult<Option<TransactionExecutionInfo>> {
+    ) -> ProviderResult<Option<TypedTransactionExecutionInfo>> {
         self.provider.transaction_execution(hash)
     }
 
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>> {
+    ) -> ProviderResult<Option<Vec<TypedTransactionExecutionInfo>>> {
         self.provider.transaction_executions_by_block(block_id)
     }
 
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionExecutionInfo>> {
+    ) -> ProviderResult<Vec<TypedTransactionExecutionInfo>> {
         self.provider.transaction_executions_in_range(range)
     }
 }
@@ -246,7 +246,7 @@ impl<Db: Database> BlockWriter for ForkedProvider<Db> {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TransactionExecutionInfo>,
+        executions: Vec<TypedTransactionExecutionInfo>,
     ) -> ProviderResult<()> {
         self.provider.insert_block_with_states_and_receipts(block, states, receipts, executions)
     }

--- a/crates/storage/provider/src/traits/block.rs
+++ b/crates/storage/provider/src/traits/block.rs
@@ -5,7 +5,7 @@ use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag, BlockWithTxHashes,
     FinalityStatus, Header, SealedBlockWithStatus,
 };
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::StateUpdatesWithClasses;
 
@@ -148,6 +148,6 @@ pub trait BlockWriter: Send + Sync {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithClasses,
         receipts: Vec<Receipt>,
-        executions: Vec<TransactionExecutionInfo>,
+        executions: Vec<TypedTransactionExecutionInfo>,
     ) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/src/traits/transaction.rs
+++ b/crates/storage/provider/src/traits/transaction.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockNumber, FinalityStatus};
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 
@@ -59,19 +59,19 @@ pub trait TransactionTraceProvider: Send + Sync {
     fn transaction_execution(
         &self,
         hash: TxHash,
-    ) -> ProviderResult<Option<TransactionExecutionInfo>>;
+    ) -> ProviderResult<Option<TypedTransactionExecutionInfo>>;
 
     /// Returns all the transactions executions for a given block.
     fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionExecutionInfo>>>;
+    ) -> ProviderResult<Option<Vec<TypedTransactionExecutionInfo>>>;
 
     /// Retrieves the execution traces for the given range of tx numbers.
     fn transaction_executions_in_range(
         &self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<Vec<TransactionExecutionInfo>>;
+    ) -> ProviderResult<Vec<TypedTransactionExecutionInfo>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]

--- a/crates/storage/provider/tests/utils.rs
+++ b/crates/storage/provider/tests/utils.rs
@@ -1,5 +1,5 @@
 use katana_primitives::block::{Block, BlockHash, FinalityStatus, Header, SealedBlockWithStatus};
-use katana_primitives::execution::TransactionExecutionInfo;
+use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::fee::{PriceUnit, TxFeeInfo};
 use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
 use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxWithHash};
@@ -7,7 +7,7 @@ use katana_primitives::Felt;
 
 pub fn generate_dummy_txs_and_receipts(
     count: usize,
-) -> (Vec<TxWithHash>, Vec<Receipt>, Vec<TransactionExecutionInfo>) {
+) -> (Vec<TxWithHash>, Vec<Receipt>, Vec<TypedTransactionExecutionInfo>) {
     let mut txs = Vec::with_capacity(count);
     let mut receipts = Vec::with_capacity(count);
     let mut executions = Vec::with_capacity(count);
@@ -26,7 +26,7 @@ pub fn generate_dummy_txs_and_receipts(
             execution_resources: Default::default(),
             fee: TxFeeInfo { gas_consumed: 0, gas_price: 0, overall_fee: 0, unit: PriceUnit::Wei },
         }));
-        executions.push(TransactionExecutionInfo::default());
+        executions.push(TypedTransactionExecutionInfo::default());
     }
 
     (txs, receipts, executions)
@@ -34,7 +34,7 @@ pub fn generate_dummy_txs_and_receipts(
 
 pub fn generate_dummy_blocks_and_receipts(
     count: u64,
-) -> Vec<(SealedBlockWithStatus, Vec<Receipt>, Vec<TransactionExecutionInfo>)> {
+) -> Vec<(SealedBlockWithStatus, Vec<Receipt>, Vec<TypedTransactionExecutionInfo>)> {
     let mut blocks = Vec::with_capacity(count as usize);
     let mut parent_hash: BlockHash = 0u8.into();
 


### PR DESCRIPTION
Simplify conversion and table lookup by embedding the transaction type into the execution info that we store in the db.

For example, this is what we do currently on a call to `starknet_transactionTrace`:

https://github.com/dojoengine/katana/blob/b45d91107aaf6e90e54e91ac50857457f2047861/crates/rpc/rpc/src/starknet/trace.rs#L186-L199

We perform two table lookups - (1) `Transactions` to extract the type information from, and (2) `TxTraces` to get the execution info itself. By including the transaction type directly into the return type of the call to `provider.transaction_execution()` we can remove the call to `provider.transaction_by_hash()` entirely.

