### PR TITLE
fix(cli): make public the config file path

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -73,7 +73,7 @@ pub struct NodeArgs {
 
     /// Configuration file
     #[arg(long)]
-    config: Option<PathBuf>,
+    pub config: Option<PathBuf>,
 
     /// Configure the messaging with an other chain.
     ///


### PR DESCRIPTION
It would be helpful to have this field public for slot CLI to rebuild a full `NodeArgs` just from a config file.

But I couldn't remember if there was a reason not having it public. If none, will unlock the new state update to have this field public. 🫡 