### PR TITLE
feat: bump starknet-rs to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
  "futures-utils-wasm",
  "lru 0.12.5",
  "pin-project 1.1.9",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -584,7 +584,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project 1.1.9",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -628,7 +628,7 @@ dependencies = [
  "alloy-transport-http 0.4.2",
  "futures",
  "pin-project 1.1.9",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "tokio",
@@ -649,7 +649,7 @@ dependencies = [
  "alloy-transport-http 0.11.1",
  "futures",
  "pin-project 1.1.9",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "tokio",
@@ -912,7 +912,7 @@ checksum = "b367dcccada5b28987c2296717ee04b9a5637aacd78eacb1726ef211678b5212"
 dependencies = [
  "alloy-json-rpc 0.4.2",
  "alloy-transport 0.4.2",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -926,7 +926,7 @@ source = "git+https://github.com/alloy-rs/alloy#be979a000bba43fa111d1e8a11c8f42c
 dependencies = [
  "alloy-json-rpc 0.11.1",
  "alloy-transport 0.11.1",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -2472,26 +2472,26 @@ dependencies = [
 
 [[package]]
 name = "cainome"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04a357fdab01f56b676c8c41e11b154bb69eef184204cae47a4209eb4e0035"
+checksum = "48dd7cc8b7674f2285ea36cdf883c14f7c6bfedf12a9643d77dd618e43d34345"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome-cairo-serde 0.2.0",
+ "cainome-cairo-serde 0.2.1",
  "cainome-cairo-serde-derive",
- "cainome-parser 0.2.0",
- "cainome-rs 0.2.0",
- "cainome-rs-macro 0.2.0",
+ "cainome-parser 0.3.0",
+ "cainome-rs 0.3.1",
+ "cainome-rs-macro 0.3.0",
  "camino",
  "clap",
  "clap_complete",
- "convert_case 0.6.0",
+ "convert_case 0.8.0",
  "serde",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-types-core",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2512,15 +2512,15 @@ dependencies = [
 
 [[package]]
 name = "cainome-cairo-serde"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32790b9d4293a5ee97e4c646e2d40c186f6d2e0f5f9141e46bf187446bf4883f"
+checksum = "da490d99e84c141e9f5646965de176d6fbfcc7a525f17b6b08e208cd65e6fe35"
 dependencies = [
  "num-bigint",
  "serde",
  "serde_with 3.12.0",
- "starknet 0.14.0",
- "thiserror 1.0.69",
+ "starknet 0.15.1",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "cainome-parser"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499219c70d1382b5f7defc6985b0266fb10b27b91dc4e8b0b0e4a10258e5d292"
+checksum = "feaf4e3cba66ccc85bca9726e09ffd69d3b1be37f1305ed59e1b1d5a6e86fabc"
 dependencies = [
  "convert_case 0.6.0",
  "quote",
@@ -2584,21 +2584,21 @@ dependencies = [
 
 [[package]]
 name = "cainome-rs"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67adae2e76aeb14e514dcda34092c86170e0f84843727b1ad8e2b7398b3e0b56"
+checksum = "b24e87fcf544b3112f70e36eb560c78c0f7e18ca5d6a1483fdf7b05e7e8302e9"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.2.0",
- "cainome-parser 0.2.0",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-parser 0.3.0",
  "camino",
  "prettyplease",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "syn 2.0.98",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2622,14 +2622,14 @@ dependencies = [
 
 [[package]]
 name = "cainome-rs-macro"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c4e39d654e8e5c94f31a59ae8583771abbd784f96215dae1d1592f1b7526b2"
+checksum = "919354b1142e3ca398313b842a5f95b081b0261270164a8fcdf13c8c633193fd"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.2.0",
- "cainome-parser 0.2.0",
- "cainome-rs 0.2.0",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-parser 0.3.0",
+ "cainome-rs 0.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3715,6 +3715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,7 +4028,7 @@ dependencies = [
  "katana-node",
  "katana-primitives",
  "katana-provider",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tokio",
 ]
 
@@ -4843,7 +4852,7 @@ dependencies = [
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -6196,7 +6205,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "byte-unit",
- "cainome 0.6.1",
+ "cainome 0.8.0",
  "clap",
  "clap_complete",
  "colored_json 5.0.0",
@@ -6217,7 +6226,7 @@ dependencies = [
  "rstest 0.18.2",
  "shellexpand",
  "spinoff",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "strum_macros 0.25.3",
  "tempfile",
  "thiserror 1.0.69",
@@ -6244,7 +6253,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tempfile",
  "thiserror 1.0.69",
  "toml",
@@ -6272,7 +6281,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tokio",
  "toml",
  "tracing",
@@ -6328,7 +6337,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rstest 0.18.2",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-types-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -6358,7 +6367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
@@ -6390,7 +6399,7 @@ dependencies = [
  "rstest_reuse 0.6.0",
  "serde_json",
  "similar-asserts",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "thiserror 1.0.69",
  "tokio",
@@ -6410,7 +6419,7 @@ dependencies = [
  "jsonrpsee",
  "katana-runner",
  "katana-tasks",
- "reqwest 0.11.27",
+ "reqwest 0.12.15",
  "rust-embed",
  "tiny_http",
  "tokio",
@@ -6427,12 +6436,12 @@ version = "1.6.0-alpha.1"
 dependencies = [
  "katana-primitives",
  "katana-rpc-types",
- "reqwest 0.11.27",
+ "reqwest 0.12.15",
  "rstest 0.18.2",
  "serde",
  "serde_json",
  "similar-asserts",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6449,7 +6458,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "parking_lot",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6506,10 +6515,10 @@ dependencies = [
  "katana-chain-spec",
  "katana-pool",
  "katana-primitives",
- "reqwest 0.11.27",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-crypto 0.7.4",
  "thiserror 1.0.69",
  "tokio",
@@ -6562,7 +6571,7 @@ dependencies = [
  "katana-tasks",
  "serde",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -6585,7 +6594,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6618,7 +6627,7 @@ dependencies = [
  "katana-provider",
  "parking_lot",
  "rand 0.8.5",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6634,7 +6643,7 @@ dependencies = [
  "assert_matches",
  "base64 0.21.7",
  "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "cainome-cairo-serde 0.2.0",
+ "cainome-cairo-serde 0.2.1",
  "cairo-lang-starknet-classes",
  "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion",
@@ -6652,7 +6661,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with 3.12.0",
  "similar-asserts",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-crypto 0.7.4",
  "starknet-types-core",
  "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
@@ -6682,7 +6691,7 @@ dependencies = [
  "rstest 0.18.2",
  "rstest_reuse 0.6.0",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-types-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -6700,7 +6709,7 @@ dependencies = [
  "anyhow",
  "ark-ec 0.4.2",
  "assert_matches",
- "cainome 0.6.1",
+ "cainome 0.8.0",
  "cairo-lang-starknet-classes",
  "dojo-utils",
  "futures",
@@ -6729,13 +6738,13 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "rand 0.8.5",
- "reqwest 0.11.27",
+ "reqwest 0.12.15",
  "rstest 0.18.2",
  "serde",
  "serde_json",
  "similar-asserts",
  "stark-vrf",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-crypto 0.7.4",
  "tempfile",
  "thiserror 1.0.69",
@@ -6760,7 +6769,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "thiserror 1.0.69",
 ]
 
@@ -6770,8 +6779,8 @@ version = "1.6.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
- "cainome 0.6.1",
- "cainome-cairo-serde 0.2.0",
+ "cainome 0.8.0",
+ "cainome-cairo-serde 0.2.1",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "derive_more 0.99.19",
@@ -6785,7 +6794,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with 3.12.0",
  "similar-asserts",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "thiserror 1.0.69",
 ]
@@ -6799,7 +6808,7 @@ dependencies = [
  "katana-primitives",
  "katana-provider",
  "katana-rpc-types",
- "starknet 0.14.0",
+ "starknet 0.15.1",
 ]
 
 [[package]]
@@ -6811,7 +6820,7 @@ dependencies = [
  "jsonrpsee",
  "katana-node-bindings",
  "katana-runner-macro",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tokio",
 ]
 
@@ -6850,7 +6859,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "num-traits",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6879,7 +6888,7 @@ dependencies = [
  "katana-primitives",
  "serde",
  "slab",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-types-core",
  "thiserror 1.0.69",
 ]
@@ -6900,7 +6909,7 @@ dependencies = [
  "katana-provider",
  "katana-rpc",
  "rand 0.8.5",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -7856,7 +7865,7 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "opentelemetry",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
 ]
 
 [[package]]
@@ -7871,7 +7880,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "thiserror 2.0.11",
  "tokio",
  "tonic 0.13.1",
@@ -8216,10 +8225,10 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "piltover"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/piltover.git?rev=45263e8#45263e815d584ca46a029ccbe06e431e24897deb"
+source = "git+https://github.com/cartridge-gg/piltover.git?rev=3bed7ac554259668dbdce6a5f56de5b2bf7faf43#3bed7ac554259668dbdce6a5f56de5b2bf7faf43"
 dependencies = [
- "cainome 0.6.1",
- "starknet 0.14.0",
+ "cainome 0.8.0",
+ "starknet 0.15.1",
 ]
 
 [[package]]
@@ -9076,9 +9085,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -9161,7 +9170,7 @@ dependencies = [
  "headless_chrome",
  "katana-utils",
  "nix 0.30.0",
- "reqwest 0.11.27",
+ "reqwest 0.12.15",
  "tokio",
 ]
 
@@ -10373,7 +10382,7 @@ dependencies = [
  "katana-primitives",
  "katana-provider",
  "prove_block",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "starknet-os",
  "tokio",
 ]
@@ -10535,6 +10544,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ec983c56ce05b2d7679fa860b37b2ade21004c343ff49374a591b40ee8ee1d"
+dependencies = [
+ "starknet-accounts 0.14.0",
+ "starknet-contract 0.14.0",
+ "starknet-core 0.14.0",
+ "starknet-core-derive",
+ "starknet-crypto 0.7.4",
+ "starknet-macros",
+ "starknet-providers 0.14.1",
+ "starknet-signers 0.12.0",
+]
+
+[[package]]
 name = "starknet-accounts"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10595,6 +10620,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-accounts"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7adf55fa08ffed413614df3171632e45dcba72cc53706b147ba08e5b7b4e4fb"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "starknet-core 0.14.0",
+ "starknet-crypto 0.7.4",
+ "starknet-providers 0.14.1",
+ "starknet-signers 0.12.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "starknet-contract"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10651,6 +10691,21 @@ dependencies = [
  "starknet-accounts 0.13.0",
  "starknet-core 0.13.0",
  "starknet-providers 0.13.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starknet-contract"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72746fa496e352ef16b4a8fd11e415ada6b7b5a9107fc6e845eeb921b8bb2a69"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with 3.12.0",
+ "starknet-accounts 0.14.0",
+ "starknet-core 0.14.0",
+ "starknet-providers 0.14.1",
  "thiserror 1.0.69",
 ]
 
@@ -10847,7 +10902,7 @@ dependencies = [
  "pathfinder-serde",
  "primitive-types",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "rstest 0.18.2",
  "serde",
  "serde_json",
@@ -11004,6 +11059,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-providers"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce77bf215b70673264bc875d59c45fb7da500e7e6f71d2608ad25a1f7280671"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethereum-types",
+ "flate2",
+ "getrandom 0.2.15",
+ "log",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "serde_with 3.12.0",
+ "starknet-core 0.14.0",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "starknet-signers"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11050,6 +11126,23 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "starknet-core 0.13.0",
+ "starknet-crypto 0.7.4",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starknet-signers"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd831176f8a217694895fd69be17f985e5e28f00bc8044eb54b55656f3a7f1"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "crypto-bigint",
+ "eth-keystore",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
+ "starknet-core 0.14.0",
  "starknet-crypto 0.7.4",
  "thiserror 1.0.69",
 ]
@@ -12943,13 +13036,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -12987,6 +13080,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -13073,11 +13175,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -13108,6 +13226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13124,6 +13248,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -13144,10 +13274,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -13168,6 +13310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13184,6 +13332,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -13204,6 +13358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13220,6 +13380,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ debug = true
 inherits = "release"
 
 [workspace.dependencies]
-cainome = { version = "0.6.0", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { version = "0.2.0" }
+cainome = { version = "0.8.0", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { version = "0.2.1" }
 dojo-utils = { git = "https://github.com/dojoengine/dojo", tag = "v1.2.2" }
 
 # katana
@@ -144,7 +144,7 @@ pretty_assertions = "1.2.1"
 rand = "0.8.5"
 rayon = "1.8.0"
 regex = "1.10.3"
-reqwest = { version = "0.11.27", features = [ "json", "rustls-tls" ], default-features = false }
+reqwest = { version = "0.12.15", features = [ "json", "rustls-tls" ], default-features = false }
 rpassword = "7.2.0"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
@@ -214,7 +214,7 @@ alloy-signer = { version = "0.4", default-features = false }
 alloy-transport = { version = "0.4", default-features = false }
 
 bitvec = "1.0.1"
-starknet = "0.14.0"
+starknet = "0.15.1"
 starknet-crypto = "0.7.1"
 starknet-types-core = { version = "0.1.8", features = [ "arbitrary", "hash" ] }
 # macro

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -24,7 +24,8 @@ comfy-table = "7.1.1"
 const_format = "0.2.33"
 indicatif = "0.17.8"
 inquire = "0.7.5"
-piltover = { git = "https://github.com/keep-starknet-strange/piltover.git", rev = "45263e8" }
+# Rev on branch starknet 0.15.1.
+piltover = { git = "https://github.com/cartridge-gg/piltover.git", rev = "3bed7ac554259668dbdce6a5f56de5b2bf7faf43" }
 rand.workspace = true
 shellexpand = "3.1.0"
 spinoff.workspace = true

--- a/crates/rpc/rpc-api/src/error/starknet.rs
+++ b/crates/rpc/rpc-api/src/error/starknet.rs
@@ -94,6 +94,12 @@ pub enum StarknetApiError {
     EntrypointNotFound,
     #[error("The transaction's resources don't cover validation or the minimal transaction fee")]
     InsufficientResourcesForValidate,
+    #[error("Invalid subscription id")]
+    InvalidSubscriptionId,
+    #[error("Too many addresses provided in a filter")]
+    TooManyAddressesInFilter,
+    #[error("Too many blocks back")]
+    TooManyBlocksBack,
 }
 
 impl StarknetApiError {
@@ -129,6 +135,9 @@ impl StarknetApiError {
             StarknetApiError::UnsupportedTransactionVersion => 61,
             StarknetApiError::UnsupportedContractClassVersion => 62,
             StarknetApiError::UnexpectedError { .. } => 63,
+            StarknetApiError::InvalidSubscriptionId => 66,
+            StarknetApiError::TooManyAddressesInFilter => 67,
+            StarknetApiError::TooManyBlocksBack => 68,
             StarknetApiError::ProofLimitExceeded { .. } => 1000,
         }
     }
@@ -264,6 +273,9 @@ impl From<StarknetRsError> for StarknetApiError {
             StarknetRsError::InsufficientResourcesForValidate => {
                 Self::InsufficientResourcesForValidate
             }
+            StarknetRsError::InvalidSubscriptionId => Self::InvalidSubscriptionId,
+            StarknetRsError::TooManyAddressesInFilter => Self::TooManyAddressesInFilter,
+            StarknetRsError::TooManyBlocksBack => Self::TooManyBlocksBack,
         }
     }
 }

--- a/crates/rpc/rpc-api/src/error/starknet.rs
+++ b/crates/rpc/rpc-api/src/error/starknet.rs
@@ -96,9 +96,9 @@ pub enum StarknetApiError {
     InsufficientResourcesForValidate,
     #[error("Invalid subscription id")]
     InvalidSubscriptionId,
-    #[error("Too many addresses provided in a filter")]
+    #[error("Too many addresses in filter sender_address filter")]
     TooManyAddressesInFilter,
-    #[error("Too many blocks back")]
+    #[error("Cannot go back more than 1024 blocks")]
     TooManyBlocksBack,
 }
 
@@ -328,6 +328,9 @@ mod tests {
     #[case(StarknetApiError::InsufficientAccountBalance, 54, "Account balance is smaller than the transaction's max_fee")]
     #[case(StarknetApiError::CompiledClassHashMismatch, 60, "The compiled class hash did not match the one supplied in the transaction")]
     #[case(StarknetApiError::InsufficientResourcesForValidate, 53, "The transaction's resources don't cover validation or the minimal transaction fee")]
+    #[case(StarknetApiError::InvalidSubscriptionId, 66, "Invalid subscription id")]
+    #[case(StarknetApiError::TooManyAddressesInFilter, 67, "Too many addresses in filter sender_address filter")]
+    #[case(StarknetApiError::TooManyBlocksBack, 68, "Cannot go back more than 1024 blocks")]
     fn test_starknet_api_error_to_error_conversion_data_none(
         #[case] starknet_error: StarknetApiError,
         #[case] expected_code: i32,

--- a/crates/rpc/rpc-types/src/trace.rs
+++ b/crates/rpc/rpc-types/src/trace.rs
@@ -96,13 +96,13 @@ pub fn to_rpc_fee_estimate(resources: &receipt::ExecutionResources, fee: &FeeInf
 
     FeeEstimate {
         unit,
-        overall_fee: fee.overall_fee.into(),
-        l2_gas_price: fee.l2_gas_price.into(),
-        l1_gas_price: fee.l1_gas_price.into(),
-        l1_data_gas_price: fee.l1_data_gas_price.into(),
-        l1_gas_consumed: resources.gas.l1_gas.into(),
-        l2_gas_consumed: resources.gas.l2_gas.into(),
-        l1_data_gas_consumed: resources.gas.l1_data_gas.into(),
+        overall_fee: fee.overall_fee,
+        l2_gas_price: fee.l2_gas_price,
+        l1_gas_price: fee.l1_gas_price,
+        l1_data_gas_price: fee.l1_data_gas_price,
+        l1_gas_consumed: resources.gas.l1_gas,
+        l2_gas_consumed: resources.gas.l2_gas,
+        l1_data_gas_consumed: resources.gas.l1_data_gas,
     }
 }
 

--- a/crates/rpc/rpc/src/starknet/blockifier.rs
+++ b/crates/rpc/rpc/src/starknet/blockifier.rs
@@ -82,13 +82,13 @@ pub fn estimate_fees(
 
                         results.push(Ok(FeeEstimate {
                             unit,
-                            overall_fee: fee.overall_fee.into(),
-                            l2_gas_price: fee.l2_gas_price.into(),
-                            l1_gas_price: fee.l1_gas_price.into(),
-                            l2_gas_consumed: resources.gas.l2_gas.into(),
-                            l1_gas_consumed: resources.gas.l1_gas.into(),
-                            l1_data_gas_price: fee.l1_data_gas_price.into(),
-                            l1_data_gas_consumed: resources.gas.l1_data_gas.into(),
+                            overall_fee: fee.overall_fee,
+                            l2_gas_price: fee.l2_gas_price,
+                            l1_gas_price: fee.l1_gas_price,
+                            l2_gas_consumed: resources.gas.l2_gas,
+                            l1_gas_consumed: resources.gas.l1_gas,
+                            l1_data_gas_price: fee.l1_data_gas_price,
+                            l1_data_gas_consumed: resources.gas.l1_data_gas,
                         }));
                     }
                 }


### PR DESCRIPTION
This PR aims at bumping starknet-rs to the latest stable version, to ease the migration of the whole stack to a common version.