### PR TITLE
fix(db): enum variants ordering

### DIFF
--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -335,10 +335,10 @@ impl InvokeTx {
 #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeclareTx {
+    V0(DeclareTxV0),
     V1(DeclareTxV1),
     V2(DeclareTxV2),
     V3(DeclareTxV3),
-    V0(DeclareTxV0),
 }
 
 impl DeclareTx {

--- a/crates/storage/db/src/models/versioned/transaction/v6.rs
+++ b/crates/storage/db/src/models/versioned/transaction/v6.rs
@@ -1,3 +1,7 @@
+//! IMPORTANT: The ordering for enumerable types should not be modified as this is the order that
+//! has been defined in database version 6. Modifying the order will break compatibility with the
+//! version.
+
 use katana_primitives::{chain, class, contract, da, fee, transaction, Felt};
 use serde::{Deserialize, Serialize};
 
@@ -60,34 +64,38 @@ pub struct DeployAccountTxV3 {
     pub fee_data_availability_mode: da::DataAvailabilityMode,
 }
 
+#[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(::arbitrary::Arbitrary))]
 pub enum InvokeTx {
-    V0(transaction::InvokeTxV0),
+    V0(transaction::InvokeTxV0) = 0,
     V1(transaction::InvokeTxV1),
     V3(InvokeTxV3),
 }
 
+#[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(::arbitrary::Arbitrary))]
 pub enum DeclareTx {
-    V1(transaction::DeclareTxV1),
-    V2(transaction::DeclareTxV2),
-    V3(DeclareTxV3),
-    V0(transaction::DeclareTxV0),
+    V1(transaction::DeclareTxV1) = 0,
+    V2(transaction::DeclareTxV2) = 1,
+    V3(DeclareTxV3) = 2,
+    V0(transaction::DeclareTxV0) = 3,
 }
 
+#[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(::arbitrary::Arbitrary))]
 pub enum DeployAccountTx {
-    V1(transaction::DeployAccountTxV1),
+    V1(transaction::DeployAccountTxV1) = 0,
     V3(DeployAccountTxV3),
 }
 
+#[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(::arbitrary::Arbitrary))]
 pub enum Tx {
-    Invoke(InvokeTx),
+    Invoke(InvokeTx) = 0,
     Declare(DeclareTx),
     L1Handler(transaction::L1HandlerTx),
     DeployAccount(DeployAccountTx),

--- a/crates/storage/db/src/models/versioned/transaction/v6.rs
+++ b/crates/storage/db/src/models/versioned/transaction/v6.rs
@@ -71,10 +71,10 @@ pub enum InvokeTx {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(::arbitrary::Arbitrary))]
 pub enum DeclareTx {
-    V0(transaction::DeclareTxV0),
     V1(transaction::DeclareTxV1),
     V2(transaction::DeclareTxV2),
     V3(DeclareTxV3),
+    V0(transaction::DeclareTxV0),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR fixes wrong enum ordering for the v6 transactions. The ordering matters here as it will affect how the variant is encoded when using binary serialization format like `postcard`.

Changing the order will change how postcard de/serialize the enum:

```rust
// V6 before:
pub enum DeclareTx {
    V0(transaction::DeclareTxV0),  // Position 0
    V1(transaction::DeclareTxV1),  // Position 1  
    V2(transaction::DeclareTxV2),  // Position 2
    V3(DeclareTxV3),              // Position 3
}

// V6 after:
pub enum DeclareTx {
    V1(transaction::DeclareTxV1),  // Position 0
    V2(transaction::DeclareTxV2),  // Position 1
    V3(DeclareTxV3),              // Position 2
    V0(transaction::DeclareTxV0),  // Position 3
}
```

Currently, when reading a `DeclareTx` from the database where the actual variant is a `DeclareTx::V3`, because we're deserializing the bytes as `DeclareTx` (**before**), the entry would end up being deserialized as a `DeclareTx::V2`.

In addition to this, to maintain consistency I decided to rearrange the enum variants for current (v7) `DeclareTx` - positioning V0 as the first variant. This does break the database format but it's fine because we're still in pre-release stage of V7 db format. Thus, this change will be part of the changes introduces by the new db format.