### PR TITLE
refactor(executor): use global class cache always

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6189,6 +6189,7 @@ version = "1.5.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "assert_matches",
  "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "cairo-native",
  "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -339,6 +339,7 @@ impl<'c> GenesisTransactionsBuilder<'c> {
 mod tests {
 
     use alloy_primitives::U256;
+    use katana_executor::implementation::blockifier::cache::ClassCache;
     use katana_executor::implementation::blockifier::BlockifierFactory;
     use katana_executor::{BlockLimits, ExecutorFactory};
     use katana_primitives::chain::ChainId;
@@ -400,6 +401,7 @@ mod tests {
             },
             Default::default(),
             BlockLimits::default(),
+            ClassCache::new().unwrap(),
         )
     }
 

--- a/crates/core/tests/backend.rs
+++ b/crates/core/tests/backend.rs
@@ -4,6 +4,7 @@ use katana_chain_spec::{dev, ChainSpec, SettlementLayer};
 use katana_core::backend::gas_oracle::GasOracle;
 use katana_core::backend::storage::{Blockchain, Database};
 use katana_core::backend::Backend;
+use katana_executor::implementation::blockifier::cache::ClassCache;
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::BlockLimits;
 use katana_primitives::chain::ChainId;
@@ -27,6 +28,7 @@ fn executor(chain_spec: &ChainSpec) -> BlockifierFactory {
         },
         Default::default(),
         BlockLimits::default(),
+        ClassCache::new().unwrap(),
     )
 }
 

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -30,6 +30,7 @@ katana-rpc-types.workspace = true
 
 alloy-primitives.workspace = true
 anyhow.workspace = true
+assert_matches.workspace = true
 num-traits.workspace = true
 rstest.workspace = true
 rstest_reuse.workspace = true

--- a/crates/executor/benches/concurrent.rs
+++ b/crates/executor/benches/concurrent.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkGroup, Criterion};
+use katana_executor::implementation::blockifier::cache::ClassCache;
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::{BlockLimits, ExecutionFlags, ExecutorFactory};
 use katana_primitives::env::{BlockEnv, CfgEnv};
@@ -44,7 +45,12 @@ fn blockifier(
     (block_env, cfg_env): (BlockEnv, CfgEnv),
     tx: ExecutableTxWithHash,
 ) {
-    let factory = Arc::new(BlockifierFactory::new(cfg_env, flags.clone(), BlockLimits::default()));
+    let factory = Arc::new(BlockifierFactory::new(
+        cfg_env,
+        flags.clone(),
+        BlockLimits::default(),
+        ClassCache::new().unwrap(),
+    ));
 
     group.bench_function("Blockifier.1", |b| {
         b.iter_batched(

--- a/crates/executor/benches/execution.rs
+++ b/crates/executor/benches/execution.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use blockifier::state::cached_state::CachedState;
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkGroup, Criterion};
-use katana_executor::implementation::blockifier::cache::ClassCache;
 use katana_executor::implementation::blockifier::state::StateProviderDb;
 use katana_executor::ExecutionFlags;
 use katana_primitives::env::{BlockEnv, CfgEnv};
@@ -47,8 +46,7 @@ fn blockifier(
             || {
                 // setup state
                 let state = provider.latest().expect("failed to get latest state");
-                let class_cache = ClassCache::new().unwrap();
-                let state = CachedState::new(StateProviderDb::new(state, class_cache));
+                let state = CachedState::new(StateProviderDb::new(state));
 
                 (state, &block_context, execution_flags, tx.clone())
             },

--- a/crates/executor/src/implementation/blockifier/cache.rs
+++ b/crates/executor/src/implementation/blockifier/cache.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, OnceLock};
 
 use blockifier::execution::contract_class::{CompiledClassV1, RunnableCompiledClass};
 use katana_primitives::class::{ClassHash, CompiledClass, ContractClass};
@@ -8,11 +8,16 @@ use starknet_api::contract_class::SierraVersion;
 
 use super::utils::to_class;
 
-pub static COMPILED_CLASS_CACHE: LazyLock<ClassCache> =
-    LazyLock::new(|| ClassCache::builder().build().unwrap());
+static COMPILED_CLASS_CACHE: OnceLock<ClassCache> = OnceLock::new();
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("global class cache already initialized.")]
+    AlreadyInitialized,
+
+    #[error("global class cache not initialized.")]
+    NotInitialized,
+
     #[cfg(feature = "native")]
     #[error(transparent)]
     FailedToCreateThreadPool(#[from] rayon::ThreadPoolBuildError),
@@ -126,6 +131,20 @@ impl ClassCacheBuilder {
             }),
         })
     }
+
+    /// Builds a new `ClassCache` instance and sets it as the global cache.
+    ///
+    /// This builds and initializes a global `ClassCache` that can be accessed via
+    /// [`ClassCache::global`].
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the global cache has already been initialized.
+    pub fn build_global(self) -> Result<ClassCache, Error> {
+        let cache = self.build()?;
+        COMPILED_CLASS_CACHE.set(cache.clone()).map_err(|_| Error::AlreadyInitialized)?;
+        Ok(cache)
+    }
 }
 
 impl std::fmt::Debug for ClassCacheBuilder {
@@ -191,6 +210,23 @@ impl ClassCache {
     /// Returns a new [`ClassCacheBuilder`] for configuring a `ClassCache` instance.
     pub fn builder() -> ClassCacheBuilder {
         ClassCacheBuilder::new()
+    }
+
+    /// Returns a reference to the global cache instance.
+    ///
+    /// This method will return an error if the global cache has not been initialized via
+    /// [`ClassCache::initialize_global`] first.
+    pub fn try_global() -> Result<&'static ClassCache, Error> {
+        COMPILED_CLASS_CACHE.get().ok_or(Error::NotInitialized)
+    }
+
+    /// Returns a reference to the global cache instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the global cache has not been initialized.
+    pub fn global() -> &'static ClassCache {
+        Self::try_global().expect("global class cache not initialized")
     }
 
     pub fn get(&self, hash: &ClassHash) -> Option<RunnableCompiledClass> {

--- a/crates/executor/src/implementation/blockifier/cache.rs
+++ b/crates/executor/src/implementation/blockifier/cache.rs
@@ -215,7 +215,7 @@ impl ClassCache {
     /// Returns a reference to the global cache instance.
     ///
     /// This method will return an error if the global cache has not been initialized via
-    /// [`ClassCache::initialize_global`] first.
+    /// [`ClassCacheBuilder::build_global`] first.
     pub fn try_global() -> Result<&'static ClassCache, Error> {
         COMPILED_CLASS_CACHE.get().ok_or(Error::NotInitialized)
     }

--- a/crates/executor/src/implementation/blockifier/call.rs
+++ b/crates/executor/src/implementation/blockifier/call.rs
@@ -118,7 +118,6 @@ mod tests {
     use starknet::macros::selector;
 
     use super::execute_call_inner;
-    use crate::implementation::blockifier::cache::ClassCache;
     use crate::implementation::blockifier::state::StateProviderDb;
     use crate::EntryPointCall;
 
@@ -141,8 +140,7 @@ mod tests {
         provider.set_class_hash_of_contract(address, class_hash).unwrap();
 
         let state = provider.latest().unwrap();
-        let cache = ClassCache::new().expect("failed to create ClassCache");
-        let state = StateProviderDb::new(state, cache);
+        let state = StateProviderDb::new(state);
 
         // ---------------------------------------------------------------
 
@@ -218,8 +216,7 @@ mod tests {
         provider.set_class_hash_of_contract(address, class_hash).unwrap();
 
         let state = provider.latest().unwrap();
-        let cache = ClassCache::new().expect("failed to create ClassCache");
-        let state = StateProviderDb::new(state, cache);
+        let state = StateProviderDb::new(state);
 
         // ---------------------------------------------------------------
 

--- a/crates/executor/src/implementation/blockifier/state.rs
+++ b/crates/executor/src/implementation/blockifier/state.rs
@@ -32,8 +32,8 @@ pub(crate) struct CachedStateInner<'a> {
 }
 
 impl<'a> CachedState<'a> {
-    pub(super) fn new(state: impl StateProvider + 'a, compiled_class_cache: ClassCache) -> Self {
-        let state = StateProviderDb::new(Box::new(state), compiled_class_cache);
+    pub(super) fn new(state: impl StateProvider + 'a, class_cache: ClassCache) -> Self {
+        let state = StateProviderDb::new_with_class_cache(Box::new(state), class_cache);
         let cached_state = cached_state::CachedState::new(state);
 
         let declared_classes = HashMap::new();
@@ -152,8 +152,18 @@ impl<'a> Deref for StateProviderDb<'a> {
 }
 
 impl<'a> StateProviderDb<'a> {
-    pub fn new(provider: Box<dyn StateProvider + 'a>, compiled_class_cache: ClassCache) -> Self {
+    /// Creates a new [`StateProviderDb`].
+    pub fn new(provider: Box<dyn StateProvider + 'a>) -> Self {
+        let compiled_class_cache = ClassCache::new().expect("failed to build class cache");
         Self { provider, compiled_class_cache }
+    }
+
+    /// Creates a new [`StateProviderDb`] with a custom class cache.
+    pub fn new_with_class_cache(
+        provider: Box<dyn StateProvider + 'a>,
+        class_cache: ClassCache,
+    ) -> Self {
+        Self { provider, compiled_class_cache: class_cache }
     }
 }
 

--- a/crates/executor/tests/fixtures/mod.rs
+++ b/crates/executor/tests/fixtures/mod.rs
@@ -270,6 +270,7 @@ pub fn executor_factory<EF: ExecutorFactory>(
 
 #[cfg(feature = "blockifier")]
 pub mod blockifier {
+    use katana_executor::implementation::blockifier::cache::ClassCache;
     use katana_executor::implementation::blockifier::BlockifierFactory;
     use katana_executor::{BlockLimits, ExecutionFlags};
 
@@ -277,6 +278,6 @@ pub mod blockifier {
 
     #[rstest::fixture]
     pub fn factory(cfg: CfgEnv, #[with(true)] flags: ExecutionFlags) -> BlockifierFactory {
-        BlockifierFactory::new(cfg, flags, BlockLimits::default())
+        BlockifierFactory::new(cfg, flags, BlockLimits::default(), ClassCache::new().unwrap())
     }
 }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 katana-chain-spec.workspace = true
 katana-core.workspace = true
 katana-db.workspace = true
-katana-executor.workspace = true
+katana-executor = { workspace = true, features = [ "blockifier" ] }
 katana-explorer.workspace = true
 katana-messaging.workspace = true
 katana-metrics.workspace = true

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -25,6 +25,7 @@ use katana_core::constants::{
 use katana_core::env::BlockContextGenerator;
 use katana_core::service::block_producer::BlockProducer;
 use katana_db::mdbx::DbEnv;
+use katana_executor::implementation::blockifier::cache::ClassCache;
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::ExecutionFlags;
 use katana_metrics::exporters::prometheus::PrometheusRecorder;
@@ -106,17 +107,24 @@ impl Node {
             .with_fee(config.dev.fee);
 
         let executor_factory = {
-            let mut factory =
-                BlockifierFactory::new(cfg_env, execution_flags, config.sequencing.block_limits());
-
-            if let Some(max_call_gas) = config.rpc.max_call_gas {
-                factory.set_max_call_gas(max_call_gas);
-            }
+            #[allow(unused_mut)]
+            let mut class_cache = ClassCache::builder();
 
             #[cfg(feature = "native")]
             {
                 info!(enabled = config.execution.compile_native, "Cairo native compilation");
-                factory.cairo_native(config.execution.compile_native);
+                class_cache = class_cache.compile_native(config.execution.compile_native);
+            }
+
+            let mut factory = BlockifierFactory::new(
+                cfg_env,
+                execution_flags,
+                config.sequencing.block_limits(),
+                class_cache.build()?,
+            );
+
+            if let Some(max_call_gas) = config.rpc.max_call_gas {
+                factory.set_max_call_gas(max_call_gas);
             }
 
             Arc::new(factory)

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -116,11 +116,13 @@ impl Node {
                 class_cache = class_cache.compile_native(config.execution.compile_native);
             }
 
+            let global_class_cache = class_cache.build_global()?;
+
             let mut factory = BlockifierFactory::new(
                 cfg_env,
                 execution_flags,
                 config.sequencing.block_limits(),
-                class_cache.build()?,
+                global_class_cache,
             );
 
             if let Some(max_call_gas) = config.rpc.max_call_gas {

--- a/crates/pool/src/validation/stateful.rs
+++ b/crates/pool/src/validation/stateful.rs
@@ -10,7 +10,7 @@ use katana_executor::implementation::blockifier::blockifier::transaction::errors
     TransactionExecutionError, TransactionFeeError, TransactionPreValidationError,
 };
 use katana_executor::implementation::blockifier::blockifier::transaction::transaction_execution::Transaction;
-use katana_executor::implementation::blockifier::cache::COMPILED_CLASS_CACHE;
+use katana_executor::implementation::blockifier::cache::ClassCache;
 use katana_executor::implementation::blockifier::state::StateProviderDb;
 use katana_executor::implementation::blockifier::utils::{
     block_context_from_envs, to_address, to_executor_tx,
@@ -99,9 +99,12 @@ impl Inner {
     // for transaction validation.
     fn prepare(&self) -> StatefulValidator<StateProviderDb<'static>> {
         let state = Box::new(self.state.clone());
-        let cached_state =
-            CachedState::new(StateProviderDb::new(state, COMPILED_CLASS_CACHE.clone()));
+        let class_cache = ClassCache::global().clone();
+        let state_provider = StateProviderDb::new_with_class_cache(state, class_cache);
+
+        let cached_state = CachedState::new(state_provider);
         let context = block_context_from_envs(&self.block_env, &self.cfg_env);
+
         StatefulValidator::create(cached_state, context)
     }
 }


### PR DESCRIPTION
Includes a fix for a regression introduced in #69. This PR also refactors where the global class cache is being constructed - at the `katana-node` level instead of in the executor. The reason for the refactor, is to remove the responsibility of determining whether the class cache should compile with native or not, away from the executor and to the build process of the `Node`.