### PR TITLE
feat(rpc): implement simplified `RpcLogger`

### DIFF
--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -24,6 +24,7 @@ pub mod health;
 pub mod metrics;
 pub mod starknet;
 
+mod logger;
 mod utils;
 use cors::Cors;
 use health::HealthCheck;
@@ -201,7 +202,8 @@ impl RpcServer {
         #[cfg(feature = "explorer")]
         let http_middleware = http_middleware.option_layer(explorer_layer);
 
-        let rpc_middleware = RpcServiceBuilder::new().option_layer(rpc_metrics).rpc_logger(0);
+        let rpc_middleware =
+            RpcServiceBuilder::new().option_layer(rpc_metrics).layer(logger::RpcLoggerLayer::new());
 
         let cfg = ServerConfig::builder()
             .max_connections(self.max_connections)

--- a/crates/rpc/rpc/src/logger.rs
+++ b/crates/rpc/rpc/src/logger.rs
@@ -1,0 +1,60 @@
+use std::future::Future;
+
+use jsonrpsee::core::middleware;
+use jsonrpsee::core::middleware::{Batch, Notification};
+use jsonrpsee::types::Request;
+
+/// RPC logger layer.
+#[derive(Copy, Clone, Debug)]
+pub struct RpcLoggerLayer;
+
+impl RpcLoggerLayer {
+    /// Create a new RPC logging layer.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> tower::Layer<S> for RpcLoggerLayer {
+    type Service = RpcLogger<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        RpcLogger { service }
+    }
+}
+
+/// A middleware that logs each RPC call.
+#[derive(Debug, Clone)]
+pub struct RpcLogger<S> {
+    service: S,
+}
+
+impl<S> middleware::RpcServiceT for RpcLogger<S>
+where
+    S: middleware::RpcServiceT + Send + Sync + Clone + 'static,
+{
+    type BatchResponse = S::BatchResponse;
+    type MethodResponse = S::MethodResponse;
+    type NotificationResponse = S::NotificationResponse;
+
+    #[inline]
+    #[tracing::instrument(target = "rpc", level = "trace", name = "rpc_call", skip_all, fields(method = req.method_name()))]
+    fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+        self.service.call(req)
+    }
+
+    #[inline]
+    #[tracing::instrument(target = "rpc", level = "trace", name = "rpc_batch", skip_all, fields(batch_size = batch.len()) )]
+    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        self.service.batch(batch)
+    }
+
+    #[inline]
+    #[tracing::instrument(target = "rpc", level = "trace", name = "rpc_notification", skip_all, fields(method = &*n.method))]
+    fn notification<'a>(
+        &self,
+        n: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        self.service.notification(n)
+    }
+}


### PR DESCRIPTION
A simplified version of `RpcLogger` implementation, provided by [`jsonrpsee`](https://docs.rs/jsonrpsee-core/0.25.1/jsonrpsee_core/middleware/layer/struct.RpcLogger.html), without the extra [stuff](https://docs.rs/jsonrpsee-core/0.25.1/src/jsonrpsee_core/middleware/layer/logger.rs.html#73) that we don't exactly need at this moment. 