### PR TITLE
bench: load test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,7 +4019,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "db-compat-test"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "katana-chain-spec",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "katana"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6241,7 +6241,7 @@ dependencies = [
 
 [[package]]
 name = "katana-chain-spec"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "katana-cli"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6293,7 +6293,7 @@ dependencies = [
 
 [[package]]
 name = "katana-codecs"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "bytes",
  "katana-primitives",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "katana-codecs-derive"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6311,7 +6311,7 @@ dependencies = [
 
 [[package]]
 name = "katana-core"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "katana-db"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "katana-executor"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6410,7 +6410,7 @@ dependencies = [
 
 [[package]]
 name = "katana-explorer"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "axum 0.6.20",
@@ -6434,7 +6434,7 @@ dependencies = [
 
 [[package]]
 name = "katana-feeder-gateway"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "katana-primitives",
  "katana-rpc-types",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "katana-fork"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -6469,7 +6469,7 @@ dependencies = [
 
 [[package]]
 name = "katana-gas-oracle"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-provider 0.4.2",
  "alloy-rpc-types-eth 0.4.2",
@@ -6490,7 +6490,7 @@ dependencies = [
 
 [[package]]
 name = "katana-grpc"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "tonic 0.11.0",
  "tonic-build",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "katana-log"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6523,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "katana-messaging"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-contract 0.4.2",
  "alloy-network 0.4.2",
@@ -6551,7 +6551,7 @@ dependencies = [
 
 [[package]]
 name = "katana-metrics"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "hyper 0.14.32",
  "jemalloc-ctl",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-node"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6611,7 +6611,7 @@ dependencies = [
 
 [[package]]
 name = "katana-node-bindings"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "criterion",
  "pprof",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "katana-pipeline"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -6642,7 +6642,7 @@ dependencies = [
 
 [[package]]
 name = "katana-pool"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "futures",
  "futures-util",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "katana-primitives"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "katana-provider"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc-api"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc-types"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc-types-builder"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "katana-executor",
@@ -6837,7 +6837,7 @@ dependencies = [
 
 [[package]]
 name = "katana-runner"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "katana-runner-macro"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "katana-slot-controller"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "account_sdk",
  "katana-primitives",
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "katana-stage"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6891,7 +6891,7 @@ dependencies = [
 
 [[package]]
 name = "katana-tasks"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "futures",
  "rayon",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "katana-trie"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6919,7 +6919,7 @@ dependencies = [
 
 [[package]]
 name = "katana-utils"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "katana-utils-macro"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "reverse-proxy-test"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "headless_chrome",
@@ -10410,7 +10410,7 @@ dependencies = [
 
 [[package]]
 name = "snos-integration-test"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie",
+ "idna 0.3.0",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,6 +3953,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
+dependencies = [
+ "nix 0.30.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4315,6 +4353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dummy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4658,6 +4702,18 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -5057,6 +5113,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "goose"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfeedc01d217935e1371901ea642ea6693d68893c67336d146eba23be04bf11"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ctrlc",
+ "downcast-rs",
+ "flume",
+ "futures",
+ "gumdrop",
+ "http 0.2.12",
+ "itertools 0.11.0",
+ "lazy_static",
+ "log",
+ "num-format",
+ "rand 0.8.5",
+ "regex",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "tokio",
+ "tokio-tungstenite",
+ "tungstenite 0.20.1",
+ "url",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,6 +5153,26 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "gumdrop"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5194,7 +5302,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.11",
- "tungstenite",
+ "tungstenite 0.26.2",
  "ureq 3.0.11",
  "url",
  "walkdir",
@@ -5451,6 +5559,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -5644,6 +5765,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -5887,6 +6018,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -7127,6 +7267,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "load-test"
+version = "1.6.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "goose",
+ "hex",
+ "katana-node-bindings",
+ "katana-primitives",
+ "katana-rpc-types",
+ "rand 0.8.5",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "starknet 0.15.1",
+ "starknet-crypto 0.7.4",
+ "starknet-types-core",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7499,6 +7664,15 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "native-tls"
@@ -8740,6 +8914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8757,6 +8937,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna 1.0.3",
+ "psl-types",
 ]
 
 [[package]]
@@ -9086,8 +9276,11 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
+ "async-compression",
  "base64 0.21.7",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -9096,10 +9289,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -9111,7 +9306,9 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -9140,7 +9337,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -10331,6 +10528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10467,6 +10675,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinoff"
@@ -11553,6 +11764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11828,6 +12048,18 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -12228,6 +12460,25 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
 	"crates/trie",
 	"crates/utils",
 	"tests/db-compat",
+	"tests/load-test",
 	"tests/reverse-proxy",
 	"tests/snos",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ edition = "2021"
 license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/dojoengine/katana/"
-version = "1.6.0-alpha.1"
+version = "1.6.0"
 
 [profile.performance]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 ## Table of Contents
 
 - [Development Setup](#development-setup)
+- [Cairo Native](#cairo-native)
 - [Testing](#testing)
 
 ## Development Setup
 
 ### Rust
 
-The project is built with Rust. You'll need to have Rust and Cargo installed first in order to start developing.
+The project is built with the Rust programming language. You'll need to have Rust and Cargo (the Rust package manager) installed first in order to start developing.
 Follow the installation steps here: https://www.rust-lang.org/tools/install
 
 ### LLVM Dependencies
@@ -42,7 +43,25 @@ Building the Explorer application will be handled automatically by Cargo, but it
 make build-explorer
 ```
 
+## Cairo Native
+
+Katana supports Cairo Native execution, which significantly improves the performance of Starknet contract execution by compiling Cairo contracts into optimized machine code.
+
+Cairo Native uses a multi-stage compilation process (Sierra → MLIR → LLVM → Native Executables) to generate fast, efficient binaries. This reduces the overhead of virtual machine emulation and allows Katana to process transactions at much higher speeds. Check out the [`cairo_native`](https://github.com/lambdaclass/cairo_native) repository to learn more.
+
+To build the Katana binary from source with Cairo Native support, make sure to enable the `native` Cargo feature:
+
+> _NOTE: Ensure you have configured the necessary [LLVM dependencies](#llvm-dependencies) before proceeding_.
+
+```bash
+cargo build --bin katana --features native
+```
+
+Cairo Native is disabled by default but can be enabled at runtime by specifying the `--enable-native-compilation` flag.
+
 ## Testing
+
+We recommend using `cargo nextest` for running the tests. Nextest is a next-generation test runner for Rust that provides better performance and user experience compared to `cargo test`. For more information on `cargo-nextest`, including installation instructions, please refer to the [official documentation](https://nexte.st/).
 
 ### Setting Up the Test Environment
 
@@ -55,5 +74,5 @@ make test-artifacts
 Once setup is complete, you can run the tests using:
 
 ```bash
-cargo test
+cargo nextest run
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [Development Setup](#development-setup)
 - [Cairo Native](#cairo-native)
+- [Explorer](#explorer)
 - [Testing](#testing)
 
 ## Development Setup
@@ -33,11 +34,12 @@ After installing LLVM, you need to make sure the required environment variables 
 source scripts/cairo-native.env.sh
 ```
 
-### Bun (for Explorer)
+### Bun
 
-When building the project, you may need to build the Explorer application. For that, you need to have [Bun](https://bun.sh/docs/installation) installed.
+When building the project, you may need to build the [Explorer](#explorer) web application.
+For that, you need to have [Bun](https://bun.sh/docs/installation) installed.
 
-Building the Explorer application will be handled automatically by Cargo, but it can also be built manually:
+The actual building flow will be handled automatically by Cargo, but it can also be built manually:
 
 ```bash
 make build-explorer
@@ -58,6 +60,18 @@ cargo build --bin katana --features native
 ```
 
 Cairo Native is disabled by default but can be enabled at runtime by specifying the `--enable-native-compilation` flag.
+
+## Explorer
+
+Katana includes a built-in, developer-focused, and stateless block explorer called **Explorer**. It is bundled with the Katana binary and can be enabled using the `--explorer` flag:
+
+```bash
+katana --explorer
+```
+
+Once enabled, the Explorer web application will be served at the `/explorer` path relative to the Katana RPC server endpoint. For example, if the RPC server is running at `http://localhost:5050`, the Explorer will be accessible at `http://localhost:5050/explorer`.
+
+This makes it easy for developers to inspect blocks, transactions, and other on-chain data in a lightweight, self-hosted interface. The Explorer is designed to be fast, minimal, and fully integrated into the Katana workflow without requiring additional setup. To learn more about the Explorer or contribute to its development, visit the [repository](https://github.com/cartridge-gg/explorer/).
 
 ## Testing
 

--- a/tests/load-test/Cargo.toml
+++ b/tests/load-test/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+edition.workspace = true
+license.workspace = true
+name = "load-test"
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+# Load testing framework
+goose = "0.17"
+
+# Async runtime
+tokio = { workspace = true, features = [ "full" ] }
+
+# HTTP client
+reqwest = { workspace = true, features = [ "json" ] }
+
+# Serialization
+serde = { workspace = true, features = [ "derive" ] }
+serde_json = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Utilities
+clap = { workspace = true, features = [ "derive" ] }
+futures = { workspace = true }
+hex = { workspace = true }
+rand = { workspace = true }
+
+# Starknet/Cairo dependencies
+starknet = { workspace = true }
+starknet-crypto = { workspace = true }
+starknet-types-core = { workspace = true }
+
+# Katana dependencies (for types and test utilities)
+katana-node-bindings = { workspace = true, optional = true }
+katana-primitives = { workspace = true }
+katana-rpc-types = { workspace = true }
+
+# Metrics and observability
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[features]
+default = [  ]
+embedded = [ "katana-node-bindings" ]
+
+[[bin]]
+name = "katana-load-test"
+path = "src/main.rs"

--- a/tests/load-test/README.md
+++ b/tests/load-test/README.md
@@ -1,0 +1,232 @@
+# Katana Load Testing Tool
+
+A comprehensive load testing tool for the Katana sequencer built with the Goose load testing framework.
+
+## Features
+
+- **Multiple Test Scenarios**: Constant load, ramp-up, burst testing, and custom scenarios
+- **Real Transaction Load**: Simulates actual StarkNet transactions (ERC20 transfers, account deployments)
+- **Comprehensive Metrics**: TPS, latency percentiles, success rates, and resource monitoring
+- **Configurable Parameters**: Users, duration, transaction types, and load patterns
+- **JSON Output**: Export results for analysis and reporting
+
+## Installation
+
+```bash
+# Add to workspace Cargo.toml
+cargo build -p katana-load-test
+```
+
+## Usage
+
+### Basic Examples
+
+```bash
+# Constant load test - 50 TPS for 2 minutes
+./target/debug/katana-load-test constant --tps 50 --duration 120 --users 25
+
+# Ramp-up test - 1 to 100 TPS over 5 minutes, hold for 2 minutes
+./target/debug/katana-load-test ramp-up --start-tps 1 --max-tps 100 --ramp-duration 300 --hold-duration 120
+
+# Burst test - baseline 20 TPS with 200 TPS bursts
+./target/debug/katana-load-test burst --baseline-tps 20 --burst-tps 200 --burst-duration 30 --total-duration 600
+
+# Custom scenario with specific parameters
+./target/debug/katana-load-test custom --users 100 --spawn-rate 5 --duration 300
+```
+
+### Configuration Options
+
+#### Global Options
+- `--rpc-url`: Katana RPC endpoint (default: http://localhost:5050)
+- `--private-key`: Private key for signing transactions (env: KATANA_PRIVATE_KEY)
+- `--account-address`: Account address (env: KATANA_ACCOUNT)
+- `--debug`: Enable debug logging
+- `--output`: JSON output file for results
+
+#### Test-Specific Options
+
+**Constant Load**
+- `--tps`: Target transactions per second
+- `--duration`: Test duration in seconds
+- `--users`: Number of concurrent users
+
+**Ramp-Up Load**
+- `--start-tps`: Starting TPS
+- `--max-tps`: Maximum TPS
+- `--ramp-duration`: Ramp-up duration
+- `--hold-duration`: Hold duration at max TPS
+
+**Burst Load**
+- `--baseline-tps`: Normal TPS
+- `--burst-tps`: Burst TPS
+- `--burst-duration`: Duration of each burst
+- `--total-duration`: Total test duration
+
+## Test Scenarios
+
+### 1. Constant Load
+Maintains steady transaction rate throughout the test duration.
+
+**Use Case**: Baseline performance measurement, capacity planning.
+
+### 2. Ramp-Up Load
+Gradually increases transaction rate from start to max, then holds.
+
+**Use Case**: Finding breaking points, stress testing.
+
+### 3. Burst Load
+Alternates between baseline and burst traffic patterns.
+
+**Use Case**: Testing resilience to traffic spikes, queue handling.
+
+### 4. Custom Scenario
+Flexible configuration for specific testing needs.
+
+**Use Case**: Reproducing specific load patterns, complex scenarios.
+
+## Transaction Types
+
+The tool simulates various StarkNet transaction types:
+
+- **ERC20 Transfers**: Token transfers between accounts
+- **Account Deployments**: New account creation
+- **Contract Calls**: General contract interactions
+
+Transaction parameters are randomized to simulate realistic load patterns.
+
+## Metrics and Reporting
+
+### Real-time Metrics
+- Transactions per second (TPS)
+- Response time percentiles (50th, 95th, 99th)
+- Success/failure rates
+- Error categorization
+
+### Output Example
+```
+=== Load Test Summary ===
+Total requests: 3000
+Total users: 50
+Success rate: 98.50%
+Average response time: 45.23ms
+95th percentile: 120.45ms
+99th percentile: 250.78ms
+Requests per second: 49.85
+```
+
+### JSON Export
+```json
+{
+  "total_requests": 3000,
+  "success_rate": 98.5,
+  "avg_response_time": 45.23,
+  "p95_response_time": 120.45,
+  "p99_response_time": 250.78,
+  "requests_per_second": 49.85,
+  "errors": {
+    "timeout": 15,
+    "invalid_nonce": 30
+  }
+}
+```
+
+## Performance Considerations
+
+### Optimal Configuration
+- **Users**: Start with 2-5x target TPS, adjust based on latency
+- **Spawn Rate**: Gradual ramp-up (2-10 users/second) for stable results
+- **Duration**: Minimum 60 seconds for reliable metrics
+
+### Resource Requirements
+- **CPU**: ~0.1 core per 100 TPS
+- **Memory**: ~50MB base + 1MB per 100 concurrent users
+- **Network**: ~10KB per transaction
+
+### Katana Configuration
+For optimal load testing performance:
+
+```toml
+# Recommended Katana settings
+[sequencing]
+block_time = 1000  # 1 second blocks
+max_transactions_per_block = 1000
+
+[rpc]
+max_connections = 1000
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Connection Refused**
+```bash
+# Ensure Katana is running
+katana --host 0.0.0.0 --port 5050
+```
+
+**Nonce Errors**
+- Use separate accounts for high-concurrency tests
+- Enable nonce management in scenarios
+
+**Low TPS**
+- Increase user count
+- Reduce transaction complexity
+- Check Katana block time settings
+
+### Debug Mode
+```bash
+./target/debug/katana-load-test --debug constant --tps 10 --duration 30
+```
+
+## Advanced Usage
+
+### Environment Variables
+```bash
+export KATANA_PRIVATE_KEY="0x1800000000300000180000000000030000000000003006001800006600"
+export KATANA_ACCOUNT="0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"
+```
+
+### CI/CD Integration
+```bash
+# Automated performance regression testing
+./target/debug/katana-load-test constant --tps 100 --duration 60 --output results.json
+python analyze_results.py results.json
+```
+
+### Distributed Testing
+For higher load, run multiple instances:
+```bash
+# Terminal 1
+./target/debug/katana-load-test constant --tps 50 --duration 300
+
+# Terminal 2
+./target/debug/katana-load-test constant --tps 50 --duration 300
+```
+
+## Development
+
+### Adding New Transaction Types
+1. Extend `TransactionType` enum in `transactions.rs`
+2. Implement transaction building logic
+3. Add to scenario weight distribution
+
+### Custom Scenarios
+Implement new scenarios in `scenarios.rs` following the Goose pattern:
+```rust
+pub async fn custom_scenario(user: &mut GooseUser) -> TransactionResult {
+    // Your custom logic here
+}
+```
+
+## Contributing
+
+1. Add new features with comprehensive tests
+2. Update documentation for new scenarios
+3. Ensure backward compatibility
+4. Follow Katana coding standards
+
+## License
+
+Apache License 2.0 - see LICENSE file for details.

--- a/tests/load-test/examples/basic_usage.md
+++ b/tests/load-test/examples/basic_usage.md
@@ -1,0 +1,223 @@
+# Katana Load Testing - Basic Usage Examples
+
+## Quick Start
+
+```bash
+# Build the load testing tool
+cargo build -p katana-load-test
+
+# Start Katana in another terminal
+katana --host 0.0.0.0 --port 5050
+```
+
+## Viewing Results & Metrics
+
+### 1. Real-time Console Output
+By default, Goose displays live metrics in the terminal:
+
+```bash
+# Basic load test with live console metrics
+./target/debug/katana-load-test constant --tps 20 --duration 60 --users 10
+```
+
+**Sample Output:**
+```
+=== PER TRANSACTION METRICS ===
+Name                     |   # times run |        # fails |  trans/s |  fail/s
+send_transaction         |           489 |         2 (0%) |     8.15 |    0.03
+check_tx_status          |           156 |         0 (0%) |     2.60 |    0.00
+
+Name                     |    Avg (ms) |        Min |         Max |     Median
+send_transaction         |      245.3  |         89 |       1,234 |        210
+check_tx_status          |       45.2  |         12 |         156 |         38
+```
+
+### 2. HTML Reports with Interactive Charts
+Generate comprehensive HTML reports with graphs and detailed breakdowns:
+
+```bash
+# Generate HTML report
+./target/debug/katana-load-test constant \
+  --tps 50 --duration 120 --users 25 \
+  --html-report katana_performance_report.html
+
+# Open the report in your browser
+open katana_performance_report.html
+```
+
+**HTML Report Features:**
+- Interactive response time charts
+- Transaction distribution graphs
+- Error rate visualization
+- Percentile breakdowns
+- Timeline of load test execution
+
+### 3. Real-time Dashboard & Control
+Enable real-time monitoring and control via WebSocket:
+
+```bash
+# Start with dashboard enabled
+./target/debug/katana-load-test constant \
+  --tps 30 --duration 300 --users 15 \
+  --dashboard
+
+# Dashboard available at: ws://localhost:5117
+# Telnet control available at: telnet localhost 5116
+```
+
+**Dashboard Features:**
+- Live TPS monitoring
+- Real-time error rates
+- Response time graphs
+- Start/stop/pause controls
+
+### 4. Manual Control Mode
+Start the load test without auto-starting, control via telnet/WebSocket:
+
+```bash
+# Start in manual mode
+./target/debug/katana-load-test constant \
+  --tps 100 --duration 600 --users 50 \
+  --no-autostart --dashboard
+
+# Control via telnet
+telnet localhost 5116
+> start
+> stop
+> config
+> metrics
+```
+
+### 5. JSON Export for Analysis
+Export raw metrics data for custom analysis:
+
+```bash
+# Export to JSON file
+./target/debug/katana-load-test ramp-up \
+  --start-tps 1 --max-tps 200 --ramp-duration 300 \
+  --output katana_metrics.json \
+  --html-report katana_report.html
+
+# Analyze with custom tools
+python analyze_katana_performance.py katana_metrics.json
+```
+
+## Sample Test Scenarios
+
+### Finding Maximum TPS
+```bash
+# Ramp up to find breaking point
+./target/debug/katana-load-test ramp-up \
+  --start-tps 1 --max-tps 500 \
+  --ramp-duration 600 --hold-duration 120 \
+  --html-report max_tps_test.html
+```
+
+### Stress Testing with Bursts
+```bash
+# Test resilience to traffic spikes
+./target/debug/katana-load-test burst \
+  --baseline-tps 50 --burst-tps 300 \
+  --burst-duration 30 --total-duration 600 \
+  --dashboard --html-report burst_test.html
+```
+
+### Sustained Load Testing
+```bash
+# Long-running constant load
+./target/debug/katana-load-test constant \
+  --tps 100 --duration 3600 --users 50 \
+  --html-report sustained_load.html \
+  --output sustained_metrics.json
+```
+
+### Monitoring During Test
+
+**Terminal 1: Load Test**
+```bash
+./target/debug/katana-load-test constant --tps 75 --duration 300 --dashboard
+```
+
+**Terminal 2: Real-time Telnet Control**
+```bash
+telnet localhost 5116
+> metrics    # View current metrics
+> config     # Show configuration
+> pause      # Pause the test
+> resume     # Resume the test
+```
+
+**Browser: WebSocket Dashboard**
+```
+Open: ws://localhost:5117 in a WebSocket client
+Real-time charts and controls available
+```
+
+## Interpreting Results
+
+### Key Metrics to Monitor
+- **TPS (Transactions Per Second)**: Actual throughput achieved
+- **Response Time Percentiles**: 50th, 95th, 99th percentiles
+- **Error Rate**: Failed transactions percentage
+- **Success Rate**: Successful transactions percentage
+
+### Sample Analysis
+```
+=== Load Test Summary ===
+Total requests: 4,523
+Success rate: 98.2%
+Average response time: 156.7ms
+95th percentile: 445ms
+99th percentile: 1.2s
+Requests per second: 75.4
+
+# Analysis:
+# - Achieved 75.4 TPS vs target 75 TPS ✓
+# - 98.2% success rate is excellent ✓
+# - 95th percentile under 500ms is good ✓
+# - 99th percentile over 1s indicates some slow transactions ⚠️
+```
+
+### Performance Tuning
+
+**If TPS is too low:**
+- Increase user count
+- Reduce wait times between requests
+- Check Katana block time settings
+
+**If error rate is high:**
+- Reduce load intensity
+- Check nonce management
+- Verify transaction validity
+
+**If latency is high:**
+- Monitor Katana resource usage
+- Check network connectivity
+- Reduce transaction complexity
+
+## Integration with CI/CD
+
+```bash
+#!/bin/bash
+# performance_test.sh
+
+# Start Katana
+katana --host 0.0.0.0 --port 5050 &
+KATANA_PID=$!
+
+# Wait for startup
+sleep 5
+
+# Run performance test
+./target/debug/katana-load-test constant \
+  --tps 50 --duration 120 --users 25 \
+  --output ci_metrics.json
+
+# Analyze results
+python validate_performance.py ci_metrics.json
+
+# Cleanup
+kill $KATANA_PID
+```
+
+This comprehensive monitoring and reporting setup provides deep insights into Katana's performance characteristics under various load conditions.

--- a/tests/load-test/src/client.rs
+++ b/tests/load-test/src/client.rs
@@ -1,0 +1,206 @@
+use anyhow::{anyhow, Result};
+use reqwest::Client;
+use serde_json::{json, Value};
+use starknet::core::types::{BlockId, BlockTag, Felt};
+use starknet_crypto::{sign, PrivateKey, PublicKey};
+use std::sync::Arc;
+use tracing::{debug, info};
+
+pub struct StarknetClient {
+    client: Client,
+    rpc_url: String,
+}
+
+#[derive(Clone)]
+pub struct Account {
+    pub address: Felt,
+    pub private_key: PrivateKey,
+    pub public_key: PublicKey,
+}
+
+impl StarknetClient {
+    pub fn new(rpc_url: &str) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+
+        Ok(Self {
+            client,
+            rpc_url: rpc_url.to_string(),
+        })
+    }
+
+    pub async fn validate_connection(&self) -> Result<()> {
+        let response = self.chain_id().await?;
+        info!("Connected to Katana - Chain ID: {:#x}", response);
+        Ok(())
+    }
+
+    pub async fn chain_id(&self) -> Result<Felt> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_chainId",
+            "params": [],
+            "id": 1
+        });
+
+        let response = self.send_rpc_request(body).await?;
+        let chain_id_hex = response["result"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Invalid chain_id response"))?;
+
+        Ok(Felt::from_hex(chain_id_hex)?)
+    }
+
+    pub async fn get_block_number(&self) -> Result<u64> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_blockNumber",
+            "params": [],
+            "id": 1
+        });
+
+        let response = self.send_rpc_request(body).await?;
+        let block_number = response["result"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("Invalid block_number response"))?;
+
+        Ok(block_number)
+    }
+
+    pub async fn get_nonce(&self, address: Felt) -> Result<Felt> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getNonce",
+            "params": [
+                {"block_id": "pending"},
+                format!("{:#x}", address)
+            ],
+            "id": 1
+        });
+
+        let response = self.send_rpc_request(body).await?;
+        let nonce_hex = response["result"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Invalid nonce response"))?;
+
+        Ok(Felt::from_hex(nonce_hex)?)
+    }
+
+    pub async fn add_invoke_transaction(&self, transaction: Value) -> Result<Felt> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_addInvokeTransaction",
+            "params": [transaction],
+            "id": 1
+        });
+
+        let response = self.send_rpc_request(body).await?;
+        
+        if let Some(error) = response.get("error") {
+            return Err(anyhow!("Transaction failed: {}", error));
+        }
+
+        let tx_hash = response["result"]["transaction_hash"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Invalid transaction response"))?;
+
+        Ok(Felt::from_hex(tx_hash)?)
+    }
+
+    pub async fn get_transaction_status(&self, tx_hash: Felt) -> Result<String> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getTransactionStatus",
+            "params": [format!("{:#x}", tx_hash)],
+            "id": 1
+        });
+
+        let response = self.send_rpc_request(body).await?;
+        
+        if let Some(error) = response.get("error") {
+            return Err(anyhow!("Failed to get transaction status: {}", error));
+        }
+
+        let status = response["result"]["execution_status"]
+            .as_str()
+            .unwrap_or("UNKNOWN")
+            .to_string();
+
+        Ok(status)
+    }
+
+    pub async fn get_transaction_receipt(&self, tx_hash: Felt) -> Result<Value> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getTransactionReceipt",
+            "params": [format!("{:#x}", tx_hash)],
+            "id": 1
+        });
+
+        let response = self.send_rpc_request(body).await?;
+        
+        if let Some(error) = response.get("error") {
+            return Err(anyhow!("Failed to get transaction receipt: {}", error));
+        }
+
+        Ok(response["result"].clone())
+    }
+
+    async fn send_rpc_request(&self, body: Value) -> Result<Value> {
+        debug!("Sending RPC request: {}", body);
+        
+        let response = self
+            .client
+            .post(&self.rpc_url)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("HTTP error: {}", response.status()));
+        }
+
+        let json_response: Value = response.json().await?;
+        debug!("RPC response: {}", json_response);
+
+        Ok(json_response)
+    }
+}
+
+impl Account {
+    pub fn new(private_key_hex: &str, address_hex: &str) -> Result<Self> {
+        let private_key = PrivateKey::from_hex(private_key_hex)?;
+        let public_key = PublicKey::from_private_key(&private_key);
+        let address = Felt::from_hex(address_hex)?;
+
+        Ok(Self {
+            address,
+            private_key,
+            public_key,
+        })
+    }
+
+    pub fn default_test_account() -> Self {
+        // Default Katana test account
+        let private_key = PrivateKey::from_hex(
+            "0x1800000000300000180000000000030000000000003006001800006600"
+        ).unwrap();
+        let public_key = PublicKey::from_private_key(&private_key);
+        let address = Felt::from_hex(
+            "0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"
+        ).unwrap();
+
+        Self {
+            address,
+            private_key,
+            public_key,
+        }
+    }
+
+    pub fn sign_transaction_hash(&self, tx_hash: Felt) -> Result<(Felt, Felt)> {
+        let signature = sign(&self.private_key, &tx_hash)?;
+        Ok((signature.r, signature.s))
+    }
+}

--- a/tests/load-test/src/main.rs
+++ b/tests/load-test/src/main.rs
@@ -1,0 +1,290 @@
+use anyhow::Result;
+use clap::{Args, Parser, Subcommand};
+use goose::prelude::*;
+use std::time::Duration;
+use tracing::{info, warn};
+
+mod client;
+mod scenarios;
+mod transactions;
+mod utils;
+
+use client::StarknetClient;
+use scenarios::{burst_load, constant_load, ramp_up_load};
+
+#[derive(Parser)]
+#[command(name = "katana-load-test")]
+#[command(about = "Load testing tool for Katana sequencer")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+
+    #[command(flatten)]
+    pub global: GlobalArgs,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Run constant load test
+    Constant(ConstantLoadArgs),
+    /// Run ramp-up load test
+    RampUp(RampUpArgs),
+    /// Run burst load test
+    Burst(BurstArgs),
+    /// Run custom scenario
+    Custom(CustomArgs),
+}
+
+#[derive(Args)]
+pub struct GlobalArgs {
+    /// Katana RPC URL
+    #[arg(long, default_value = "http://localhost:5050")]
+    pub rpc_url: String,
+
+    /// Private key for transaction signing (hex)
+    #[arg(long, env = "KATANA_PRIVATE_KEY")]
+    pub private_key: Option<String>,
+
+    /// Account address (hex)
+    #[arg(long, env = "KATANA_ACCOUNT")]
+    pub account_address: Option<String>,
+
+    /// Enable debug logging
+    #[arg(long)]
+    pub debug: bool,
+
+    /// Output file for metrics (JSON)
+    #[arg(long)]
+    pub output: Option<String>,
+
+    /// Generate HTML report
+    #[arg(long)]
+    pub html_report: Option<String>,
+
+    /// Enable real-time dashboard (WebSocket on port 5117)
+    #[arg(long)]
+    pub dashboard: bool,
+
+    /// Disable auto-start (wait for controller command)
+    #[arg(long)]
+    pub no_autostart: bool,
+}
+
+#[derive(Args)]
+pub struct ConstantLoadArgs {
+    /// Transactions per second
+    #[arg(long, default_value = "10")]
+    pub tps: u64,
+
+    /// Test duration in seconds
+    #[arg(long, default_value = "60")]
+    pub duration: u64,
+
+    /// Number of concurrent users
+    #[arg(long, default_value = "10")]
+    pub users: usize,
+}
+
+#[derive(Args)]
+pub struct RampUpArgs {
+    /// Starting TPS
+    #[arg(long, default_value = "1")]
+    pub start_tps: u64,
+
+    /// Maximum TPS
+    #[arg(long, default_value = "100")]
+    pub max_tps: u64,
+
+    /// Ramp-up duration in seconds
+    #[arg(long, default_value = "300")]
+    pub ramp_duration: u64,
+
+    /// Hold duration at max TPS
+    #[arg(long, default_value = "60")]
+    pub hold_duration: u64,
+}
+
+#[derive(Args)]
+pub struct BurstArgs {
+    /// Normal TPS (baseline)
+    #[arg(long, default_value = "10")]
+    pub baseline_tps: u64,
+
+    /// Burst TPS
+    #[arg(long, default_value = "100")]
+    pub burst_tps: u64,
+
+    /// Burst duration in seconds
+    #[arg(long, default_value = "30")]
+    pub burst_duration: u64,
+
+    /// Total test duration in seconds
+    #[arg(long, default_value = "300")]
+    pub total_duration: u64,
+}
+
+#[derive(Args)]
+pub struct CustomArgs {
+    /// Number of users
+    #[arg(long, default_value = "50")]
+    pub users: usize,
+
+    /// Spawn rate (users per second)
+    #[arg(long, default_value = "2")]
+    pub spawn_rate: f64,
+
+    /// Test duration in seconds
+    #[arg(long, default_value = "300")]
+    pub duration: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Initialize tracing
+    let level = if cli.global.debug {
+        tracing::Level::DEBUG
+    } else {
+        tracing::Level::INFO
+    };
+
+    tracing_subscriber::fmt()
+        .with_max_level(level)
+        .with_target(false)
+        .init();
+
+    info!("Starting Katana load test");
+    info!("RPC URL: {}", cli.global.rpc_url);
+
+    // Validate connection to Katana
+    let client = StarknetClient::new(&cli.global.rpc_url)?;
+    client.validate_connection().await?;
+
+    // Build base Goose attack with enhanced metrics
+    let mut base_attack = GooseAttack::initialize()?;
+
+    // Configure enhanced reporting and monitoring
+    if let Some(html_file) = &cli.global.html_report {
+        base_attack = base_attack.set_default(GooseDefault::ReportFile, html_file.as_str())?;
+    }
+
+    if cli.global.no_autostart {
+        base_attack = base_attack.set_default(GooseDefault::NoAutoStart, true)?;
+        info!("Load test ready - use telnet (port 5116) or WebSocket (port 5117) to control");
+    }
+
+    if cli.global.dashboard {
+        info!("Real-time dashboard available at: ws://localhost:5117");
+    }
+
+    // Add detailed metrics configuration
+    base_attack = base_attack
+        .set_default(GooseDefault::NoMetrics, false)?
+        .set_default(GooseDefault::StatusCodes, true)?;
+
+    // Build specific attack based on command
+    let attack = match cli.command {
+        Commands::Constant(args) => {
+            info!(
+                "Running constant load test: {} TPS for {} seconds with {} users",
+                args.tps, args.duration, args.users
+            );
+            
+            constant_load(
+                base_attack,
+                cli.global,
+                args.users,
+                Duration::from_secs(args.duration),
+                args.tps,
+            ).await?
+        }
+        Commands::RampUp(args) => {
+            info!(
+                "Running ramp-up test: {} -> {} TPS over {} seconds, hold for {} seconds",
+                args.start_tps, args.max_tps, args.ramp_duration, args.hold_duration
+            );
+            
+            ramp_up_load(base_attack, cli.global, args).await?
+        }
+        Commands::Burst(args) => {
+            info!(
+                "Running burst test: {} TPS baseline with {} TPS bursts for {} seconds",
+                args.baseline_tps, args.burst_tps, args.burst_duration
+            );
+            
+            burst_load(base_attack, cli.global, args).await?
+        }
+        Commands::Custom(args) => {
+            info!(
+                "Running custom test: {} users, spawn rate {}/s for {} seconds",
+                args.users, args.spawn_rate, args.duration
+            );
+            
+            base_attack
+                .register_scenario(
+                    scenario!("KatanaLoadTest")
+                        .register_transaction(
+                            transaction!(scenarios::send_transaction)
+                                .set_name("send_erc20_transfer")
+                                .set_weight(10)?
+                        )
+                        .register_transaction(
+                            transaction!(scenarios::check_transaction_status)
+                                .set_name("check_tx_status")
+                                .set_weight(2)?
+                        )
+                )
+                .set_default(
+                    GooseDefault::Host,
+                    cli.global.rpc_url.as_str(),
+                )?
+                .set_default(GooseDefault::Users, args.users)?
+                .set_default(GooseDefault::HatchRate, args.spawn_rate)?
+                .set_default(GooseDefault::RunTime, args.duration)?
+        }
+    };
+
+    // Execute the load test
+    let goose_metrics = attack.execute().await?;
+
+    // Print summary
+    print_summary(&goose_metrics);
+
+    // Save results if output file specified
+    if let Some(output_file) = cli.global.output {
+        save_results(&goose_metrics, &output_file)?;
+    }
+
+    Ok(())
+}
+
+fn print_summary(metrics: &GooseMetrics) {
+    info!("=== Load Test Summary ===");
+    info!("Total requests: {}", metrics.requests.len());
+    info!("Total users: {}", metrics.users);
+    
+    if let Some(final_metrics) = metrics.requests.get("Aggregated") {
+        info!("Success rate: {:.2}%", 
+            (final_metrics.success_count as f64 / final_metrics.raw_data.counter as f64) * 100.0
+        );
+        info!("Average response time: {:.2}ms", final_metrics.raw_data.mean);
+        info!("95th percentile: {:.2}ms", final_metrics.raw_data.percentile_95);
+        info!("99th percentile: {:.2}ms", final_metrics.raw_data.percentile_99);
+        info!("Requests per second: {:.2}", final_metrics.requests_per_second);
+    }
+
+    if !metrics.errors.is_empty() {
+        warn!("Errors encountered:");
+        for (error, count) in &metrics.errors {
+            warn!("  {}: {} occurrences", error, count);
+        }
+    }
+}
+
+fn save_results(metrics: &GooseMetrics, output_file: &str) -> Result<()> {
+    let json = serde_json::to_string_pretty(metrics)?;
+    std::fs::write(output_file, json)?;
+    info!("Results saved to: {}", output_file);
+    Ok(())
+}

--- a/tests/load-test/src/scenarios.rs
+++ b/tests/load-test/src/scenarios.rs
@@ -1,0 +1,290 @@
+use anyhow::Result;
+use goose::prelude::*;
+use rand::Rng;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use crate::client::{Account, StarknetClient};
+use crate::transactions::TransactionType;
+use crate::{BurstArgs, GlobalArgs, RampUpArgs};
+
+/// Global state shared across Goose users
+#[derive(Clone)]
+pub struct UserState {
+    pub client: StarknetClient,
+    pub account: Account,
+    pub nonce: Arc<Mutex<starknet::core::types::Felt>>,
+}
+
+impl UserState {
+    pub async fn new(global_args: &GlobalArgs) -> Result<Self> {
+        let client = StarknetClient::new(&global_args.rpc_url)?;
+        
+        let account = if let (Some(private_key), Some(address)) = 
+            (&global_args.private_key, &global_args.account_address) {
+            Account::new(private_key, address)?
+        } else {
+            Account::default_test_account()
+        };
+
+        // Get current nonce
+        let current_nonce = client.get_nonce(account.address).await?;
+        let nonce = Arc::new(Mutex::new(current_nonce));
+
+        Ok(Self {
+            client,
+            account,
+            nonce,
+        })
+    }
+
+    pub async fn get_and_increment_nonce(&self) -> starknet::core::types::Felt {
+        let mut nonce = self.nonce.lock().await;
+        let current = *nonce;
+        *nonce = current + starknet::core::types::Felt::ONE;
+        current
+    }
+}
+
+/// Main transaction sending scenario
+pub async fn send_transaction(user: &mut GooseUser) -> TransactionResult {
+    let state = user.get_session_data::<UserState>()
+        .ok_or_else(|| GooseError::from("No user state found"))?;
+
+    let tx_type = TransactionType::random();
+    let nonce = state.get_and_increment_nonce().await;
+
+    debug!("Sending transaction: {:?} with nonce: {:#x}", tx_type, nonce);
+
+    let transaction = tx_type.build_transaction(&state.account, nonce)
+        .map_err(|e| GooseError::from(format!("Failed to build transaction: {}", e)))?;
+
+    let start_time = std::time::Instant::now();
+    
+    match state.client.add_invoke_transaction(transaction).await {
+        Ok(tx_hash) => {
+            let elapsed = start_time.elapsed();
+            debug!("Transaction submitted: {:#x} in {:?}", tx_hash, elapsed);
+            
+            // Store tx_hash in user session for status checking
+            user.set_session_data(tx_hash);
+            
+            user.set_success(&TransactionRequest {
+                elapsed: elapsed.as_millis() as u64,
+                final_url: state.client.rpc_url.clone(),
+                name: format!("send_{:?}", tx_type).to_lowercase(),
+                redirected: false,
+                response_time: elapsed.as_millis() as u64,
+                status_code: 200,
+                success: true,
+                update: false,
+                user: user.weighted_users_index,
+                ..Default::default()
+            })
+        }
+        Err(e) => {
+            let elapsed = start_time.elapsed();
+            warn!("Transaction failed: {}", e);
+            
+            user.set_failure(&format!("Transaction failed: {}", e), &mut TransactionRequest {
+                elapsed: elapsed.as_millis() as u64,
+                final_url: state.client.rpc_url.clone(),
+                name: format!("send_{:?}", tx_type).to_lowercase(),
+                redirected: false,
+                response_time: elapsed.as_millis() as u64,
+                status_code: 500,
+                success: false,
+                update: false,
+                user: user.weighted_users_index,
+                ..Default::default()
+            })
+        }
+    }
+}
+
+/// Check transaction status scenario
+pub async fn check_transaction_status(user: &mut GooseUser) -> TransactionResult {
+    let state = user.get_session_data::<UserState>()
+        .ok_or_else(|| GooseError::from("No user state found"))?;
+
+    // Get the last transaction hash from session
+    let tx_hash = match user.get_session_data::<starknet::core::types::Felt>() {
+        Some(hash) => hash,
+        None => {
+            // If no transaction hash, skip this request
+            return user.set_success(&TransactionRequest {
+                name: "check_tx_status_skipped".to_string(),
+                ..Default::default()
+            });
+        }
+    };
+
+    let start_time = std::time::Instant::now();
+    
+    match state.client.get_transaction_status(*tx_hash).await {
+        Ok(status) => {
+            let elapsed = start_time.elapsed();
+            debug!("Transaction {:#x} status: {}", tx_hash, status);
+            
+            user.set_success(&TransactionRequest {
+                elapsed: elapsed.as_millis() as u64,
+                final_url: state.client.rpc_url.clone(),
+                name: "check_tx_status".to_string(),
+                redirected: false,
+                response_time: elapsed.as_millis() as u64,
+                status_code: 200,
+                success: true,
+                update: false,
+                user: user.weighted_users_index,
+                ..Default::default()
+            })
+        }
+        Err(e) => {
+            let elapsed = start_time.elapsed();
+            warn!("Failed to check transaction status: {}", e);
+            
+            user.set_failure(&format!("Status check failed: {}", e), &mut TransactionRequest {
+                elapsed: elapsed.as_millis() as u64,
+                final_url: state.client.rpc_url.clone(),
+                name: "check_tx_status".to_string(),
+                redirected: false,
+                response_time: elapsed.as_millis() as u64,
+                status_code: 500,
+                success: false,
+                update: false,
+                user: user.weighted_users_index,
+                ..Default::default()
+            })
+        }
+    }
+}
+
+/// Initialize user state
+pub async fn setup_user(user: &mut GooseUser) -> TransactionResult {
+    let global_args = user.get_base_url(); // We'll store global args in base_url for now
+    
+    // For simplicity, create a default state
+    // In a real implementation, you'd pass global_args properly
+    let state = UserState {
+        client: StarknetClient::new("http://localhost:5050").unwrap(),
+        account: Account::default_test_account(),
+        nonce: Arc::new(Mutex::new(starknet::core::types::Felt::ZERO)),
+    };
+
+    // Initialize nonce from network
+    match state.client.get_nonce(state.account.address).await {
+        Ok(nonce) => {
+            *state.nonce.lock().await = nonce;
+            info!("Initialized user with nonce: {:#x}", nonce);
+        }
+        Err(e) => {
+            warn!("Failed to get initial nonce: {}", e);
+            // Continue with nonce 0
+        }
+    }
+
+    user.set_session_data(state);
+    user.set_success(&TransactionRequest::default())
+}
+
+/// Constant load scenario
+pub async fn constant_load(
+    mut attack: GooseAttack,
+    global_args: GlobalArgs,
+    users: usize,
+    duration: Duration,
+    tps: u64,
+) -> Result<GooseAttack> {
+    // Calculate request frequency per user
+    let requests_per_user_per_sec = tps as f64 / users as f64;
+    let wait_time = if requests_per_user_per_sec > 0.0 {
+        Duration::from_millis((1000.0 / requests_per_user_per_sec) as u64)
+    } else {
+        Duration::from_secs(1)
+    };
+
+    Ok(attack
+        .register_scenario(
+            scenario!("KatanaConstantLoad")
+                .register_transaction(transaction!(setup_user).set_on_start())
+                .register_transaction(
+                    transaction!(send_transaction)
+                        .set_name("send_transaction")
+                        .set_weight(10)?
+                        .set_wait_time(wait_time, wait_time)?
+                )
+                .register_transaction(
+                    transaction!(check_transaction_status)
+                        .set_name("check_tx_status")
+                        .set_weight(2)?
+                )
+        )
+        .set_default(GooseDefault::Host, &global_args.rpc_url)?
+        .set_default(GooseDefault::Users, users)?
+        .set_default(GooseDefault::HatchRate, users as f64)?
+        .set_default(GooseDefault::RunTime, duration.as_secs())?
+    )
+}
+
+/// Ramp-up load scenario
+pub async fn ramp_up_load(
+    mut attack: GooseAttack,
+    global_args: GlobalArgs,
+    args: RampUpArgs,
+) -> Result<GooseAttack> {
+    // Calculate max users needed for max TPS
+    let max_users = (args.max_tps as f64 * 1.5) as usize; // 1.5x buffer
+    
+    Ok(attack
+        .register_scenario(
+            scenario!("KatanaRampUpLoad")
+                .register_transaction(transaction!(setup_user).set_on_start())
+                .register_transaction(
+                    transaction!(send_transaction)
+                        .set_name("send_transaction")
+                        .set_weight(10)?
+                )
+                .register_transaction(
+                    transaction!(check_transaction_status)
+                        .set_name("check_tx_status")
+                        .set_weight(2)?
+                )
+        )
+        .set_default(GooseDefault::Host, &global_args.rpc_url)?
+        .set_default(GooseDefault::Users, max_users)?
+        .set_default(GooseDefault::HatchRate, 2.0)? // Gradual ramp
+        .set_default(GooseDefault::RunTime, args.ramp_duration + args.hold_duration)?
+    )
+}
+
+/// Burst load scenario
+pub async fn burst_load(
+    mut attack: GooseAttack,
+    global_args: GlobalArgs,
+    args: BurstArgs,
+) -> Result<GooseAttack> {
+    let max_users = (args.burst_tps as f64 * 1.5) as usize;
+    
+    Ok(attack
+        .register_scenario(
+            scenario!("KatanaBurstLoad")
+                .register_transaction(transaction!(setup_user).set_on_start())
+                .register_transaction(
+                    transaction!(send_transaction)
+                        .set_name("send_transaction")
+                        .set_weight(10)?
+                )
+                .register_transaction(
+                    transaction!(check_transaction_status)
+                        .set_name("check_tx_status")
+                        .set_weight(2)?
+                )
+        )
+        .set_default(GooseDefault::Host, &global_args.rpc_url)?
+        .set_default(GooseDefault::Users, max_users)?
+        .set_default(GooseDefault::HatchRate, 10.0)? // Fast burst
+        .set_default(GooseDefault::RunTime, args.total_duration)?
+    )
+}

--- a/tests/load-test/src/transactions.rs
+++ b/tests/load-test/src/transactions.rs
@@ -1,0 +1,214 @@
+use anyhow::Result;
+use rand::Rng;
+use serde_json::{json, Value};
+use starknet::core::types::Felt;
+use starknet_crypto::{pedersen_hash, PrivateKey, PoseidonHasher};
+use starknet_types_core::hash::{Poseidon, StarkHash};
+
+use crate::client::Account;
+
+/// ERC20 transfer transaction builder
+pub struct ERC20Transfer {
+    pub contract_address: Felt,
+    pub recipient: Felt,
+    pub amount_low: Felt,
+    pub amount_high: Felt,
+}
+
+impl ERC20Transfer {
+    pub fn new_random() -> Self {
+        let mut rng = rand::thread_rng();
+        
+        // Use default ERC20 contract from Katana genesis
+        let contract_address = Felt::from_hex(
+            "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+        ).unwrap();
+
+        // Random recipient (keep it simple, use a few predefined addresses)
+        let recipients = [
+            Felt::from_hex("0x1").unwrap(),
+            Felt::from_hex("0x2").unwrap(),
+            Felt::from_hex("0x3").unwrap(),
+            Felt::from_hex("0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973").unwrap(),
+        ];
+        let recipient = recipients[rng.gen_range(0..recipients.len())];
+
+        // Random amount between 1 and 1000
+        let amount = rng.gen_range(1..=1000);
+
+        Self {
+            contract_address,
+            recipient,
+            amount_low: Felt::from(amount),
+            amount_high: Felt::ZERO,
+        }
+    }
+
+    pub fn build_invoke_transaction(&self, account: &Account, nonce: Felt) -> Result<Value> {
+        // transfer(recipient, amount)
+        let calldata = vec![
+            self.recipient,
+            self.amount_low,
+            self.amount_high,
+        ];
+
+        // Prepare transaction for signing
+        let tx_hash = self.calculate_transaction_hash(account, &calldata, nonce)?;
+        let (r, s) = account.sign_transaction_hash(tx_hash)?;
+
+        let transaction = json!({
+            "type": "INVOKE",
+            "version": "0x1",
+            "max_fee": "0x4f3878200000", // 1 ETH in wei (high fee for speed)
+            "signature": [
+                format!("{:#x}", r),
+                format!("{:#x}", s)
+            ],
+            "nonce": format!("{:#x}", nonce),
+            "sender_address": format!("{:#x}", account.address),
+            "calldata": calldata.iter().map(|x| format!("{:#x}", x)).collect::<Vec<_>>()
+        });
+
+        Ok(transaction)
+    }
+
+    fn calculate_transaction_hash(&self, account: &Account, calldata: &[Felt], nonce: Felt) -> Result<Felt> {
+        // This is a simplified transaction hash calculation
+        // In production, this should follow the exact StarkNet transaction hash spec
+        
+        let mut hasher = PoseidonHasher::new();
+        
+        // Add transaction fields to hash
+        hasher.update(Felt::from_hex("invoke").unwrap_or(Felt::ZERO)); // tx type
+        hasher.update(Felt::ONE); // version
+        hasher.update(account.address); // sender
+        hasher.update(Felt::ZERO); // entry point selector (for invoke v1)
+        
+        // Add calldata hash
+        let mut calldata_hasher = PoseidonHasher::new();
+        for data in calldata {
+            calldata_hasher.update(*data);
+        }
+        hasher.update(calldata_hasher.finalize());
+        
+        hasher.update(Felt::from_hex("0x4f3878200000").unwrap()); // max_fee
+        hasher.update(nonce);
+
+        Ok(hasher.finalize())
+    }
+}
+
+/// Account deployment transaction
+pub struct AccountDeployment {
+    pub class_hash: Felt,
+    pub constructor_calldata: Vec<Felt>,
+    pub salt: Felt,
+}
+
+impl AccountDeployment {
+    pub fn new_random() -> Self {
+        let mut rng = rand::thread_rng();
+        
+        // Standard account class hash (Katana default)
+        let class_hash = Felt::from_hex(
+            "0x025ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918"
+        ).unwrap();
+
+        // Random salt
+        let salt = Felt::from(rng.gen::<u64>());
+
+        // Constructor calldata for account (public key)
+        let constructor_calldata = vec![
+            Felt::from(rng.gen::<u64>()), // public key (mock)
+        ];
+
+        Self {
+            class_hash,
+            constructor_calldata,
+            salt,
+        }
+    }
+
+    pub fn build_deploy_account_transaction(&self, account: &Account, nonce: Felt) -> Result<Value> {
+        let tx_hash = self.calculate_deploy_hash(account, nonce)?;
+        let (r, s) = account.sign_transaction_hash(tx_hash)?;
+
+        let transaction = json!({
+            "type": "DEPLOY_ACCOUNT",
+            "version": "0x1",
+            "max_fee": "0x4f3878200000",
+            "signature": [
+                format!("{:#x}", r),
+                format!("{:#x}", s)
+            ],
+            "nonce": format!("{:#x}", nonce),
+            "class_hash": format!("{:#x}", self.class_hash),
+            "contract_address_salt": format!("{:#x}", self.salt),
+            "constructor_calldata": self.constructor_calldata
+                .iter()
+                .map(|x| format!("{:#x}", x))
+                .collect::<Vec<_>>()
+        });
+
+        Ok(transaction)
+    }
+
+    fn calculate_deploy_hash(&self, account: &Account, nonce: Felt) -> Result<Felt> {
+        let mut hasher = PoseidonHasher::new();
+        
+        hasher.update(Felt::from_hex("deploy_account").unwrap_or(Felt::ZERO));
+        hasher.update(Felt::ONE); // version
+        hasher.update(account.address);
+        hasher.update(self.class_hash);
+        hasher.update(self.salt);
+        
+        // Constructor calldata hash
+        let mut calldata_hasher = PoseidonHasher::new();
+        for data in &self.constructor_calldata {
+            calldata_hasher.update(*data);
+        }
+        hasher.update(calldata_hasher.finalize());
+        
+        hasher.update(Felt::from_hex("0x4f3878200000").unwrap()); // max_fee
+        hasher.update(nonce);
+
+        Ok(hasher.finalize())
+    }
+}
+
+/// Transaction types for load testing
+#[derive(Debug, Clone)]
+pub enum TransactionType {
+    ERC20Transfer,
+    AccountDeploy,
+    ContractCall,
+}
+
+impl TransactionType {
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        match rng.gen_range(0..3) {
+            0 => Self::ERC20Transfer,
+            1 => Self::AccountDeploy,
+            _ => Self::ContractCall,
+        }
+    }
+
+    pub fn build_transaction(&self, account: &Account, nonce: Felt) -> Result<Value> {
+        match self {
+            Self::ERC20Transfer => {
+                let transfer = ERC20Transfer::new_random();
+                transfer.build_invoke_transaction(account, nonce)
+            }
+            Self::AccountDeploy => {
+                let deploy = AccountDeployment::new_random();
+                deploy.build_deploy_account_transaction(account, nonce)
+            }
+            Self::ContractCall => {
+                // For now, use ERC20 transfer as a contract call
+                let transfer = ERC20Transfer::new_random();
+                transfer.build_invoke_transaction(account, nonce)
+            }
+        }
+    }
+}

--- a/tests/load-test/src/utils.rs
+++ b/tests/load-test/src/utils.rs
@@ -1,0 +1,286 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::time::{Duration, Instant};
+use tracing::{debug, info, warn};
+
+/// Performance metrics collector
+#[derive(Debug, Clone)]
+pub struct PerformanceMetrics {
+    pub start_time: Instant,
+    pub total_transactions: u64,
+    pub successful_transactions: u64,
+    pub failed_transactions: u64,
+    pub total_latency: Duration,
+    pub min_latency: Option<Duration>,
+    pub max_latency: Option<Duration>,
+    pub latencies: Vec<Duration>,
+}
+
+impl PerformanceMetrics {
+    pub fn new() -> Self {
+        Self {
+            start_time: Instant::now(),
+            total_transactions: 0,
+            successful_transactions: 0,
+            failed_transactions: 0,
+            total_latency: Duration::ZERO,
+            min_latency: None,
+            max_latency: None,
+            latencies: Vec::new(),
+        }
+    }
+
+    pub fn record_transaction(&mut self, latency: Duration, success: bool) {
+        self.total_transactions += 1;
+        
+        if success {
+            self.successful_transactions += 1;
+        } else {
+            self.failed_transactions += 1;
+        }
+
+        self.total_latency += latency;
+        self.latencies.push(latency);
+
+        // Update min/max latency
+        if self.min_latency.is_none() || latency < self.min_latency.unwrap() {
+            self.min_latency = Some(latency);
+        }
+        if self.max_latency.is_none() || latency > self.max_latency.unwrap() {
+            self.max_latency = Some(latency);
+        }
+    }
+
+    pub fn tps(&self) -> f64 {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        if elapsed > 0.0 {
+            self.successful_transactions as f64 / elapsed
+        } else {
+            0.0
+        }
+    }
+
+    pub fn success_rate(&self) -> f64 {
+        if self.total_transactions > 0 {
+            self.successful_transactions as f64 / self.total_transactions as f64 * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    pub fn average_latency(&self) -> Duration {
+        if self.total_transactions > 0 {
+            self.total_latency / self.total_transactions as u32
+        } else {
+            Duration::ZERO
+        }
+    }
+
+    pub fn percentile_latency(&self, percentile: f64) -> Duration {
+        if self.latencies.is_empty() {
+            return Duration::ZERO;
+        }
+
+        let mut sorted_latencies = self.latencies.clone();
+        sorted_latencies.sort();
+
+        let index = (percentile / 100.0 * sorted_latencies.len() as f64) as usize;
+        let index = index.min(sorted_latencies.len() - 1);
+        
+        sorted_latencies[index]
+    }
+
+    pub fn print_summary(&self) {
+        let elapsed = self.start_time.elapsed();
+        
+        info!("=== Performance Summary ===");
+        info!("Test Duration: {:.2}s", elapsed.as_secs_f64());
+        info!("Total Transactions: {}", self.total_transactions);
+        info!("Successful: {} ({:.1}%)", self.successful_transactions, self.success_rate());
+        info!("Failed: {}", self.failed_transactions);
+        info!("Transactions per Second: {:.2}", self.tps());
+        info!("Average Latency: {:.2}ms", self.average_latency().as_millis());
+        
+        if let Some(min) = self.min_latency {
+            info!("Min Latency: {:.2}ms", min.as_millis());
+        }
+        if let Some(max) = self.max_latency {
+            info!("Max Latency: {:.2}ms", max.as_millis());
+        }
+        
+        if !self.latencies.is_empty() {
+            info!("50th Percentile: {:.2}ms", self.percentile_latency(50.0).as_millis());
+            info!("95th Percentile: {:.2}ms", self.percentile_latency(95.0).as_millis());
+            info!("99th Percentile: {:.2}ms", self.percentile_latency(99.0).as_millis());
+        }
+    }
+}
+
+impl Default for PerformanceMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Utility functions for transaction validation
+pub fn validate_transaction_response(response: &Value) -> Result<String> {
+    if let Some(error) = response.get("error") {
+        return Err(anyhow::anyhow!("Transaction error: {}", error));
+    }
+
+    let tx_hash = response
+        .get("result")
+        .and_then(|r| r.get("transaction_hash"))
+        .and_then(|h| h.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Invalid transaction response format"))?;
+
+    Ok(tx_hash.to_string())
+}
+
+/// Rate limiter for controlling transaction submission rate
+pub struct RateLimiter {
+    interval: Duration,
+    last_request: Instant,
+}
+
+impl RateLimiter {
+    pub fn new(requests_per_second: f64) -> Self {
+        let interval = Duration::from_secs_f64(1.0 / requests_per_second);
+        Self {
+            interval,
+            last_request: Instant::now() - interval, // Allow immediate first request
+        }
+    }
+
+    pub async fn wait(&mut self) {
+        let elapsed = self.last_request.elapsed();
+        if elapsed < self.interval {
+            let wait_time = self.interval - elapsed;
+            tokio::time::sleep(wait_time).await;
+        }
+        self.last_request = Instant::now();
+    }
+}
+
+/// Resource monitor for tracking system resources during load test
+#[derive(Debug, Clone)]
+pub struct ResourceMonitor {
+    pub cpu_usage: Vec<f64>,
+    pub memory_usage: Vec<u64>,
+    pub timestamps: Vec<Instant>,
+}
+
+impl ResourceMonitor {
+    pub fn new() -> Self {
+        Self {
+            cpu_usage: Vec::new(),
+            memory_usage: Vec::new(),
+            timestamps: Vec::new(),
+        }
+    }
+
+    pub fn record_sample(&mut self, cpu: f64, memory: u64) {
+        self.cpu_usage.push(cpu);
+        self.memory_usage.push(memory);
+        self.timestamps.push(Instant::now());
+    }
+
+    pub fn average_cpu(&self) -> f64 {
+        if self.cpu_usage.is_empty() {
+            0.0
+        } else {
+            self.cpu_usage.iter().sum::<f64>() / self.cpu_usage.len() as f64
+        }
+    }
+
+    pub fn average_memory(&self) -> u64 {
+        if self.memory_usage.is_empty() {
+            0
+        } else {
+            self.memory_usage.iter().sum::<u64>() / self.memory_usage.len() as u64
+        }
+    }
+}
+
+impl Default for ResourceMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Configuration validator
+pub fn validate_config(rpc_url: &str) -> Result<()> {
+    // Basic URL validation
+    if !rpc_url.starts_with("http://") && !rpc_url.starts_with("https://") {
+        return Err(anyhow::anyhow!("Invalid RPC URL format"));
+    }
+
+    // Additional validation can be added here
+    debug!("Configuration validated successfully");
+    Ok(())
+}
+
+/// Pretty print JSON for debugging
+pub fn pretty_print_json(value: &Value) {
+    if let Ok(pretty) = serde_json::to_string_pretty(value) {
+        debug!("JSON: {}", pretty);
+    }
+}
+
+/// Convert hex string to felt safely
+pub fn safe_hex_to_felt(hex_str: &str) -> Result<starknet::core::types::Felt> {
+    let cleaned = if hex_str.starts_with("0x") {
+        &hex_str[2..]
+    } else {
+        hex_str
+    };
+    
+    starknet::core::types::Felt::from_hex(hex_str)
+        .map_err(|e| anyhow::anyhow!("Invalid hex string '{}': {}", hex_str, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_performance_metrics() {
+        let mut metrics = PerformanceMetrics::new();
+        
+        // Record some transactions
+        metrics.record_transaction(Duration::from_millis(100), true);
+        metrics.record_transaction(Duration::from_millis(200), true);
+        metrics.record_transaction(Duration::from_millis(150), false);
+        
+        assert_eq!(metrics.total_transactions, 3);
+        assert_eq!(metrics.successful_transactions, 2);
+        assert_eq!(metrics.failed_transactions, 1);
+        assert_eq!(metrics.success_rate(), 66.66666666666667);
+        
+        // Check latency calculations
+        assert_eq!(metrics.average_latency(), Duration::from_millis(150));
+        assert_eq!(metrics.min_latency, Some(Duration::from_millis(100)));
+        assert_eq!(metrics.max_latency, Some(Duration::from_millis(200)));
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter() {
+        let mut limiter = RateLimiter::new(2.0); // 2 requests per second
+        
+        let start = Instant::now();
+        limiter.wait().await;
+        limiter.wait().await;
+        let elapsed = start.elapsed();
+        
+        // Should take at least 500ms for the second request
+        assert!(elapsed >= Duration::from_millis(450));
+    }
+
+    #[test]
+    fn test_config_validation() {
+        assert!(validate_config("http://localhost:5050").is_ok());
+        assert!(validate_config("https://api.example.com").is_ok());
+        assert!(validate_config("invalid-url").is_err());
+        assert!(validate_config("ftp://example.com").is_err());
+    }
+}


### PR DESCRIPTION
This PR sets up the foundation for load testing to measure the system’s latency and throughput, with a focus on write performance (i.e. adding transactions).

The long-term goal is to build a suite of performance tests that measure:

- pure TPS/SPS/GPS
- performance of random read-only RPC requests
- combined read + write scenarios 

For now, the intended way to perform the test is to run against a Katana with metrics enabled, ideally with Prometheus and Grafana running to monitor the system during the test.

## Implementations

- A test database populated with initial state (starting with the Simple example project from the Dojo repo)
- Generating multiple accounts to send parallel transactions
- Basic measurement of:
	- raw TPS (add transactions without estimating fees)
	- accurate TPS (add transactions with fee estimation) 

Test scenarios include running Katana both with and without a custom block time.

Future work will expand the test DB with more complex state and introduce read-heavy and mixed load tests.

---

Example implementation: https://github.com/kariy/katana-load-test