### PR TITLE
chore(cli): feature gate explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6353,7 +6353,6 @@ dependencies = [
  "katana-core",
  "katana-db",
  "katana-executor",
- "katana-explorer",
  "katana-feeder-gateway",
  "katana-messaging",
  "katana-metrics",

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -44,7 +44,7 @@ rstest.workspace = true
 starknet.workspace = true
 
 [features]
-default = [ "cartridge", "init-slot", "jemalloc" ]
+default = [ "cartridge", "init-slot", "jemalloc", "katana-cli/explorer" ]
 
 cartridge = [ "katana-cli/cartridge" ]
 init-custom-settlement-chain = [  ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,5 +39,6 @@ cartridge = [
 	"katana-rpc/cartridge",
 ]
 default = [ "cartridge", "server" ]
+explorer = [ "katana-node/explorer" ]
 native = [ "katana-node/native" ]
 server = [  ]

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -475,6 +475,7 @@ impl Default for CartridgeOptions {
     }
 }
 
+#[cfg(feature = "explorer")]
 #[derive(Debug, Default, Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Explorer options")]
 pub struct ExplorerOptions {
@@ -578,10 +579,12 @@ where
     }
 }
 
+#[cfg(feature = "cartridge")]
 fn default_paymaster() -> bool {
     false
 }
 
+#[cfg(feature = "cartridge")]
 fn default_api_url() -> Url {
     Url::parse("https://api.cartridge.gg").expect("qed; invalid url")
 }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -10,7 +10,6 @@ katana-chain-spec.workspace = true
 katana-core.workspace = true
 katana-db.workspace = true
 katana-executor = { workspace = true, features = [ "blockifier" ] }
-katana-explorer.workspace = true
 katana-messaging.workspace = true
 katana-metrics.workspace = true
 katana-pipeline.workspace = true
@@ -48,6 +47,7 @@ tracing-subscriber = { workspace = true, optional = true }
 
 [features]
 cartridge = [ "katana-rpc-api/cartridge", "katana-rpc/cartridge" ]
+explorer = [ "katana-rpc/explorer" ]
 native = [ "katana-executor/native" ]
 # experimental feature to test katana full node mode
 full-node = [ "dep:katana-feeder-gateway", "dep:tokio" ]

--- a/crates/node/src/config/rpc.rs
+++ b/crates/node/src/config/rpc.rs
@@ -41,6 +41,7 @@ pub enum RpcModuleKind {
 pub struct RpcConfig {
     pub addr: IpAddr,
     pub port: u16,
+    #[cfg(feature = "explorer")]
     pub explorer: bool,
     pub apis: RpcModulesList,
     pub cors_origins: Vec<HeaderValue>,
@@ -63,6 +64,7 @@ impl RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
+            #[cfg(feature = "explorer")]
             explorer: false,
             cors_origins: Vec::new(),
             addr: DEFAULT_RPC_ADDR,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -280,12 +280,12 @@ impl Node {
             rpc_modules.merge(DevApiServer::into_rpc(api))?;
         }
 
-        let mut rpc_server = RpcServer::new()
-            .metrics(true)
-            .health_check(true)
-            .explorer(config.rpc.explorer)
-            .cors(cors)
-            .module(rpc_modules)?;
+        #[allow(unused_mut)]
+        let mut rpc_server =
+            RpcServer::new().metrics(true).health_check(true).cors(cors).module(rpc_modules)?;
+
+        #[cfg(feature = "explorer")]
+        let mut rpc_server = rpc_server.explorer(config.rpc.explorer);
 
         if let Some(timeout) = config.rpc.timeout {
             rpc_server = rpc_server.timeout(timeout);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -280,12 +280,16 @@ impl Node {
             rpc_modules.merge(DevApiServer::into_rpc(api))?;
         }
 
+
         #[allow(unused_mut)]
         let mut rpc_server =
             RpcServer::new().metrics(true).health_check(true).cors(cors).module(rpc_modules)?;
 
         #[cfg(feature = "explorer")]
-        let mut rpc_server = rpc_server.explorer(config.rpc.explorer);
+        {
+            rpc_server = rpc_server.explorer(config.rpc.explorer);
+        }
+
 
         if let Some(timeout) = config.rpc.timeout {
             rpc_server = rpc_server.timeout(timeout);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -280,7 +280,6 @@ impl Node {
             rpc_modules.merge(DevApiServer::into_rpc(api))?;
         }
 
-
         #[allow(unused_mut)]
         let mut rpc_server =
             RpcServer::new().metrics(true).health_check(true).cors(cors).module(rpc_modules)?;
@@ -289,7 +288,6 @@ impl Node {
         {
             rpc_server = rpc_server.explorer(config.rpc.explorer);
         }
-
 
         if let Some(timeout) = config.rpc.timeout {
             rpc_server = rpc_server.timeout(timeout);

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 [dependencies]
 katana-core.workspace = true
 katana-executor.workspace = true
-katana-explorer = { workspace = true, features = [ "jsonrpsee" ] }
+katana-explorer = { workspace = true, features = [ "jsonrpsee" ], optional = true }
 katana-metrics.workspace = true
 katana-pool.workspace = true
 katana-primitives.workspace = true
@@ -70,3 +70,4 @@ cartridge = [
 	"dep:serde",
 	"katana-rpc-api/cartridge",
 ]
+explorer = [ "dep:katana-explorer" ]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 katana-chain-spec.workspace = true
 katana-core.workspace = true
 katana-executor.workspace = true
-katana-node.workspace = true
+katana-node = { workspace = true, features = [ "explorer" ] }
 katana-primitives.workspace = true
 katana-provider.workspace = true
 


### PR DESCRIPTION
To allow `slot` to use the `NodeArgs` struct without needing to pull in Explorer dependencies (i.e., `bun`)