### PR TITLE
feat(cli): inspect db version

### DIFF
--- a/crates/storage/db/src/version.rs
+++ b/crates/storage/db/src/version.rs
@@ -59,7 +59,7 @@ pub(super) fn check_db_version(path: impl AsRef<Path>) -> Result<(), DatabaseVer
 }
 
 /// Get the version of the database at the given `path`.
-pub(super) fn get_db_version(path: impl AsRef<Path>) -> Result<u32, DatabaseVersionError> {
+pub fn get_db_version(path: impl AsRef<Path>) -> Result<u32, DatabaseVersionError> {
     let path = path.as_ref();
     let path = if path.is_dir() { default_version_file_path(path) } else { path.to_path_buf() };
 


### PR DESCRIPTION
New `katana db` subcommand for inspecting the version of a Katana database. It will display both the current database version of the Katana binary and the version of the database at the given path.

Help message: 

```
λ katana db version -h
Shows database version information

Usage: katana db version [OPTIONS]

Options:
  -p, --path <PATH>  Path to the database directory
  -h, --help         Print help (see more with '--help')
```

```
λ katana db version -p path/to/db
current version: 7
database version: 6
```