### PR TITLE
feat(rpc): bump spec version

### DIFF
--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -29,7 +29,7 @@ use starknet::core::types::{
 };
 
 /// The currently supported version of the Starknet JSON-RPC specification.
-pub const RPC_SPEC_VERSION: &str = "0.7.1";
+pub const RPC_SPEC_VERSION: &str = "0.8.1";
 
 /// Read API.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "starknet"))]


### PR DESCRIPTION
Correctly reflect the current version of the Starknet RPC specification that `katana` currently is following.