### PR TITLE
feat(katana): default to deserialize response as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6224,6 +6224,8 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rstest 0.18.2",
+ "serde",
+ "serde_json",
  "shellexpand",
  "spinoff",
  "starknet 0.15.1",

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -27,6 +27,8 @@ inquire = "0.7.5"
 # Rev on branch starknet 0.15.1.
 piltover = { git = "https://github.com/cartridge-gg/piltover.git", rev = "3bed7ac554259668dbdce6a5f56de5b2bf7faf43" }
 rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 shellexpand = "3.1.0"
 spinoff.workspace = true
 starknet.workspace = true

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -28,7 +28,6 @@ inquire = "0.7.5"
 piltover = { git = "https://github.com/cartridge-gg/piltover.git", rev = "3bed7ac554259668dbdce6a5f56de5b2bf7faf43" }
 rand.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 shellexpand = "3.1.0"
 spinoff.workspace = true
 starknet.workspace = true
@@ -39,6 +38,7 @@ tracing.workspace = true
 url.workspace = true
 
 colored_json = { version = "5.0", optional = true }
+serde_json = { workspace = true, optional = true }
 
 [build-dependencies]
 vergen = { version = "9.0.0", features = [ "build", "cargo", "emit_and_set" ] }
@@ -57,7 +57,7 @@ tempfile.workspace = true
 default = [ "cartridge", "init-slot", "jemalloc", "katana-cli/explorer" ]
 
 cartridge = [ "katana-cli/cartridge" ]
-client = [ "dep:colored_json" ]
+client = [ "dep:colored_json", "dep:serde_json" ]
 init-custom-settlement-chain = [  ]
 init-slot = [  ]
 jemalloc = [  ]

--- a/bin/katana/src/cli/rpc/client.rs
+++ b/bin/katana/src/cli/rpc/client.rs
@@ -108,7 +108,7 @@ impl Client {
         contract_address: Felt,
         key: Felt,
         block_id: BlockId,
-    ) -> Result<Felt> {
+    ) -> Result<Value> {
         self.send_request(
             StarknetJsonRpcMethod::GetStorageAt,
             GetStorageAtRequestRef {
@@ -177,7 +177,7 @@ impl Client {
         &self,
         block_id: BlockId,
         contract_address: Felt,
-    ) -> Result<Felt> {
+    ) -> Result<Value> {
         self.send_request(
             StarknetJsonRpcMethod::GetClassHashAt,
             GetClassHashAtRequestRef {
@@ -210,7 +210,7 @@ impl Client {
         .map_err(|e| anyhow!("Failed to get block transaction count: {e}"))
     }
 
-    pub async fn call(&self, request: FunctionCall, block_id: BlockId) -> Result<Vec<Felt>> {
+    pub async fn call(&self, request: FunctionCall, block_id: BlockId) -> Result<Vec<Value>> {
         self.send_request(
             StarknetJsonRpcMethod::Call,
             CallRequestRef { request: request.as_ref(), block_id: block_id.as_ref() },
@@ -231,7 +231,7 @@ impl Client {
             .map_err(|e| anyhow!("Failed to get block hash and number: {e}"))
     }
 
-    pub async fn chain_id(&self) -> Result<Felt> {
+    pub async fn chain_id(&self) -> Result<Value> {
         self.send_request(StarknetJsonRpcMethod::ChainId, ChainIdRequest)
             .await
             .map_err(|e| anyhow!("Failed to get chain id: {e}"))
@@ -243,7 +243,7 @@ impl Client {
             .map_err(|e| anyhow!("Failed to get syncing status: {e}"))
     }
 
-    pub async fn get_nonce(&self, block_id: BlockId, contract_address: Felt) -> Result<Felt> {
+    pub async fn get_nonce(&self, block_id: BlockId, contract_address: Felt) -> Result<Value> {
         self.send_request(
             StarknetJsonRpcMethod::GetNonce,
             GetNonceRequestRef {

--- a/bin/katana/src/cli/rpc/client.rs
+++ b/bin/katana/src/cli/rpc/client.rs
@@ -1,67 +1,106 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use katana_primitives::block::BlockNumber;
 use katana_primitives::transaction::TxHash;
 use katana_primitives::Felt;
-use starknet::core::types::{
-    BlockHashAndNumber, BlockId, ContractClass, FunctionCall, MaybePendingBlockWithReceipts,
-    MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingStateUpdate,
-    SyncStatusType, Transaction, TransactionReceiptWithBlockInfo, TransactionStatus,
-    TransactionTrace, TransactionTraceWithHash,
+use katana_utils::node::StarknetError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use starknet::core::types::requests::*;
+use starknet::core::types::{BlockHashAndNumber, BlockId, FunctionCall, SyncStatusType};
+use starknet::providers::jsonrpc::{
+    HttpTransport, JsonRpcClientError, JsonRpcMethod as StarknetJsonRpcMethod, JsonRpcResponse,
+    JsonRpcTransport,
 };
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider, Url};
+use starknet::providers::{ProviderError as StarknetProviderError, Url};
 
-#[derive(Debug)]
+/// A generic JSON-RPC client with any transport.
+///
+/// A "transport" is any implementation that can send JSON-RPC requests and receive responses. This
+/// most commonly happens over a network via HTTP connections, as with [`HttpTransport`].
+#[derive(Debug, Clone)]
 pub struct Client {
-    rpc_client: JsonRpcClient<HttpTransport>,
+    transport: HttpTransport,
 }
 
 impl Client {
     pub fn new(url: Url) -> Self {
-        Self { rpc_client: JsonRpcClient::new(HttpTransport::new(url)) }
+        Self { transport: HttpTransport::new(url) }
     }
 
+    async fn send_request<P, R>(
+        &self,
+        method: StarknetJsonRpcMethod,
+        params: P,
+    ) -> Result<R, StarknetProviderError>
+    where
+        P: Serialize + Send + Sync,
+        R: DeserializeOwned,
+    {
+        match self
+            .transport
+            .send_request(method, params)
+            .await
+            .map_err(JsonRpcClientError::TransportError)?
+        {
+            JsonRpcResponse::Success { result, .. } => Ok(result),
+            JsonRpcResponse::Error { error, .. } => {
+                Err(match TryInto::<StarknetError>::try_into(&error) {
+                    Ok(error) => StarknetProviderError::StarknetError(error),
+                    Err(_) => JsonRpcClientError::<<HttpTransport as JsonRpcTransport>::Error>::JsonRpcError(error).into(),
+                })
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Client Starknet JSON-RPC implementations
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl Client {
     // Read API methods
 
-    pub async fn spec_version(&self) -> Result<String> {
-        self.rpc_client
-            .spec_version()
+    pub async fn spec_version(&self) -> Result<Value> {
+        self.send_request(StarknetJsonRpcMethod::SpecVersion, SpecVersionRequest)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get spec version: {}", e))
+            .map_err(|e| anyhow!("Failed to get spec version: {e}"))
     }
 
-    pub async fn get_block_with_tx_hashes(
-        &self,
-        block_id: BlockId,
-    ) -> Result<MaybePendingBlockWithTxHashes> {
-        self.rpc_client
-            .get_block_with_tx_hashes(block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get block with tx hashes: {}", e))
+    pub async fn get_block_with_tx_hashes(&self, block_id: BlockId) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetBlockWithTxHashes,
+            GetBlockWithTxHashesRequestRef { block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get block with tx hashes: {e}"))
     }
 
-    pub async fn get_block_with_txs(&self, block_id: BlockId) -> Result<MaybePendingBlockWithTxs> {
-        self.rpc_client
-            .get_block_with_txs(block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get block with txs: {}", e))
+    pub async fn get_block_with_txs(&self, block_id: BlockId) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetBlockWithTxs,
+            GetBlockWithTxsRequestRef { block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get block with txs: {e}"))
     }
 
-    pub async fn get_block_with_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> Result<MaybePendingBlockWithReceipts> {
-        self.rpc_client
-            .get_block_with_receipts(block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get block with receipts: {}", e))
+    pub async fn get_block_with_receipts(&self, block_id: BlockId) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetBlockWithReceipts,
+            GetBlockWithReceiptsRequestRef { block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get block with receipts: {e}"))
     }
 
-    pub async fn get_state_update(&self, block_id: BlockId) -> Result<MaybePendingStateUpdate> {
-        self.rpc_client
-            .get_state_update(block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get state update: {}", e))
+    pub async fn get_state_update(&self, block_id: BlockId) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetStateUpdate,
+            GetStateUpdateRequestRef { block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get state update: {e}"))
     }
 
     pub async fn get_storage_at(
@@ -70,52 +109,68 @@ impl Client {
         key: Felt,
         block_id: BlockId,
     ) -> Result<Felt> {
-        self.rpc_client
-            .get_storage_at(contract_address, key, block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get storage at: {}", e))
+        self.send_request(
+            StarknetJsonRpcMethod::GetStorageAt,
+            GetStorageAtRequestRef {
+                contract_address: contract_address.as_ref(),
+                block_id: block_id.as_ref(),
+                key: key.as_ref(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get storage at: {e}"))
     }
 
-    pub async fn get_transaction_by_hash(&self, tx_hash: TxHash) -> Result<Transaction> {
-        self.rpc_client
-            .get_transaction_by_hash(tx_hash)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get transaction by hash: {}", e))
+    pub async fn get_transaction_by_hash(&self, tx_hash: TxHash) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetTransactionByHash,
+            GetTransactionByHashRequestRef { transaction_hash: tx_hash.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get transaction by hash: {e}"))
     }
 
     pub async fn get_transaction_by_block_id_and_index(
         &self,
         block_id: BlockId,
         index: u64,
-    ) -> Result<Transaction> {
-        self.rpc_client
-            .get_transaction_by_block_id_and_index(block_id, index)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get transaction by block id and index: {}", e))
+    ) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetTransactionByBlockIdAndIndex,
+            GetTransactionByBlockIdAndIndexRequestRef {
+                block_id: block_id.as_ref(),
+                index: &index,
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get transaction by block id and index: {e}"))
     }
 
-    pub async fn get_transaction_receipt(
-        &self,
-        tx_hash: TxHash,
-    ) -> Result<TransactionReceiptWithBlockInfo> {
-        self.rpc_client
-            .get_transaction_receipt(tx_hash)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get transaction receipt: {}", e))
+    pub async fn get_transaction_receipt(&self, tx_hash: TxHash) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetTransactionReceipt,
+            GetTransactionReceiptRequestRef { transaction_hash: tx_hash.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get transaction receipt: {e}"))
     }
 
-    pub async fn get_transaction_status(&self, tx_hash: TxHash) -> Result<TransactionStatus> {
-        self.rpc_client
-            .get_transaction_status(tx_hash)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get transaction status: {}", e))
+    pub async fn get_transaction_status(&self, tx_hash: TxHash) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetTransactionStatus,
+            GetTransactionStatusRequestRef { transaction_hash: tx_hash.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get transaction status: {e}"))
     }
 
-    pub async fn get_class(&self, block_id: BlockId, class_hash: Felt) -> Result<ContractClass> {
-        self.rpc_client
-            .get_class(block_id, class_hash)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get class: {}", e))
+    pub async fn get_class(&self, block_id: BlockId, class_hash: Felt) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetClass,
+            GetClassRequestRef { block_id: block_id.as_ref(), class_hash: class_hash.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get class: {e}"))
     }
 
     pub async fn get_class_hash_at(
@@ -123,88 +178,100 @@ impl Client {
         block_id: BlockId,
         contract_address: Felt,
     ) -> Result<Felt> {
-        self.rpc_client
-            .get_class_hash_at(block_id, contract_address)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get class hash at: {}", e))
+        self.send_request(
+            StarknetJsonRpcMethod::GetClassHashAt,
+            GetClassHashAtRequestRef {
+                block_id: block_id.as_ref(),
+                contract_address: contract_address.as_ref(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get class hash at: {e}"))
     }
 
-    pub async fn get_class_at(
-        &self,
-        block_id: BlockId,
-        contract_address: Felt,
-    ) -> Result<ContractClass> {
-        self.rpc_client
-            .get_class_at(block_id, contract_address)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get class at: {}", e))
+    pub async fn get_class_at(&self, block_id: BlockId, contract_address: Felt) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::GetClassAt,
+            GetClassAtRequestRef {
+                block_id: block_id.as_ref(),
+                contract_address: contract_address.as_ref(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get class at: {e}"))
     }
 
     pub async fn get_block_transaction_count(&self, block_id: BlockId) -> Result<u64> {
-        self.rpc_client
-            .get_block_transaction_count(block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get block transaction count: {}", e))
+        self.send_request(
+            StarknetJsonRpcMethod::GetBlockTransactionCount,
+            GetBlockTransactionCountRequestRef { block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get block transaction count: {e}"))
     }
 
     pub async fn call(&self, request: FunctionCall, block_id: BlockId) -> Result<Vec<Felt>> {
-        self.rpc_client
-            .call(request, block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to call: {}", e))
+        self.send_request(
+            StarknetJsonRpcMethod::Call,
+            CallRequestRef { request: request.as_ref(), block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to call: {e}"))
     }
 
     pub async fn block_number(&self) -> Result<BlockNumber> {
-        self.rpc_client
-            .block_number()
+        self.send_request(StarknetJsonRpcMethod::BlockNumber, BlockNumberRequest)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get block number: {}", e))
+            .map_err(|e| anyhow!("Failed to get block number: {e}"))
     }
 
     pub async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber> {
-        self.rpc_client
-            .block_hash_and_number()
+        self.send_request(StarknetJsonRpcMethod::BlockHashAndNumber, BlockHashAndNumberRequest)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get block hash and number: {}", e))
+            .map_err(|e| anyhow!("Failed to get block hash and number: {e}"))
     }
 
     pub async fn chain_id(&self) -> Result<Felt> {
-        self.rpc_client
-            .chain_id()
+        self.send_request(StarknetJsonRpcMethod::ChainId, ChainIdRequest)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get chain id: {}", e))
+            .map_err(|e| anyhow!("Failed to get chain id: {e}"))
     }
 
     pub async fn syncing(&self) -> Result<SyncStatusType> {
-        self.rpc_client
-            .syncing()
+        self.send_request(StarknetJsonRpcMethod::Syncing, SyncingRequest)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get syncing status: {}", e))
+            .map_err(|e| anyhow!("Failed to get syncing status: {e}"))
     }
 
     pub async fn get_nonce(&self, block_id: BlockId, contract_address: Felt) -> Result<Felt> {
-        self.rpc_client
-            .get_nonce(block_id, contract_address)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get nonce: {}", e))
+        self.send_request(
+            StarknetJsonRpcMethod::GetNonce,
+            GetNonceRequestRef {
+                block_id: block_id.as_ref(),
+                contract_address: contract_address.as_ref(),
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to get nonce: {e}"))
     }
 
     // Trace API methods
 
-    pub async fn trace_transaction(&self, transaction_hash: TxHash) -> Result<TransactionTrace> {
-        self.rpc_client
-            .trace_transaction(transaction_hash)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to trace transaction: {}", e))
+    pub async fn trace_transaction(&self, transaction_hash: TxHash) -> Result<Value> {
+        self.send_request(
+            StarknetJsonRpcMethod::TraceTransaction,
+            TraceTransactionRequestRef { transaction_hash: transaction_hash.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to trace transaction: {e}"))
     }
 
-    pub async fn trace_block_transactions(
-        &self,
-        block_id: BlockId,
-    ) -> Result<Vec<TransactionTraceWithHash>> {
-        self.rpc_client
-            .trace_block_transactions(block_id)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to trace block transactions: {}", e))
+    pub async fn trace_block_transactions(&self, block_id: BlockId) -> Result<Vec<Value>> {
+        self.send_request(
+            StarknetJsonRpcMethod::TraceBlockTransactions,
+            TraceBlockTransactionsRequestRef { block_id: block_id.as_ref() },
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to trace block transactions: {e}"))
     }
 }


### PR DESCRIPTION
Deserialize the JSON-RPC response object as a raw JSON to make the client compatible with other Starknet RPC spec. 

Currently, we deserialize the response as concrete types from `starknet-rs` crate. The crate only supports a single RPC spec at a time so the types are bounded to a single RPC spec. Meaning the client is only compatible when interacting the a server of a similar spec. 

Deserializing as raw JSON makes the client more flexible and can be used to interact with Starknet servers regardless of the RPC spec version.