### PR TITLE
fix(executor): map L2 gas correctly

### DIFF
--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -145,12 +145,16 @@ impl<'a> StarknetVMProcessor<'a> {
         let number = BlockNumber(header.number);
         let timestamp = BlockTimestamp(header.timestamp);
 
-        // TODO: should we enforce the gas price to not be 0,
-        // as there's a flag to disable gas uasge instead?
+        let eth_l2_gas_price = NonzeroGasPrice::new(header.l2_gas_prices.eth.get().into())
+            .unwrap_or(NonzeroGasPrice::MIN);
+        let strk_l2_gas_price = NonzeroGasPrice::new(header.l2_gas_prices.strk.get().into())
+            .unwrap_or(NonzeroGasPrice::MIN);
+
         let eth_l1_gas_price = NonzeroGasPrice::new(header.l1_gas_prices.eth.get().into())
             .unwrap_or(NonzeroGasPrice::MIN);
         let strk_l1_gas_price = NonzeroGasPrice::new(header.l1_gas_prices.strk.get().into())
             .unwrap_or(NonzeroGasPrice::MIN);
+
         let eth_l1_data_gas_price =
             NonzeroGasPrice::new(header.l1_data_gas_prices.eth.get().into())
                 .unwrap_or(NonzeroGasPrice::MIN);
@@ -169,16 +173,14 @@ impl<'a> StarknetVMProcessor<'a> {
             sequencer_address: utils::to_blk_address(header.sequencer_address),
             gas_prices: GasPrices {
                 eth_gas_prices: GasPriceVector {
+                    l2_gas_price: eth_l2_gas_price,
                     l1_gas_price: eth_l1_gas_price,
                     l1_data_gas_price: eth_l1_data_gas_price,
-                    // TODO: update to use the correct value
-                    l2_gas_price: eth_l1_gas_price,
                 },
                 strk_gas_prices: GasPriceVector {
+                    l2_gas_price: strk_l2_gas_price,
                     l1_gas_price: strk_l1_gas_price,
                     l1_data_gas_price: strk_l1_data_gas_price,
-                    // TODO: update to use the correct value
-                    l2_gas_price: strk_l1_gas_price,
                 },
             },
             use_kzg_da: false,


### PR DESCRIPTION
Currently, we're not passing the L2 gas prices from the primitive `Header` to `blockifier`'s `BlockContext` because we initially didn't have support for L2 gas prices - not until #19. The L2 gas prices parameter is introduced in Starknet RPC spec 0.8 - which only recently we have support for. And with the recent addition of Starknet gas price oracle in #152, we can finally sample the L2 gas prices correctly instead of implicitly using the L1 gas prices. 