### PR TITLE
fix(log): remove `LogTracer` initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ tokio-util = "0.7.12"
 toml = "0.8"
 tracing = { version = "0.1.38", features = [ "log" ], default-features = false }
 tracing-log = "0.1.3"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "json" ] }
+tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "json", "tracing-log" ] }
 url = { version = "2.4.0", features = [ "serde" ] }
 walkdir = "2.5.0"
 # TODO: see if we still need the git version

--- a/crates/log/src/lib.rs
+++ b/crates/log/src/lib.rs
@@ -81,7 +81,6 @@ pub async fn init(
             LogFormat::Json => tracing_subscriber::fmt::layer().json().boxed(),
         };
 
-        LogTracer::init()?;
         tracing_subscriber::registry().with(filter).with(fmt).init();
     }
 

--- a/crates/log/src/lib.rs
+++ b/crates/log/src/lib.rs
@@ -1,7 +1,6 @@
 use opentelemetry_gcloud_trace::errors::GcloudTraceError;
 use tracing::subscriber::SetGlobalDefaultError;
 use tracing_log::log::SetLoggerError;
-use tracing_log::LogTracer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{filter, EnvFilter, Layer};


### PR DESCRIPTION
It is already being initialized in the call to: https://github.com/dojoengine/katana/blob/130a9fbc6e9fe3b8c0b9ff88ba97a4967d8a70e1/crates/log/src/lib.rs#L84