### PR TITLE
feat(db): versioned types for backward compatibility

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -81,12 +81,21 @@ impl GasPrice {
         Self { eth, strk }
     }
 
+    /// Creates a zero gas price.
+    ///
+    /// # Safety
+    ///
+    /// This is primarily used for testing purposes.
+    pub const unsafe fn zero() -> Self {
+        Self::new_unchecked(0, 0)
+    }
+
     /// Creates a non-zero gas price without checking whether the value is non-zero.
     /// This may results in undefined behaviour if the value is zero.
     ///
     /// # Safety
     ///
-    /// The value must not be zero.
+    /// The caller must ensure that gas price is not zero.
     pub const unsafe fn new_unchecked(eth: u128, strk: u128) -> Self {
         Self { eth: NonZeroU128::new_unchecked(eth), strk: NonZeroU128::new_unchecked(strk) }
     }

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,4 +1,3 @@
-use katana_primitives::block::Header;
 use katana_primitives::contract::{ContractAddress, GenericContractInfo};
 use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
@@ -37,7 +36,6 @@ impl_compress_and_decompress_for_table_values!(
     u64,
     Tx,
     TxExecInfo,
-    Header,
     Receipt,
     Felt,
     TrieDatabaseValue,

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -19,7 +19,10 @@ pub mod version;
 
 use mdbx::{DbEnv, DbEnvKind};
 use utils::is_database_empty;
-use version::{check_db_version, create_db_version_file, DatabaseVersionError, CURRENT_DB_VERSION};
+use version::{
+    check_db_version, create_db_version_file, is_block_compatible_version, DatabaseVersionError,
+    CURRENT_DB_VERSION,
+};
 
 /// Initialize the database at the given path and returning a handle to the its
 /// environment.
@@ -36,6 +39,16 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> anyhow::Result<DbEnv> {
     } else {
         match check_db_version(&path) {
             Ok(_) => {}
+            Err(DatabaseVersionError::MismatchVersion { found, .. }) => {
+                if is_block_compatible_version(found) {
+                    println!("Using database version {} with block compatibility mode", found);
+                } else {
+                    return Err(anyhow!(DatabaseVersionError::MismatchVersion {
+                        expected: CURRENT_DB_VERSION,
+                        found
+                    }));
+                }
+            }
             Err(DatabaseVersionError::FileNotFound) => {
                 create_db_version_file(&path, CURRENT_DB_VERSION).with_context(|| {
                     format!(

--- a/crates/storage/db/src/mdbx/mod.rs
+++ b/crates/storage/db/src/mdbx/mod.rs
@@ -276,6 +276,7 @@ mod tests {
     use crate::codecs::Encode;
     use crate::mdbx::test_utils::create_test_db;
     use crate::models::storage::StorageEntry;
+    use crate::models::versioned;
     use crate::tables::{BlockHashes, ContractInfo, ContractStorage, Headers, Table};
 
     const ERROR_PUT: &str = "Not able to insert value into table.";
@@ -299,7 +300,8 @@ mod tests {
 
         // Insert some data to ensure non-zero stats
         let tx = env.tx_mut().expect(ERROR_INIT_TX);
-        tx.put::<Headers>(1u64, Header::default()).expect(ERROR_PUT);
+        tx.put::<Headers>(1u64, versioned::block::VersionedHeader::V7(Header::default()))
+            .expect(ERROR_PUT);
         tx.commit().expect(ERROR_COMMIT);
 
         // Retrieve stats
@@ -334,7 +336,8 @@ mod tests {
 
         // PUT
         let tx = env.tx_mut().expect(ERROR_INIT_TX);
-        tx.put::<Headers>(key, value.clone()).expect(ERROR_PUT);
+        tx.put::<Headers>(key, versioned::block::VersionedHeader::V7(value.clone()))
+            .expect(ERROR_PUT);
         tx.commit().expect(ERROR_COMMIT);
 
         // GET
@@ -344,7 +347,7 @@ mod tests {
         tx.commit().expect(ERROR_COMMIT);
 
         assert!(total_entries == 1);
-        assert!(result.expect(ERROR_RETURN_VALUE) == value);
+        assert!(result.expect(ERROR_RETURN_VALUE) == versioned::block::VersionedHeader::V7(value));
     }
 
     #[test]
@@ -356,7 +359,7 @@ mod tests {
 
         // PUT
         let tx = env.tx_mut().expect(ERROR_INIT_TX);
-        tx.put::<Headers>(key, value).expect(ERROR_PUT);
+        tx.put::<Headers>(key, versioned::block::VersionedHeader::V7(value)).expect(ERROR_PUT);
         tx.commit().expect(ERROR_COMMIT);
 
         let entries = env.tx().expect(ERROR_INIT_TX).entries::<Headers>().expect(ERROR_GET);
@@ -384,9 +387,12 @@ mod tests {
 
         // PUT
         let tx = env.tx_mut().expect(ERROR_INIT_TX);
-        tx.put::<Headers>(key1, header1.clone()).expect(ERROR_PUT);
-        tx.put::<Headers>(key2, header2.clone()).expect(ERROR_PUT);
-        tx.put::<Headers>(key3, header3.clone()).expect(ERROR_PUT);
+        tx.put::<Headers>(key1, versioned::block::VersionedHeader::V7(header1.clone()))
+            .expect(ERROR_PUT);
+        tx.put::<Headers>(key2, versioned::block::VersionedHeader::V7(header2.clone()))
+            .expect(ERROR_PUT);
+        tx.put::<Headers>(key3, versioned::block::VersionedHeader::V7(header3.clone()))
+            .expect(ERROR_PUT);
         tx.commit().expect(ERROR_COMMIT);
 
         // CURSOR
@@ -397,9 +403,9 @@ mod tests {
         let (_, result3) = cursor.next().expect(ERROR_GET_AT_CURSOR_POS).expect(ERROR_RETURN_VALUE);
         tx.commit().expect(ERROR_COMMIT);
 
-        assert!(result1 == header1);
-        assert!(result2 == header2);
-        assert!(result3 == header3);
+        assert!(result1 == versioned::block::VersionedHeader::V7(header1));
+        assert!(result2 == versioned::block::VersionedHeader::V7(header2));
+        assert!(result3 == versioned::block::VersionedHeader::V7(header3));
     }
 
     #[test]
@@ -446,7 +452,8 @@ mod tests {
 
         // PUT
         let tx = env.tx_mut().expect(ERROR_INIT_TX);
-        tx.put::<Headers>(key, value.clone()).expect(ERROR_PUT);
+        tx.put::<Headers>(key, versioned::block::VersionedHeader::V7(value.clone()))
+            .expect(ERROR_PUT);
         tx.commit().expect(ERROR_COMMIT);
 
         // Cursor
@@ -459,7 +466,11 @@ mod tests {
         // Walk
         let walk = cursor.walk(Some(key)).unwrap();
         let first = walk.into_iter().next().unwrap().unwrap();
-        assert_eq!(first.1, value, "First next should be put value");
+        assert_eq!(
+            first.1,
+            versioned::block::VersionedHeader::V7(value),
+            "First next should be put value"
+        );
     }
 
     #[test]

--- a/crates/storage/db/src/models/mod.rs
+++ b/crates/storage/db/src/models/mod.rs
@@ -5,3 +5,7 @@ pub mod list;
 pub mod stage;
 pub mod storage;
 pub mod trie;
+
+pub mod versioned;
+
+pub use versioned::block::VersionedHeader;

--- a/crates/storage/db/src/models/versioned/block/mod.rs
+++ b/crates/storage/db/src/models/versioned/block/mod.rs
@@ -1,0 +1,56 @@
+use katana_primitives::block::{self, Header};
+use serde::{Deserialize, Serialize};
+
+use crate::codecs::{Compress, Decompress};
+use crate::error::CodecError;
+
+mod v6;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum VersionedHeader {
+    V6(v6::Header),
+    V7(Header),
+}
+
+impl From<block::Header> for VersionedHeader {
+    fn from(header: block::Header) -> Self {
+        Self::V7(header)
+    }
+}
+
+impl From<VersionedHeader> for block::Header {
+    fn from(versioned: VersionedHeader) -> Self {
+        match versioned {
+            VersionedHeader::V7(header) => header,
+            VersionedHeader::V6(header) => header.into(),
+        }
+    }
+}
+
+impl Compress for VersionedHeader {
+    type Compressed = Vec<u8>;
+    fn compress(self) -> Self::Compressed {
+        postcard::to_stdvec(&self).expect("failed to serialized VersionedHeader")
+    }
+}
+
+impl Decompress for VersionedHeader {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+
+        if let Ok(header) = postcard::from_bytes::<Self>(bytes) {
+            return Ok(header);
+        }
+
+        // Try deserializing as V7 first, then fall back to V6
+        if let Ok(header) = postcard::from_bytes::<Header>(bytes) {
+            return Ok(VersionedHeader::V7(header));
+        }
+
+        if let Ok(header) = postcard::from_bytes::<v6::Header>(bytes) {
+            return Ok(VersionedHeader::V6(header));
+        }
+
+        Err(CodecError::Decompress("failed to deserialize header: unknown format".to_string()))
+    }
+}

--- a/crates/storage/db/src/models/versioned/block/v6.rs
+++ b/crates/storage/db/src/models/versioned/block/v6.rs
@@ -1,0 +1,51 @@
+use katana_primitives::block::{BlockHash, BlockNumber, GasPrice};
+use katana_primitives::contract::ContractAddress;
+use katana_primitives::da::L1DataAvailabilityMode;
+use katana_primitives::version::ProtocolVersion;
+use katana_primitives::Felt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Header {
+    pub parent_hash: BlockHash,
+    pub number: BlockNumber,
+    pub state_diff_commitment: Felt,
+    pub transactions_commitment: Felt,
+    pub receipts_commitment: Felt,
+    pub events_commitment: Felt,
+    pub state_root: Felt,
+    pub transaction_count: u32,
+    pub events_count: u32,
+    pub state_diff_length: u32,
+    pub timestamp: u64,
+    pub sequencer_address: ContractAddress,
+    pub l1_gas_prices: GasPrice,
+    pub l1_data_gas_prices: GasPrice,
+    pub l1_da_mode: L1DataAvailabilityMode,
+    pub protocol_version: ProtocolVersion,
+}
+
+impl From<Header> for katana_primitives::block::Header {
+    fn from(header: Header) -> Self {
+        katana_primitives::block::Header {
+            parent_hash: header.parent_hash,
+            number: header.number,
+            state_diff_commitment: header.state_diff_commitment,
+            transactions_commitment: header.transactions_commitment,
+            receipts_commitment: header.receipts_commitment,
+            events_commitment: header.events_commitment,
+            state_root: header.state_root,
+            transaction_count: header.transaction_count,
+            events_count: header.events_count,
+            state_diff_length: header.state_diff_length,
+            timestamp: header.timestamp,
+            sequencer_address: header.sequencer_address,
+            l1_gas_prices: header.l1_gas_prices,
+            l1_data_gas_prices: header.l1_data_gas_prices,
+            l1_da_mode: header.l1_da_mode,
+            protocol_version: header.protocol_version,
+            l2_gas_prices: GasPrice::MIN, /* this can't be zero for some reason, probably a check
+                                           * performed by blockifier */
+        }
+    }
+}

--- a/crates/storage/db/src/models/versioned/mod.rs
+++ b/crates/storage/db/src/models/versioned/mod.rs
@@ -1,0 +1,1 @@
+pub mod block;

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -1,4 +1,4 @@
-use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
+use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};
 use katana_primitives::class::{ClassHash, CompiledClassHash, ContractClass};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
 use katana_primitives::receipt::Receipt;
@@ -12,6 +12,7 @@ use crate::models::list::BlockList;
 use crate::models::stage::{StageCheckpoint, StageId};
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 use crate::models::trie::{TrieDatabaseKey, TrieDatabaseValue, TrieHistoryEntry};
+use crate::models::VersionedHeader;
 
 pub trait Key: Encode + Decode + Clone + std::fmt::Debug {}
 pub trait Value: Compress + Decompress + std::fmt::Debug {}
@@ -193,7 +194,7 @@ tables! {
     StageCheckpoints: (StageId) => StageCheckpoint,
 
     /// Store canonical block headers
-    Headers: (BlockNumber) => Header,
+    Headers: (BlockNumber) => VersionedHeader,
     /// Stores block hashes according to its block number
     BlockHashes: (BlockNumber) => BlockHash,
     /// Stores block numbers according to its block hash
@@ -375,6 +376,7 @@ mod tests {
     use crate::models::trie::{
         TrieDatabaseKey, TrieDatabaseKeyType, TrieDatabaseValue, TrieHistoryEntry,
     };
+    use crate::models::VersionedHeader;
 
     macro_rules! assert_key_encode_decode {
 	    { $( ($name:ty, $key:expr) ),* } => {
@@ -422,7 +424,7 @@ mod tests {
     #[test]
     fn test_value_compress_decompress() {
         assert_value_compress_decompress! {
-            (Header, Header::default()),
+            (VersionedHeader, VersionedHeader::V7(Header::default())),
             (BlockHash, BlockHash::default()),
             (BlockNumber, BlockNumber::default()),
             (FinalityStatus, FinalityStatus::AcceptedOnL1),

--- a/crates/storage/db/src/version.rs
+++ b/crates/storage/db/src/version.rs
@@ -58,6 +58,11 @@ pub(super) fn check_db_version(path: impl AsRef<Path>) -> Result<(), DatabaseVer
     }
 }
 
+/// Check if database version is compatible for block data access.
+pub(super) fn is_block_compatible_version(version: u32) -> bool {
+    (5..=CURRENT_DB_VERSION).contains(&version)
+}
+
 /// Get the version of the database at the given `path`.
 pub(super) fn get_db_version(path: impl AsRef<Path>) -> Result<u32, DatabaseVersionError> {
     let path = path.as_ref();

--- a/crates/storage/provider/src/providers/db/state.rs
+++ b/crates/storage/provider/src/providers/db/state.rs
@@ -405,6 +405,7 @@ where
 
     fn state_root(&self) -> ProviderResult<katana_primitives::Felt> {
         let header = self.tx.get::<tables::Headers>(self.block_number)?.expect("should exist");
+        let header: katana_primitives::block::Header = header.into();
         Ok(header.state_root)
     }
 }


### PR DESCRIPTION
There has been a mistake on the progression of the database version. For the latest stable release of Katana (v1.5.3), the database version is [6](https://github.com/dojoengine/katana/blob/8cca707d20a52b3d8d559193c77dc720ca3a4fbd/crates/storage/db/src/version.rs#L8) which hadn't changed since Katana [v1.0.10](https://github.com/dojoengine/dojo/blob/v1.0.10/crates/katana/storage/db/src/version.rs). If the rule for bumping the database version is followed correctly - bump the version if there are changes in the serialization for the database [types](https://github.com/dojoengine/katana/blob/8cca707d20a52b3d8d559193c77dc720ca3a4fbd/crates/storage/db/src/tables.rs#L191-L266) - the fact that the version remain unchanged since v1.0.10 would supposedly imply the database format remains compatible from v1.0.10 all the way to v1.5.3. Unfortunately, it is not the case for this (6) database version. 

The correct version for Katana v1.5.* should've been 7 following a change made to the `Header` struct - addition of the `l2_gas_prices` - by this [PR](https://github.com/dojoengine/katana/pull/19). But I've made a mistake of forgetting to perform a version bump following the change.

So, this PR doubles as a patch (for v1.5.*) to maintain backward compatibility across all versions of Katana with database version 6, and as the first part of implementing an actual database migration tool.



