### PR TITLE
feat(utils): mock provider builder macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6922,6 +6922,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "assert_matches",
+ "async-trait",
  "futures",
  "katana-chain-spec",
  "katana-core",
@@ -6930,9 +6931,22 @@ dependencies = [
  "katana-primitives",
  "katana-provider",
  "katana-rpc",
+ "katana-utils-macro",
  "rand 0.8.5",
  "starknet 0.15.1",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "katana-utils-macro"
+version = "1.6.0-alpha.1"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "starknet 0.15.1",
+ "syn 2.0.98",
  "tokio",
 ]
 

--- a/crates/oracle/gas/Cargo.toml
+++ b/crates/oracle/gas/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 edition.workspace = true
 license.workspace = true
-license-file.workspace = true
 name = "katana-gas-oracle"
 repository.workspace = true
 version.workspace = true

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -13,10 +13,12 @@ katana-node = { workspace = true, features = [ "explorer" ] }
 katana-primitives.workspace = true
 katana-provider.workspace = true
 katana-rpc = { workspace = true, features = [ "client" ] }
+katana-utils-macro = { path = "macro" }
 
 anyhow.workspace = true
 arbitrary.workspace = true
 assert_matches.workspace = true
+async-trait.workspace = true
 futures.workspace = true
 rand.workspace = true
 starknet.workspace = true

--- a/crates/utils/examples/mock_provider.rs
+++ b/crates/utils/examples/mock_provider.rs
@@ -1,0 +1,149 @@
+//! Example demonstrating the mock_provider macro for creating mock Provider implementations.
+//!
+//! This example shows how to use the `mock_provider!` macro to create mock implementations
+//! of the Starknet Provider trait for testing purposes.
+//!
+//! Run this example with:
+//! ```bash
+//! cargo run --example mock_provider_example
+//! ```
+
+use katana_utils::mock_provider;
+use starknet::core::types::{
+    BlockId, BlockTag, Felt, L1DataAvailabilityMode, MaybePendingBlockWithTxs, PendingBlockWithTxs,
+    ResourcePrice,
+};
+use starknet::providers::Provider;
+
+// Create a mock provider that only implements a few specific methods
+mock_provider! {
+    MyMockProvider,
+
+    // Mock the get_block_with_txs method
+    fn get_block_with_txs: (block_id) => {
+        println!("Mock get_block_with_txs called");
+        Ok(MaybePendingBlockWithTxs::PendingBlock(PendingBlockWithTxs {
+            transactions: vec![],
+            timestamp: 1234567890,
+            l1_gas_price: ResourcePrice { price_in_fri: Felt::from(100u32), price_in_wei: Felt::from(200u32) },
+            l1_data_gas_price: ResourcePrice { price_in_fri: Felt::from(50u32), price_in_wei: Felt::from(75u32) },
+            l2_gas_price: ResourcePrice { price_in_fri: Felt::from(25u32), price_in_wei: Felt::from(30u32) },
+            parent_hash: Felt::from(42u32),
+            sequencer_address: Felt::from(123u32),
+            starknet_version: "0.13.0".to_string(),
+            l1_da_mode: L1DataAvailabilityMode::Calldata,
+        }))
+    },
+
+    // Mock the get_storage_at method
+    fn get_storage_at: (contract_address, key, block_id) => {
+        println!("Mock get_storage_at called with:");
+        println!("  contract_address: {}", contract_address.as_ref());
+        println!("  key: {}", key.as_ref());
+        println!("  block_id called");
+
+        // Return a mock storage value
+        Ok(Felt::from(999u32))
+    },
+
+    // Mock the chain_id method
+    fn chain_id: () => {
+        println!("Mock chain_id called");
+        Ok(Felt::from(1u32)) // Return mock chain ID
+    },
+
+    // Mock the block_number method
+    fn block_number: () => {
+        println!("Mock block_number called");
+        Ok(12345u64) // Return mock block number
+    }
+}
+
+// Create another mock provider with different implementations
+mock_provider! {
+    DifferentMockProvider,
+
+    // This provider only implements chain_id differently
+    fn chain_id: () => {
+        println!("Different mock chain_id called");
+        Ok(Felt::from(999u32)) // Different chain ID
+    },
+
+    // And a different block_number
+    fn block_number: () => {
+        println!("Different mock block_number called");
+        Ok(54321u64) // Different block number
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🚀 Mock Provider Example");
+    println!("========================\n");
+
+    // Create instances of our mock providers
+    let mock_provider_1 = MyMockProvider::new();
+    let mock_provider_2 = DifferentMockProvider::new();
+
+    println!("1. Testing MyMockProvider:");
+    println!("--------------------------");
+
+    // Test implemented methods
+    println!("📋 Testing implemented methods:");
+
+    let chain_id = mock_provider_1.chain_id().await?;
+    println!("✅ Chain ID: {}", chain_id);
+
+    let block_number = mock_provider_1.block_number().await?;
+    println!("✅ Block number: {}", block_number);
+
+    let storage_value = mock_provider_1
+        .get_storage_at(Felt::from(0x123u32), Felt::from(0x456u32), BlockId::Tag(BlockTag::Latest))
+        .await?;
+    println!("✅ Storage value: {}", storage_value);
+
+    let block = mock_provider_1.get_block_with_txs(BlockId::Tag(BlockTag::Latest)).await?;
+    println!("✅ Block retrieved: {:?}", block);
+
+    println!("\n❌ Testing unimplemented method:");
+
+    // Test unimplemented method (this will panic with unimplemented!)
+    println!("Attempting to call spec_version() - this should panic...");
+
+    // Catch the panic to demonstrate the behavior
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { mock_provider_1.spec_version().await })
+    }));
+
+    if result.is_err() {
+        println!("✅ Unimplemented method correctly panicked!");
+    }
+
+    println!("\n2. Testing DifferentMockProvider:");
+    println!("---------------------------------");
+
+    let chain_id_2 = mock_provider_2.chain_id().await?;
+    println!("✅ Chain ID: {}", chain_id_2);
+
+    let block_number_2 = mock_provider_2.block_number().await?;
+    println!("✅ Block number: {}", block_number_2);
+
+    println!("\n3. Demonstrating different behaviors:");
+    println!("------------------------------------");
+    println!("MyMockProvider chain_id: {}", mock_provider_1.chain_id().await?);
+    println!("DifferentMockProvider chain_id: {}", mock_provider_2.chain_id().await?);
+    println!("MyMockProvider block_number: {}", mock_provider_1.block_number().await?);
+    println!("DifferentMockProvider block_number: {}", mock_provider_2.block_number().await?);
+
+    println!("\n✨ Example completed successfully!");
+    println!("\nKey takeaways:");
+    println!("- The mock_provider! macro generates a full Provider implementation");
+    println!("- You only need to implement the methods you care about for testing");
+    println!("- Unimplemented methods will panic with a clear error message");
+    println!("- Each mock provider can have different implementations");
+    println!("- The generated structs implement Default and Debug traits");
+
+    Ok(())
+}

--- a/crates/utils/examples/mock_provider.rs
+++ b/crates/utils/examples/mock_provider.rs
@@ -35,14 +35,14 @@ mock_provider! {
         }))
     },
 
-    // Mock the get_storage_at method
-    fn get_storage_at: (contract_address, key, block_id) => {
-        println!("Mock get_storage_at called with:");
-        println!("  contract_address: {}", contract_address.as_ref());
-        println!("  key: {}", key.as_ref());
-        println!("  block_id called");
+    // Mock the get_storage_at method using custom parameter names
+    fn get_storage_at: (addr, storage_key, block) => {
+        println!("Mock get_storage_at called with custom parameter names:");
+        println!("  addr: {}", addr.as_ref());
+        println!("  storage_key: {}", storage_key.as_ref());
+        println!("  block called");
 
-        // Return a mock storage value
+        // Return a mock storage value using custom parameter names
         Ok(Felt::from(999u32))
     },
 
@@ -59,7 +59,7 @@ mock_provider! {
     }
 }
 
-// Create another mock provider with different implementations
+// Create another mock provider with different implementations and custom parameter names
 mock_provider! {
     DifferentMockProvider,
 
@@ -73,6 +73,12 @@ mock_provider! {
     fn block_number: () => {
         println!("Different mock block_number called");
         Ok(54321u64) // Different block number
+    },
+
+    // Example with very descriptive custom parameter names
+    fn get_nonce: (at_block_identifier, for_account_address) => {
+        println!("Getting nonce for account: {}", for_account_address.as_ref());
+        Ok(Felt::from(42u32))
     }
 }
 
@@ -137,10 +143,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("MyMockProvider block_number: {}", mock_provider_1.block_number().await?);
     println!("DifferentMockProvider block_number: {}", mock_provider_2.block_number().await?);
 
+    println!("\n4. Testing custom parameter names:");
+    println!("----------------------------------");
+    let nonce =
+        mock_provider_2.get_nonce(BlockId::Tag(BlockTag::Latest), Felt::from(0x1234u32)).await?;
+    println!("✅ Nonce from custom params: {}", nonce);
+
     println!("\n✨ Example completed successfully!");
     println!("\nKey takeaways:");
     println!("- The mock_provider! macro generates a full Provider implementation");
     println!("- You only need to implement the methods you care about for testing");
+    println!("- You can use custom parameter names instead of the exact trait names");
     println!("- Unimplemented methods will panic with a clear error message");
     println!("- Each mock provider can have different implementations");
     println!("- The generated structs implement Default and Debug traits");

--- a/crates/utils/macro/Cargo.toml
+++ b/crates/utils/macro/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+edition.workspace = true
+license.workspace = true
+name = "katana-utils-macro"
+repository.workspace = true
+version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = [ "extra-traits", "full", "parsing", "proc-macro" ] }
+
+[dev-dependencies]
+async-trait.workspace = true
+starknet.workspace = true
+tokio = { workspace = true, features = [ "test-util" ] }

--- a/crates/utils/macro/README.md
+++ b/crates/utils/macro/README.md
@@ -1,0 +1,180 @@
+# Katana Test Utils Macro
+
+This crate provides procedural macros for creating mock implementations of traits for testing purposes.
+
+## Overview
+
+The `mock_provider!` macro allows you to create mock implementations of the Starknet `Provider` trait with minimal boilerplate. You only need to implement the methods you care about for your specific tests - all other methods will automatically use `unimplemented!()` as a placeholder.
+
+## Usage
+
+### Basic Example
+
+```rust
+use katana_utils::mock_provider;
+use starknet::core::types::{BlockId, Felt};
+use starknet::providers::Provider;
+
+mock_provider! {
+    MyMockProvider,
+
+    fn get_storage_at: (contract_address, key, block_id) => {
+        // Your custom implementation here
+        Ok(Felt::from(42u32))
+    },
+
+    fn chain_id: () => {
+        Ok(Felt::from(1u32))
+    }
+}
+
+#[tokio::test]
+async fn test_my_mock_provider() {
+    let provider = MyMockProvider::new();
+
+    // Test implemented methods
+    let storage = provider.get_storage_at(
+        Felt::from(1u32),
+        Felt::from(2u32),
+        BlockId::Tag(BlockTag::Latest)
+    ).await.unwrap();
+    assert_eq!(storage, Felt::from(42u32));
+
+    let chain_id = provider.chain_id().await.unwrap();
+    assert_eq!(chain_id, Felt::from(1u32));
+
+    // Unimplemented methods will panic with a clear error message
+    // provider.spec_version().await; // This would panic!
+}
+```
+
+### Multiple Mock Providers
+
+You can create multiple mock providers with different implementations:
+
+```rust
+mock_provider! {
+    TestnetMockProvider,
+
+    fn chain_id: () => {
+        Ok(Felt::from(1u32))
+    },
+
+    fn block_number: () => {
+        Ok(12345u64)
+    }
+}
+
+mock_provider! {
+    LocalMockProvider,
+
+    fn chain_id: () => {
+        Ok(Felt::from(1536727068981429685321u128))
+    },
+
+    fn block_number: () => {
+        Ok(1u64)
+    }
+}
+```
+
+## Syntax
+
+The macro follows this syntax:
+
+```rust
+mock_provider! {
+    StructName,
+
+    fn method_name: (param1, param2, ...) => {
+        // Method implementation
+        // Must return the appropriate Result type
+    },
+
+    fn another_method: (param) => {
+        // Another implementation
+    }
+}
+```
+
+### Key Points
+
+1. **Struct Name**: The first parameter is the name of the struct to generate
+2. **fn Keyword**: Each method must be prefixed with the `fn` keyword
+3. **Method Signature**: You only need to specify the parameter names, not their types or the full signature
+4. **Implementation**: The body should return the appropriate `Result` type for the method
+5. **Async Methods**: All Provider methods are async, so your implementations should return the result directly (not wrapped in a Future)
+
+## Generated Code
+
+The macro generates:
+
+1. A struct with the specified name
+2. `Debug`, `Clone`, `Default` implementations
+3. A `new()` constructor method
+4. A complete `Provider` trait implementation with:
+   - Your custom implementations for specified methods
+   - `unimplemented!()` for all other methods with descriptive error messages
+
+## Supported Methods
+
+The macro supports all methods from the `starknet::providers::Provider` trait, including:
+
+- `spec_version`
+- `get_block_with_tx_hashes`
+- `get_block_with_txs`
+- `get_block_with_receipts`
+- `get_state_update`
+- `get_storage_at`
+- `get_messages_status`
+- `get_transaction_status`
+- `get_transaction_by_hash`
+- `get_transaction_by_block_id_and_index`
+- `get_transaction_receipt`
+- `get_class`
+- `get_class_hash_at`
+- `get_class_at`
+- `get_block_transaction_count`
+- `call`
+- `estimate_fee`
+- `estimate_message_fee`
+- `block_number`
+- `block_hash_and_number`
+- `chain_id`
+- `syncing`
+- `get_events`
+- `get_nonce`
+- `get_storage_proof`
+- `add_invoke_transaction`
+- `add_declare_transaction`
+- `add_deploy_account_transaction`
+- `trace_transaction`
+- `simulate_transactions`
+- `trace_block_transactions`
+- `batch_requests`
+- `estimate_fee_single`
+- `simulate_transaction`
+
+## Error Handling
+
+Methods that are not implemented will panic with a descriptive error message:
+
+```
+Method get_transaction_by_hash not implemented in mock
+```
+
+This makes it easy to identify which methods your tests are trying to use that you haven't implemented yet.
+
+## Testing
+
+To test the macro itself:
+
+```bash
+cargo test -p katana-test-utils-macro
+```
+
+To run the example:
+
+```bash
+cargo run --example mock_provider_example
+```

--- a/crates/utils/macro/README.md
+++ b/crates/utils/macro/README.md
@@ -17,12 +17,12 @@ use starknet::providers::Provider;
 
 mock_provider! {
     MyMockProvider,
-
-    fn get_storage_at: (contract_address, key, block_id) => {
-        // Your custom implementation here
+    
+    fn get_storage_at: (addr, storage_key, block) => {
+        // Your custom implementation here using custom parameter names
         Ok(Felt::from(42u32))
     },
-
+    
     fn chain_id: () => {
         Ok(Felt::from(1u32))
     }
@@ -34,8 +34,8 @@ async fn test_my_mock_provider() {
 
     // Test implemented methods
     let storage = provider.get_storage_at(
-        Felt::from(1u32),
-        Felt::from(2u32),
+        Felt::from(1u32), 
+        Felt::from(2u32), 
         BlockId::Tag(BlockTag::Latest)
     ).await.unwrap();
     assert_eq!(storage, Felt::from(42u32));
@@ -55,11 +55,11 @@ You can create multiple mock providers with different implementations:
 ```rust
 mock_provider! {
     TestnetMockProvider,
-
+    
     fn chain_id: () => {
-        Ok(Felt::from(1u32))
+        Ok(Felt::from(1u32)) // Mainnet
     },
-
+    
     fn block_number: () => {
         Ok(12345u64)
     }
@@ -67,13 +67,18 @@ mock_provider! {
 
 mock_provider! {
     LocalMockProvider,
-
+    
     fn chain_id: () => {
-        Ok(Felt::from(1536727068981429685321u128))
+        Ok(Felt::from(1536727068981429685321u128)) // Local testnet
     },
-
+    
     fn block_number: () => {
         Ok(1u64)
+    },
+    
+    // Example with custom parameter names
+    fn get_storage_at: (contract_addr, key_value, at_block) => {
+        Ok(contract_addr.as_ref() + key_value.as_ref())
     }
 }
 ```
@@ -85,14 +90,14 @@ The macro follows this syntax:
 ```rust
 mock_provider! {
     StructName,
-
-    fn method_name: (param1, param2, ...) => {
-        // Method implementation
+    
+    fn method_name: (custom_param1, custom_param2, ...) => {
+        // Method implementation using your custom parameter names
         // Must return the appropriate Result type
     },
-
-    fn another_method: (param) => {
-        // Another implementation
+    
+    fn another_method: (my_param) => {
+        // Another implementation with custom parameter name
     }
 }
 ```
@@ -101,9 +106,10 @@ mock_provider! {
 
 1. **Struct Name**: The first parameter is the name of the struct to generate
 2. **fn Keyword**: Each method must be prefixed with the `fn` keyword
-3. **Method Signature**: You only need to specify the parameter names, not their types or the full signature
-4. **Implementation**: The body should return the appropriate `Result` type for the method
-5. **Async Methods**: All Provider methods are async, so your implementations should return the result directly (not wrapped in a Future)
+3. **Custom Parameter Names**: You can use any parameter names you want - they don't need to match the exact Provider trait parameter names
+4. **Method Signature**: You only need to specify the parameter names, not their types or the full signature
+5. **Implementation**: The body should return the appropriate `Result` type for the method
+6. **Async Methods**: All Provider methods are async, so your implementations should return the result directly (not wrapped in a Future)
 
 ## Generated Code
 

--- a/crates/utils/macro/src/lib.rs
+++ b/crates/utils/macro/src/lib.rs
@@ -1,0 +1,60 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+//! Procedural macros for creating mock implementations of traits for testing.
+
+use proc_macro::TokenStream;
+
+mod mock_provider;
+
+/// A procedural macro for creating mock implementations of the Provider trait.
+///
+/// The macro allows you to create mock implementations of the Starknet
+/// [`Provider`](starknet::providers::Provider) trait with minimal boilerplate.
+///
+/// # Usage
+///
+/// ```ignore
+/// use katana_utils::mock_provider;
+/// use starknet::core::types::{BlockId, Felt};
+/// use starknet::providers::Provider;
+///
+/// mock_provider! {
+///     MyMockProvider,
+///
+///     fn get_storage_at: (contract_address, key, block_id) => {
+///         Ok(Felt::from(42u32))
+///     },
+///
+///     fn chain_id: () => {
+///         Ok(Felt::from(1u32))
+///     }
+/// }
+///
+/// #[tokio::test]
+/// async fn test_mock_provider() {
+///     let provider = MyMockProvider::new();
+///     let storage = provider
+///         .get_storage_at(
+///             Felt::from(1u32),
+///             Felt::from(2u32),
+///             BlockId::Tag(starknet::core::types::BlockTag::Latest),
+///         )
+///         .await
+///         .unwrap();
+///     assert_eq!(storage, Felt::from(42u32));
+/// }
+/// ```
+///
+/// This will generate:
+/// - A struct with the specified name
+/// - A Provider trait implementation with your custom methods
+/// - `unimplemented!()` for all other Provider methods
+#[proc_macro]
+pub fn mock_provider(input: TokenStream) -> TokenStream {
+    use mock_provider::{generate_mock_provider, MockProviderInput};
+
+    match syn::parse::<MockProviderInput>(input) {
+        Ok(input) => generate_mock_provider(input).into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/crates/utils/macro/src/lib.rs
+++ b/crates/utils/macro/src/lib.rs
@@ -2,8 +2,6 @@
 
 //! Procedural macros for creating mock implementations of traits for testing.
 
-use proc_macro::TokenStream;
-
 mod mock_provider;
 
 /// A procedural macro for creating mock implementations of the Provider trait.
@@ -50,11 +48,6 @@ mod mock_provider;
 /// - A Provider trait implementation with your custom methods
 /// - `unimplemented!()` for all other Provider methods
 #[proc_macro]
-pub fn mock_provider(input: TokenStream) -> TokenStream {
-    use mock_provider::{generate_mock_provider, MockProviderInput};
-
-    match syn::parse::<MockProviderInput>(input) {
-        Ok(input) => generate_mock_provider(input).into(),
-        Err(err) => err.to_compile_error().into(),
-    }
+pub fn mock_provider(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    mock_provider::mock_provider_impl(input.into()).into()
 }

--- a/crates/utils/macro/src/mock_provider.rs
+++ b/crates/utils/macro/src/mock_provider.rs
@@ -7,8 +7,8 @@ use syn::{Ident, Result, Token};
 /// mock_provider macro entry
 pub fn mock_provider_impl(input: TokenStream) -> TokenStream {
     match syn::parse2::<MockProviderInput>(input) {
-        Ok(input) => generate_mock_provider(input).into(),
-        Err(err) => err.to_compile_error().into(),
+        Ok(input) => generate_mock_provider(input),
+        Err(err) => err.to_compile_error(),
     }
 }
 
@@ -27,16 +27,43 @@ fn generate_mock_provider(input: MockProviderInput) -> TokenStream {
 }
 
 /// Parsed input for the mock_provider macro
-pub struct MockProviderInput {
+struct MockProviderInput {
     struct_name: Ident,
     methods: Vec<MockMethod>,
 }
 
 /// A single method implementation in the mock
-pub struct MockMethod {
+struct MockMethod {
     name: Ident,
-    params: Vec<Ident>,
+    params: Vec<ParamIdent>,
     body: TokenStream,
+}
+
+/// Parameter identifier that can be either an Ident or underscore
+#[derive(Clone)]
+enum ParamIdent {
+    Ident(Ident),
+    Underscore,
+}
+
+impl Parse for ParamIdent {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        if input.peek(Token![_]) {
+            input.parse::<Token![_]>()?;
+            Ok(ParamIdent::Underscore)
+        } else {
+            let ident: Ident = input.parse()?;
+            Ok(ParamIdent::Ident(ident))
+        }
+    }
+}
+
+/// Convert a [`ParamIdent`] to a TokenStream
+fn param_to_token(param: &ParamIdent) -> TokenStream {
+    match param {
+        ParamIdent::Ident(ident) => quote! { #ident },
+        ParamIdent::Underscore => quote! { _ },
+    }
 }
 
 impl Parse for MockProviderInput {
@@ -65,7 +92,7 @@ impl Parse for MockMethod {
         let content;
         syn::parenthesized!(content in input);
         let params =
-            Punctuated::<Ident, Token![,]>::parse_terminated(&content)?.into_iter().collect();
+            Punctuated::<ParamIdent, Token![,]>::parse_terminated(&content)?.into_iter().collect();
 
         input.parse::<Token![=>]>()?;
         let body;
@@ -370,87 +397,87 @@ fn get_all_provider_methods() -> Vec<ProviderMethod> {
 }
 
 /// Generate custom parameter list using user's parameter names with correct Provider trait types
-fn generate_custom_params(method_name: &Ident, user_params: &[Ident]) -> TokenStream {
+fn generate_custom_params(method_name: &Ident, user_params: &[ParamIdent]) -> TokenStream {
     let method_name_str = method_name.to_string();
 
     match method_name_str.as_str() {
         "spec_version" => quote! { (&self) },
         "get_block_with_tx_hashes" => {
-            let block_param = &user_params[0];
+            let block_param = param_to_token(&user_params[0]);
             quote! { <B>(&self, #block_param: B) }
         }
         "get_block_with_txs" => {
-            let block_param = &user_params[0];
+            let block_param = param_to_token(&user_params[0]);
             quote! { <B>(&self, #block_param: B) }
         }
         "get_block_with_receipts" => {
-            let block_param = &user_params[0];
+            let block_param = param_to_token(&user_params[0]);
             quote! { <B>(&self, #block_param: B) }
         }
         "get_state_update" => {
-            let block_param = &user_params[0];
+            let block_param = param_to_token(&user_params[0]);
             quote! { <B>(&self, #block_param: B) }
         }
         "get_storage_at" => {
-            let contract_param = &user_params[0];
-            let key_param = &user_params[1];
-            let block_param = &user_params[2];
+            let contract_param = param_to_token(&user_params[0]);
+            let key_param = param_to_token(&user_params[1]);
+            let block_param = param_to_token(&user_params[2]);
             quote! { <A, K, B>(&self, #contract_param: A, #key_param: K, #block_param: B) }
         }
         "get_messages_status" => {
-            let tx_hash_param = &user_params[0];
+            let tx_hash_param = param_to_token(&user_params[0]);
             quote! { (&self, #tx_hash_param: starknet::core::types::Hash256) }
         }
         "get_transaction_status" => {
-            let tx_hash_param = &user_params[0];
+            let tx_hash_param = param_to_token(&user_params[0]);
             quote! { <H>(&self, #tx_hash_param: H) }
         }
         "get_transaction_by_hash" => {
-            let tx_hash_param = &user_params[0];
+            let tx_hash_param = param_to_token(&user_params[0]);
             quote! { <H>(&self, #tx_hash_param: H) }
         }
         "get_transaction_by_block_id_and_index" => {
-            let block_param = &user_params[0];
-            let index_param = &user_params[1];
+            let block_param = param_to_token(&user_params[0]);
+            let index_param = param_to_token(&user_params[1]);
             quote! { <B>(&self, #block_param: B, #index_param: u64) }
         }
         "get_transaction_receipt" => {
-            let tx_hash_param = &user_params[0];
+            let tx_hash_param = param_to_token(&user_params[0]);
             quote! { <H>(&self, #tx_hash_param: H) }
         }
         "get_class" => {
-            let block_param = &user_params[0];
-            let class_hash_param = &user_params[1];
+            let block_param = param_to_token(&user_params[0]);
+            let class_hash_param = param_to_token(&user_params[1]);
             quote! { <B, H>(&self, #block_param: B, #class_hash_param: H) }
         }
         "get_class_hash_at" => {
-            let block_param = &user_params[0];
-            let contract_param = &user_params[1];
+            let block_param = param_to_token(&user_params[0]);
+            let contract_param = param_to_token(&user_params[1]);
             quote! { <B, A>(&self, #block_param: B, #contract_param: A) }
         }
         "get_class_at" => {
-            let block_param = &user_params[0];
-            let contract_param = &user_params[1];
+            let block_param = param_to_token(&user_params[0]);
+            let contract_param = param_to_token(&user_params[1]);
             quote! { <B, A>(&self, #block_param: B, #contract_param: A) }
         }
         "get_block_transaction_count" => {
-            let block_param = &user_params[0];
+            let block_param = param_to_token(&user_params[0]);
             quote! { <B>(&self, #block_param: B) }
         }
         "call" => {
-            let request_param = &user_params[0];
-            let block_param = &user_params[1];
+            let request_param = param_to_token(&user_params[0]);
+            let block_param = param_to_token(&user_params[1]);
             quote! { <R, B>(&self, #request_param: R, #block_param: B) }
         }
         "estimate_fee" => {
-            let request_param = &user_params[0];
-            let flags_param = &user_params[1];
-            let block_param = &user_params[2];
+            let request_param = param_to_token(&user_params[0]);
+            let flags_param = param_to_token(&user_params[1]);
+            let block_param = param_to_token(&user_params[2]);
             quote! { <R, S, B>(&self, #request_param: R, #flags_param: S, #block_param: B) }
         }
         "estimate_message_fee" => {
-            let message_param = &user_params[0];
-            let block_param = &user_params[1];
+            let message_param = param_to_token(&user_params[0]);
+            let block_param = param_to_token(&user_params[1]);
             quote! { <M, B>(&self, #message_param: M, #block_param: B) }
         }
         "block_number" => quote! { (&self) },
@@ -458,63 +485,63 @@ fn generate_custom_params(method_name: &Ident, user_params: &[Ident]) -> TokenSt
         "chain_id" => quote! { (&self) },
         "syncing" => quote! { (&self) },
         "get_events" => {
-            let filter_param = &user_params[0];
-            let token_param = &user_params[1];
-            let chunk_param = &user_params[2];
+            let filter_param = param_to_token(&user_params[0]);
+            let token_param = param_to_token(&user_params[1]);
+            let chunk_param = param_to_token(&user_params[2]);
             quote! { (&self, #filter_param: starknet::core::types::EventFilter, #token_param: Option<String>, #chunk_param: u64) }
         }
         "get_nonce" => {
-            let block_param = &user_params[0];
-            let contract_param = &user_params[1];
+            let block_param = param_to_token(&user_params[0]);
+            let contract_param = param_to_token(&user_params[1]);
             quote! { <B, A>(&self, #block_param: B, #contract_param: A) }
         }
         "get_storage_proof" => {
-            let block_param = &user_params[0];
-            let class_hashes_param = &user_params[1];
-            let contract_addresses_param = &user_params[2];
-            let storage_keys_param = &user_params[3];
+            let block_param = param_to_token(&user_params[0]);
+            let class_hashes_param = param_to_token(&user_params[1]);
+            let contract_addresses_param = param_to_token(&user_params[2]);
+            let storage_keys_param = param_to_token(&user_params[3]);
             quote! { <B, H, A, K>(&self, #block_param: B, #class_hashes_param: H, #contract_addresses_param: A, #storage_keys_param: K) }
         }
         "add_invoke_transaction" => {
-            let tx_param = &user_params[0];
+            let tx_param = param_to_token(&user_params[0]);
             quote! { <I>(&self, #tx_param: I) }
         }
         "add_declare_transaction" => {
-            let tx_param = &user_params[0];
+            let tx_param = param_to_token(&user_params[0]);
             quote! { <D>(&self, #tx_param: D) }
         }
         "add_deploy_account_transaction" => {
-            let tx_param = &user_params[0];
+            let tx_param = param_to_token(&user_params[0]);
             quote! { <D>(&self, #tx_param: D) }
         }
         "trace_transaction" => {
-            let tx_hash_param = &user_params[0];
+            let tx_hash_param = param_to_token(&user_params[0]);
             quote! { <H>(&self, #tx_hash_param: H) }
         }
         "simulate_transactions" => {
-            let block_param = &user_params[0];
-            let txs_param = &user_params[1];
-            let flags_param = &user_params[2];
+            let block_param = param_to_token(&user_params[0]);
+            let txs_param = param_to_token(&user_params[1]);
+            let flags_param = param_to_token(&user_params[2]);
             quote! { <B, T, S>(&self, #block_param: B, #txs_param: T, #flags_param: S) }
         }
         "trace_block_transactions" => {
-            let block_param = &user_params[0];
+            let block_param = param_to_token(&user_params[0]);
             quote! { <B>(&self, #block_param: B) }
         }
         "batch_requests" => {
-            let requests_param = &user_params[0];
+            let requests_param = param_to_token(&user_params[0]);
             quote! { <R>(&self, #requests_param: R) }
         }
         "estimate_fee_single" => {
-            let request_param = &user_params[0];
-            let flags_param = &user_params[1];
-            let block_param = &user_params[2];
+            let request_param = param_to_token(&user_params[0]);
+            let flags_param = param_to_token(&user_params[1]);
+            let block_param = param_to_token(&user_params[2]);
             quote! { <R, S, B>(&self, #request_param: R, #flags_param: S, #block_param: B) }
         }
         "simulate_transaction" => {
-            let block_param = &user_params[0];
-            let tx_param = &user_params[1];
-            let flags_param = &user_params[2];
+            let block_param = param_to_token(&user_params[0]);
+            let tx_param = param_to_token(&user_params[1]);
+            let flags_param = param_to_token(&user_params[2]);
             quote! { <B, T, S>(&self, #block_param: B, #tx_param: T, #flags_param: S) }
         }
         _ => {

--- a/crates/utils/macro/src/mock_provider.rs
+++ b/crates/utils/macro/src/mock_provider.rs
@@ -1,0 +1,360 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Ident, Result, Token};
+
+/// Parsed input for the mock_provider macro
+pub struct MockProviderInput {
+    struct_name: Ident,
+    methods: Vec<MockMethod>,
+}
+
+/// A single method implementation in the mock
+pub struct MockMethod {
+    name: Ident,
+    params: Vec<Ident>,
+    body: TokenStream2,
+}
+
+impl Parse for MockProviderInput {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let struct_name: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let mut methods = Vec::new();
+        while !input.is_empty() {
+            methods.push(input.parse()?);
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(MockProviderInput { struct_name, methods })
+    }
+}
+
+impl Parse for MockMethod {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        input.parse::<Token![fn]>()?;
+        let name: Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+
+        let content;
+        syn::parenthesized!(content in input);
+        let params =
+            Punctuated::<Ident, Token![,]>::parse_terminated(&content)?.into_iter().collect();
+
+        input.parse::<Token![=>]>()?;
+        let body;
+        syn::braced!(body in input);
+        let body: TokenStream2 = body.parse()?;
+
+        Ok(MockMethod { name, params, body })
+    }
+}
+
+/// Generate the complete mock provider implementation
+pub fn generate_mock_provider(input: MockProviderInput) -> TokenStream2 {
+    let struct_name = &input.struct_name;
+    let methods = &input.methods;
+
+    let struct_def = generate_struct_definition(struct_name);
+    let provider_impl = generate_provider_impl(struct_name, methods);
+
+    quote! {
+        #struct_def
+        #provider_impl
+    }
+}
+
+/// Generate the struct definition
+fn generate_struct_definition(struct_name: &Ident) -> TokenStream2 {
+    quote! {
+        #[derive(Debug, Clone)]
+        pub struct #struct_name;
+
+        impl #struct_name {
+            pub fn new() -> Self {
+                Self
+            }
+        }
+
+        impl Default for #struct_name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    }
+}
+
+/// Generate the Provider trait implementation
+fn generate_provider_impl(struct_name: &Ident, methods: &[MockMethod]) -> TokenStream2 {
+    let all_methods = get_all_provider_methods();
+    let mut method_impls = Vec::new();
+
+    for method in &all_methods {
+        if let Some(user_method) = methods.iter().find(|m| m.name == method.name) {
+            // Use user implementation
+            method_impls.push(generate_user_method_impl(method, user_method));
+        } else {
+            // Use unimplemented!() for methods not provided by user
+            method_impls.push(generate_unimplemented_method(method));
+        }
+    }
+
+    quote! {
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        impl starknet::providers::Provider for #struct_name {
+            #(#method_impls)*
+        }
+    }
+}
+
+/// Generate a user-provided method implementation
+fn generate_user_method_impl(method: &ProviderMethod, user_method: &MockMethod) -> TokenStream2 {
+    let method_name = &method.name;
+    let return_type = &method.return_type;
+    let params = &method.params;
+    let where_clause = &method.where_clause;
+    let body = &user_method.body;
+
+    quote! {
+        async fn #method_name #params -> #return_type #where_clause {
+            #body
+        }
+    }
+}
+
+/// Generate an unimplemented method
+fn generate_unimplemented_method(method: &ProviderMethod) -> TokenStream2 {
+    let method_name = &method.name;
+    let return_type = &method.return_type;
+    let params = &method.params;
+    let where_clause = &method.where_clause;
+
+    quote! {
+        async fn #method_name #params -> #return_type #where_clause {
+            unimplemented!("Method {} not implemented in mock", stringify!(#method_name))
+        }
+    }
+}
+
+/// Represents a single method in the Provider trait
+struct ProviderMethod {
+    name: Ident,
+    params: TokenStream2,
+    return_type: TokenStream2,
+    where_clause: TokenStream2,
+}
+
+/// Get all Provider trait methods with their signatures
+fn get_all_provider_methods() -> Vec<ProviderMethod> {
+    vec![
+        ProviderMethod {
+            name: syn::parse_str("spec_version").unwrap(),
+            params: quote! { (&self) },
+            return_type: quote! { Result<String, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_block_with_tx_hashes").unwrap(),
+            params: quote! { <B>(&self, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::MaybePendingBlockWithTxHashes, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_block_with_txs").unwrap(),
+            params: quote! { <B>(&self, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::MaybePendingBlockWithTxs, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_block_with_receipts").unwrap(),
+            params: quote! { <B>(&self, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::MaybePendingBlockWithReceipts, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_state_update").unwrap(),
+            params: quote! { <B>(&self, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::MaybePendingStateUpdate, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_storage_at").unwrap(),
+            params: quote! { <A, K, B>(&self, contract_address: A, key: K, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::Felt, starknet::providers::ProviderError> },
+            where_clause: quote! { where A: AsRef<starknet::core::types::Felt> + Send + Sync, K: AsRef<starknet::core::types::Felt> + Send + Sync, B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_messages_status").unwrap(),
+            params: quote! { (&self, transaction_hash: starknet::core::types::Hash256) },
+            return_type: quote! { Result<Vec<starknet::core::types::MessageWithStatus>, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_transaction_status").unwrap(),
+            params: quote! { <H>(&self, transaction_hash: H) },
+            return_type: quote! { Result<starknet::core::types::TransactionStatus, starknet::providers::ProviderError> },
+            where_clause: quote! { where H: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_transaction_by_hash").unwrap(),
+            params: quote! { <H>(&self, transaction_hash: H) },
+            return_type: quote! { Result<starknet::core::types::Transaction, starknet::providers::ProviderError> },
+            where_clause: quote! { where H: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_transaction_by_block_id_and_index").unwrap(),
+            params: quote! { <B>(&self, block_id: B, index: u64) },
+            return_type: quote! { Result<starknet::core::types::Transaction, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_transaction_receipt").unwrap(),
+            params: quote! { <H>(&self, transaction_hash: H) },
+            return_type: quote! { Result<starknet::core::types::TransactionReceiptWithBlockInfo, starknet::providers::ProviderError> },
+            where_clause: quote! { where H: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_class").unwrap(),
+            params: quote! { <B, H>(&self, block_id: B, class_hash: H) },
+            return_type: quote! { Result<starknet::core::types::ContractClass, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync, H: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_class_hash_at").unwrap(),
+            params: quote! { <B, A>(&self, block_id: B, contract_address: A) },
+            return_type: quote! { Result<starknet::core::types::Felt, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync, A: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_class_at").unwrap(),
+            params: quote! { <B, A>(&self, block_id: B, contract_address: A) },
+            return_type: quote! { Result<starknet::core::types::ContractClass, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync, A: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_block_transaction_count").unwrap(),
+            params: quote! { <B>(&self, block_id: B) },
+            return_type: quote! { Result<u64, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("call").unwrap(),
+            params: quote! { <R, B>(&self, request: R, block_id: B) },
+            return_type: quote! { Result<Vec<starknet::core::types::Felt>, starknet::providers::ProviderError> },
+            where_clause: quote! { where R: AsRef<starknet::core::types::FunctionCall> + Send + Sync, B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("estimate_fee").unwrap(),
+            params: quote! { <R, S, B>(&self, request: R, simulation_flags: S, block_id: B) },
+            return_type: quote! { Result<Vec<starknet::core::types::FeeEstimate>, starknet::providers::ProviderError> },
+            where_clause: quote! { where R: AsRef<[starknet::core::types::BroadcastedTransaction]> + Send + Sync, S: AsRef<[starknet::core::types::SimulationFlagForEstimateFee]> + Send + Sync, B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("estimate_message_fee").unwrap(),
+            params: quote! { <M, B>(&self, message: M, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::FeeEstimate, starknet::providers::ProviderError> },
+            where_clause: quote! { where M: AsRef<starknet::core::types::MsgFromL1> + Send + Sync, B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("block_number").unwrap(),
+            params: quote! { (&self) },
+            return_type: quote! { Result<u64, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("block_hash_and_number").unwrap(),
+            params: quote! { (&self) },
+            return_type: quote! { Result<starknet::core::types::BlockHashAndNumber, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("chain_id").unwrap(),
+            params: quote! { (&self) },
+            return_type: quote! { Result<starknet::core::types::Felt, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("syncing").unwrap(),
+            params: quote! { (&self) },
+            return_type: quote! { Result<starknet::core::types::SyncStatusType, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_events").unwrap(),
+            params: quote! { (&self, filter: starknet::core::types::EventFilter, continuation_token: Option<String>, chunk_size: u64) },
+            return_type: quote! { Result<starknet::core::types::EventsPage, starknet::providers::ProviderError> },
+            where_clause: quote! {},
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_nonce").unwrap(),
+            params: quote! { <B, A>(&self, block_id: B, contract_address: A) },
+            return_type: quote! { Result<starknet::core::types::Felt, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync, A: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("get_storage_proof").unwrap(),
+            params: quote! { <B, H, A, K>(&self, block_id: B, class_hashes: H, contract_addresses: A, contracts_storage_keys: K) },
+            return_type: quote! { Result<starknet::core::types::StorageProof, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::ConfirmedBlockId> + Send + Sync, H: AsRef<[starknet::core::types::Felt]> + Send + Sync, A: AsRef<[starknet::core::types::Felt]> + Send + Sync, K: AsRef<[starknet::core::types::ContractStorageKeys]> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("add_invoke_transaction").unwrap(),
+            params: quote! { <I>(&self, invoke_transaction: I) },
+            return_type: quote! { Result<starknet::core::types::InvokeTransactionResult, starknet::providers::ProviderError> },
+            where_clause: quote! { where I: AsRef<starknet::core::types::BroadcastedInvokeTransaction> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("add_declare_transaction").unwrap(),
+            params: quote! { <D>(&self, declare_transaction: D) },
+            return_type: quote! { Result<starknet::core::types::DeclareTransactionResult, starknet::providers::ProviderError> },
+            where_clause: quote! { where D: AsRef<starknet::core::types::BroadcastedDeclareTransaction> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("add_deploy_account_transaction").unwrap(),
+            params: quote! { <D>(&self, deploy_account_transaction: D) },
+            return_type: quote! { Result<starknet::core::types::DeployAccountTransactionResult, starknet::providers::ProviderError> },
+            where_clause: quote! { where D: AsRef<starknet::core::types::BroadcastedDeployAccountTransaction> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("trace_transaction").unwrap(),
+            params: quote! { <H>(&self, transaction_hash: H) },
+            return_type: quote! { Result<starknet::core::types::TransactionTrace, starknet::providers::ProviderError> },
+            where_clause: quote! { where H: AsRef<starknet::core::types::Felt> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("simulate_transactions").unwrap(),
+            params: quote! { <B, T, S>(&self, block_id: B, transactions: T, simulation_flags: S) },
+            return_type: quote! { Result<Vec<starknet::core::types::SimulatedTransaction>, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync, T: AsRef<[starknet::core::types::BroadcastedTransaction]> + Send + Sync, S: AsRef<[starknet::core::types::SimulationFlag]> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("trace_block_transactions").unwrap(),
+            params: quote! { <B>(&self, block_id: B) },
+            return_type: quote! { Result<Vec<starknet::core::types::TransactionTraceWithHash>, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("batch_requests").unwrap(),
+            params: quote! { <R>(&self, requests: R) },
+            return_type: quote! { Result<Vec<starknet::providers::ProviderResponseData>, starknet::providers::ProviderError> },
+            where_clause: quote! { where R: AsRef<[starknet::providers::ProviderRequestData]> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("estimate_fee_single").unwrap(),
+            params: quote! { <R, S, B>(&self, request: R, simulation_flags: S, block_id: B) },
+            return_type: quote! { Result<starknet::core::types::FeeEstimate, starknet::providers::ProviderError> },
+            where_clause: quote! { where R: AsRef<starknet::core::types::BroadcastedTransaction> + Send + Sync, S: AsRef<[starknet::core::types::SimulationFlagForEstimateFee]> + Send + Sync, B: AsRef<starknet::core::types::BlockId> + Send + Sync },
+        },
+        ProviderMethod {
+            name: syn::parse_str("simulate_transaction").unwrap(),
+            params: quote! { <B, T, S>(&self, block_id: B, transaction: T, simulation_flags: S) },
+            return_type: quote! { Result<starknet::core::types::SimulatedTransaction, starknet::providers::ProviderError> },
+            where_clause: quote! { where B: AsRef<starknet::core::types::BlockId> + Send + Sync, T: AsRef<starknet::core::types::BroadcastedTransaction> + Send + Sync, S: AsRef<[starknet::core::types::SimulationFlag]> + Send + Sync },
+        },
+    ]
+}

--- a/crates/utils/macro/tests/custom_param_names.rs
+++ b/crates/utils/macro/tests/custom_param_names.rs
@@ -1,0 +1,153 @@
+use katana_utils_macro::mock_provider;
+use starknet::core::types::{BlockId, BlockTag, Felt};
+use starknet::providers::Provider;
+
+// Test that users can use custom parameter names instead of the exact Provider trait names
+mock_provider! {
+    CustomParamMock,
+
+    fn get_storage_at: (addr, storage_key, block) => {
+        // Use the custom parameter names in the implementation
+        println!("Custom params - addr: {}, key: {}", addr.as_ref(), storage_key.as_ref());
+        Ok(addr.as_ref() + storage_key.as_ref())
+    },
+
+    fn get_class_hash_at: (block_ref, contract_addr) => {
+        // Different custom names for these parameters
+        Ok(*contract_addr.as_ref())
+    },
+
+    fn chain_id: () => {
+        Ok(Felt::from(1337u32))
+    },
+
+    fn get_nonce: (block_identifier, account_address) => {
+        // Custom names that are more descriptive
+        Ok(*account_address.as_ref())
+    }
+}
+
+// Test with very short parameter names
+mock_provider! {
+    ShortParamMock,
+
+    fn get_storage_at: (a, k, b) => {
+        Ok(Felt::from(42u32))
+    },
+
+    fn get_transaction_by_block_id_and_index: (blk, idx) => {
+        // Use the custom short names
+        Ok(starknet::core::types::Transaction::Invoke(
+            starknet::core::types::InvokeTransaction::V1(
+                starknet::core::types::InvokeTransactionV1 {
+                    transaction_hash: Felt::from(idx),
+                    max_fee: Felt::from(1000u32),
+                    signature: vec![],
+                    nonce: Felt::ZERO,
+                    sender_address: Felt::from(123u32),
+                    calldata: vec![],
+                }
+            )
+        ))
+    }
+}
+
+// Test with descriptive parameter names
+mock_provider! {
+    DescriptiveParamMock,
+
+    fn estimate_fee: (transaction_request, simulation_options, at_block) => {
+        Ok(vec![starknet::core::types::FeeEstimate {
+            l1_gas_consumed: 21000u64,
+            l1_gas_price: 1000000000u128,
+            l1_data_gas_consumed: 128u64,
+            l1_data_gas_price: 1u128,
+            l2_gas_consumed: 5000u64,
+            l2_gas_price: 500000000u128,
+            overall_fee: 21000000000000u128,
+            unit: starknet::core::types::PriceUnit::Wei,
+        }])
+    }
+}
+
+#[tokio::test]
+async fn test_custom_parameter_names() {
+    let provider = CustomParamMock::new();
+
+    // Test that custom parameter names work correctly
+    let storage_value = provider
+        .get_storage_at(Felt::from(10u32), Felt::from(5u32), BlockId::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert_eq!(storage_value, Felt::from(15u32)); // 10 + 5
+
+    let class_hash = provider
+        .get_class_hash_at(BlockId::Tag(BlockTag::Latest), Felt::from(999u32))
+        .await
+        .unwrap();
+    assert_eq!(class_hash, Felt::from(999u32));
+
+    let chain_id = provider.chain_id().await.unwrap();
+    assert_eq!(chain_id, Felt::from(1337u32));
+
+    let nonce =
+        provider.get_nonce(BlockId::Tag(BlockTag::Latest), Felt::from(777u32)).await.unwrap();
+    assert_eq!(nonce, Felt::from(777u32));
+}
+
+#[tokio::test]
+async fn test_short_parameter_names() {
+    let provider = ShortParamMock::new();
+
+    let storage_value = provider
+        .get_storage_at(Felt::from(1u32), Felt::from(2u32), BlockId::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert_eq!(storage_value, Felt::from(42u32));
+
+    let transaction = provider
+        .get_transaction_by_block_id_and_index(BlockId::Tag(BlockTag::Latest), 123u64)
+        .await
+        .unwrap();
+
+    // Verify the transaction was created with the custom parameter value
+    if let starknet::core::types::Transaction::Invoke(
+        starknet::core::types::InvokeTransaction::V1(tx),
+    ) = transaction
+    {
+        assert_eq!(tx.transaction_hash, Felt::from(123u64));
+    } else {
+        panic!("Expected InvokeTransactionV1");
+    }
+}
+
+#[tokio::test]
+async fn test_descriptive_parameter_names() {
+    let provider = DescriptiveParamMock::new();
+
+    let fee_estimates = provider
+        .estimate_fee(
+            vec![], // empty transaction request
+            vec![], // empty simulation options
+            BlockId::Tag(BlockTag::Latest),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(fee_estimates.len(), 1);
+    assert_eq!(fee_estimates[0].l1_gas_consumed, 21000u64);
+}
+
+#[test]
+fn test_custom_param_provider_traits() {
+    // Test that generated structs still implement expected traits
+    let provider = CustomParamMock::new();
+    assert!(format!("{:?}", provider).contains("CustomParamMock"));
+
+    let provider2 = ShortParamMock::default();
+    assert!(format!("{:?}", provider2).contains("ShortParamMock"));
+
+    let provider3 = DescriptiveParamMock::new();
+    let cloned = provider3.clone();
+    assert!(format!("{:?}", cloned).contains("DescriptiveParamMock"));
+}

--- a/crates/utils/macro/tests/custom_param_names.rs
+++ b/crates/utils/macro/tests/custom_param_names.rs
@@ -6,13 +6,13 @@ use starknet::providers::Provider;
 mock_provider! {
     CustomParamMock,
 
-    fn get_storage_at: (addr, storage_key, block) => {
+    fn get_storage_at: (addr, storage_key, _block) => {
         // Use the custom parameter names in the implementation
         println!("Custom params - addr: {}, key: {}", addr.as_ref(), storage_key.as_ref());
         Ok(addr.as_ref() + storage_key.as_ref())
     },
 
-    fn get_class_hash_at: (block_ref, contract_addr) => {
+    fn get_class_hash_at: (_block_ref, contract_addr) => {
         // Different custom names for these parameters
         Ok(*contract_addr.as_ref())
     },
@@ -21,7 +21,7 @@ mock_provider! {
         Ok(Felt::from(1337u32))
     },
 
-    fn get_nonce: (block_identifier, account_address) => {
+    fn get_nonce: (_, account_address) => {
         // Custom names that are more descriptive
         Ok(*account_address.as_ref())
     }
@@ -31,11 +31,11 @@ mock_provider! {
 mock_provider! {
     ShortParamMock,
 
-    fn get_storage_at: (a, k, b) => {
+    fn get_storage_at: (_, _, _) => {
         Ok(Felt::from(42u32))
     },
 
-    fn get_transaction_by_block_id_and_index: (blk, idx) => {
+    fn get_transaction_by_block_id_and_index: (_, idx) => {
         // Use the custom short names
         Ok(starknet::core::types::Transaction::Invoke(
             starknet::core::types::InvokeTransaction::V1(
@@ -56,7 +56,7 @@ mock_provider! {
 mock_provider! {
     DescriptiveParamMock,
 
-    fn estimate_fee: (transaction_request, simulation_options, at_block) => {
+    fn estimate_fee: (_transaction_request, _simulation_options, _) => {
         Ok(vec![starknet::core::types::FeeEstimate {
             l1_gas_consumed: 21000u64,
             l1_gas_price: 1000000000u128,

--- a/crates/utils/macro/tests/mock_provider.rs
+++ b/crates/utils/macro/tests/mock_provider.rs
@@ -5,7 +5,7 @@ use starknet::providers::Provider;
 mock_provider! {
     TestMockProvider,
 
-    fn get_block_with_txs: (block_id) => {
+    fn get_block_with_txs: (_block_id) => {
         Ok(MaybePendingBlockWithTxs::PendingBlock(PendingBlockWithTxs {
             transactions: vec![],
             timestamp: 0,
@@ -19,7 +19,7 @@ mock_provider! {
         }))
     },
 
-    fn get_storage_at: (contract_address, key, block_id) => {
+    fn get_storage_at: (_, _, _) => {
         Ok(Felt::from(42u32))
     },
 
@@ -102,7 +102,7 @@ mock_provider! {
         Ok("0.13.0".to_string())
     },
 
-    fn get_nonce: (block_id, contract_address) => {
+    fn get_nonce: (_, _) => {
         Ok(Felt::from(1u32))
     }
 }

--- a/crates/utils/macro/tests/mock_provider.rs
+++ b/crates/utils/macro/tests/mock_provider.rs
@@ -1,0 +1,122 @@
+use katana_utils_macro::mock_provider;
+use starknet::core::types::{BlockId, Felt, MaybePendingBlockWithTxs, PendingBlockWithTxs};
+use starknet::providers::Provider;
+
+mock_provider! {
+    TestMockProvider,
+
+    fn get_block_with_txs: (block_id) => {
+        Ok(MaybePendingBlockWithTxs::PendingBlock(PendingBlockWithTxs {
+            transactions: vec![],
+            timestamp: 0,
+            l1_gas_price: starknet::core::types::ResourcePrice { price_in_fri: Felt::ZERO, price_in_wei: Felt::ZERO },
+            l1_data_gas_price: starknet::core::types::ResourcePrice { price_in_fri: Felt::ZERO, price_in_wei: Felt::ZERO },
+            l2_gas_price: starknet::core::types::ResourcePrice { price_in_fri: Felt::ZERO, price_in_wei: Felt::ZERO },
+            parent_hash: Felt::ZERO,
+            sequencer_address: Felt::ZERO,
+            starknet_version: "0.13.0".to_string(),
+            l1_da_mode: starknet::core::types::L1DataAvailabilityMode::Calldata,
+        }))
+    },
+
+    fn get_storage_at: (contract_address, key, block_id) => {
+        Ok(Felt::from(42u32))
+    },
+
+    fn chain_id: () => {
+        Ok(Felt::from(1u32))
+    }
+}
+
+#[tokio::test]
+async fn test_mock_provider_implemented_methods() {
+    let provider = TestMockProvider::new();
+
+    // Test implemented methods
+    let block_result =
+        provider.get_block_with_txs(BlockId::Tag(starknet::core::types::BlockTag::Latest)).await;
+    assert!(block_result.is_ok());
+
+    let storage_result = provider
+        .get_storage_at(
+            Felt::from(1u32),
+            Felt::from(2u32),
+            BlockId::Tag(starknet::core::types::BlockTag::Latest),
+        )
+        .await;
+    assert!(storage_result.is_ok());
+    assert_eq!(storage_result.unwrap(), Felt::from(42u32));
+
+    let chain_id_result = provider.chain_id().await;
+    assert!(chain_id_result.is_ok());
+    assert_eq!(chain_id_result.unwrap(), Felt::from(1u32));
+}
+
+#[tokio::test]
+async fn test_mock_provider_unimplemented_methods() {
+    let provider = TestMockProvider::new();
+
+    // Test unimplemented method - should panic with unimplemented!()
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tokio::runtime::Runtime::new().unwrap().block_on(async { provider.spec_version().await })
+    }));
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_mock_provider_default_construction() {
+    let provider = TestMockProvider::default();
+    let chain_id_result = provider.chain_id().await;
+    assert!(chain_id_result.is_ok());
+    assert_eq!(chain_id_result.unwrap(), Felt::from(1u32));
+}
+
+// Test that we can create multiple different mock providers
+mock_provider! {
+    AnotherMockProvider,
+
+    fn block_number: () => {
+        Ok(12345u64)
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_mock_providers() {
+    let provider1 = TestMockProvider::new();
+    let provider2 = AnotherMockProvider::new();
+
+    // Each provider should have its own implementation
+    let chain_id = provider1.chain_id().await.unwrap();
+    assert_eq!(chain_id, Felt::from(1u32));
+
+    let block_num = provider2.block_number().await.unwrap();
+    assert_eq!(block_num, 12345u64);
+}
+
+// Test that verifies the fn keyword syntax works correctly
+mock_provider! {
+    FnKeywordTestProvider,
+
+    fn spec_version: () => {
+        Ok("0.13.0".to_string())
+    },
+
+    fn get_nonce: (block_id, contract_address) => {
+        Ok(Felt::from(1u32))
+    }
+}
+
+#[tokio::test]
+async fn test_fn_keyword_syntax() {
+    let provider = FnKeywordTestProvider::new();
+
+    let spec_version = provider.spec_version().await.unwrap();
+    assert_eq!(spec_version, "0.13.0");
+
+    let nonce = provider
+        .get_nonce(BlockId::Tag(starknet::core::types::BlockTag::Latest), Felt::from(0x123u32))
+        .await
+        .unwrap();
+    assert_eq!(nonce, Felt::from(1u32));
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod node;
 mod tx_waiter;
 
+pub use katana_utils_macro::mock_provider;
 pub use node::TestNode;
 pub use tx_waiter::*;
 


### PR DESCRIPTION
Procedural macro to easily create a mock implementation of `starknet::provider::Provider` trait with as minimal boilerplate as possible.