### PR TITLE
feat(runner): expose no_mining argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6601,6 +6601,7 @@ version = "1.5.2"
 dependencies = [
  "anyhow",
  "assert_fs",
+ "jsonrpsee",
  "katana-node-bindings",
  "katana-runner-macro",
  "starknet 0.12.0",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -13,3 +13,4 @@ anyhow.workspace = true
 assert_fs.workspace = true
 starknet.workspace = true
 tokio.workspace = true
+jsonrpsee = { workspace = true, features = [ "client" ] }

--- a/crates/runner/src/dev.rs
+++ b/crates/runner/src/dev.rs
@@ -1,0 +1,38 @@
+//! Katana Dev Client
+//!
+//! This simple clients exposes the Katana Dev API.
+//!
+//! This is a "duplicate" from the client that can be find
+//! under the `katana-rpc-api` crate. However, this client
+//! doesn't require to import `katana-rpc-api` which depends
+//! on `katana-primitives` which introduce a coupling to the
+//! cairo version that has to be used.
+//!
+//! In the same spirit that the Karana Runner is interacting
+//! with Katana from the CLI to avoid any coupling, this
+//! client is a simple client that doesn't depend on any
+//! other crate of Katana.
+
+use anyhow::Result;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::rpc_params;
+
+#[derive(Debug, Clone)]
+pub struct KatanaDevClient {
+    client: HttpClient,
+}
+
+impl KatanaDevClient {
+    pub fn new(url: &str) -> Result<Self> {
+        let client = HttpClientBuilder::default().build(url)?;
+
+        Ok(Self { client })
+    }
+
+    pub async fn generate_block(&self) -> Result<()> {
+        let _res = self.client.request("dev_generateBlock", rpc_params![]).await?;
+
+        Ok(())
+    }
+}

--- a/crates/runner/src/dev.rs
+++ b/crates/runner/src/dev.rs
@@ -31,8 +31,7 @@ impl KatanaDevClient {
     }
 
     pub async fn generate_block(&self) -> Result<()> {
-        let _res = self.client.request("dev_generateBlock", rpc_params![]).await?;
-
+        self.client.request::<(), _>("dev_generateBlock", rpc_params![]).await?;
         Ok(())
     }
 }

--- a/crates/runner/src/dev.rs
+++ b/crates/runner/src/dev.rs
@@ -2,13 +2,13 @@
 //!
 //! This simple clients exposes the Katana Dev API.
 //!
-//! This is a "duplicate" from the client that can be find
+//! This is a "duplicate" from the client that can be found
 //! under the `katana-rpc-api` crate. However, this client
 //! doesn't require to import `katana-rpc-api` which depends
 //! on `katana-primitives` which introduce a coupling to the
 //! cairo version that has to be used.
 //!
-//! In the same spirit that the Karana Runner is interacting
+//! In the same spirit that the Katana Runner is interacting
 //! with Katana from the CLI to avoid any coupling, this
 //! client is a simple client that doesn't depend on any
 //! other crate of Katana.

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -72,6 +72,8 @@ pub struct KatanaRunnerConfig {
     pub dev: bool,
     /// The chain id to use.
     pub chain_id: Option<Felt>,
+    /// Disable auto and interval mining, and mine on demand instead via an endpoint.
+    pub no_mining: bool,
 }
 
 impl Default for KatanaRunnerConfig {
@@ -88,6 +90,7 @@ impl Default for KatanaRunnerConfig {
             db_dir: None,
             dev: false,
             chain_id: None,
+            no_mining: false,
         }
     }
 }
@@ -144,6 +147,8 @@ impl KatanaRunner {
         if let Some(path) = config.db_dir {
             builder = builder.db_dir(path);
         }
+
+        builder = builder.no_mining(config.no_mining);
 
         builder = builder.dev(config.dev);
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -138,6 +138,10 @@ impl KatanaRunner {
         }
 
         if let Some(block_time_ms) = config.block_time {
+            if config.no_mining {
+                return Err(anyhow::anyhow!("no_mining and block_time cannot be used together"));
+            }
+
             builder = builder.block_time(block_time_ms);
         }
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -1,13 +1,14 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod dev;
 mod utils;
-
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::thread;
 
 use anyhow::{Context, Result};
 use assert_fs::TempDir;
+pub use dev::KatanaDevClient;
 use katana_node_bindings::{Katana, KatanaInstance};
 pub use katana_runner_macro::test;
 use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -198,6 +198,10 @@ impl KatanaRunner {
         self.instance.starknet_provider()
     }
 
+    pub fn dev_client(&self) -> KatanaDevClient {
+        KatanaDevClient::new(self.url().as_str()).expect("failed to get runner dev client")
+    }
+
     // A contract needs to be deployed only once for each instance
     // In proptest runner is static but deployment would happen for each test, unless it is
     // persisted here.


### PR DESCRIPTION
In order to complete the integration test suite in Torii, we need to have fine control on the katana block production.

Currently, the `KatanaRunner` doesn't expose this, which forces one to import `katana-node` and `katana-utils` for the `TestNode`. However the latter introduce a hard coupling on Cairo versions, which is conflicting Torii using Dojo.

This PR aims at ensuring the `no_mining` argument is available in the `KatanaRunner`, where the mining can still be controlled by the `--dev` flag using the `DevApi` to generate a block on demand.