### PR TITLE
feat: bump Starknet version to 0.13.4

### DIFF
--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -56,7 +56,7 @@ impl ChainSpec {
             l1_data_gas_prices: self.genesis.gas_prices.clone(),
             sequencer_address: self.genesis.sequencer_address,
             // keep at 0.13.1.1 for backward compatibility reason
-            starknet_version: StarknetVersion::parse("0.13.1.1").unwrap(),
+            starknet_version: StarknetVersion::new([0, 13, 1, 1]),
         };
 
         ExecutableBlock { header, body: Vec::new() }
@@ -271,7 +271,6 @@ mod tests {
         DEFAULT_LEGACY_ERC20_CLASS, DEFAULT_LEGACY_ERC20_COMPILED_CLASS_HASH,
         DEFAULT_LEGACY_UDC_CLASS, DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH,
     };
-    use katana_primitives::version::CURRENT_STARKNET_VERSION;
     use starknet::macros::felt;
 
     use super::*;
@@ -357,7 +356,7 @@ mod tests {
                 l1_gas_prices: chain_spec.genesis.gas_prices.clone(),
                 l1_data_gas_prices: chain_spec.genesis.gas_prices.clone(),
                 l1_da_mode: L1DataAvailabilityMode::Calldata,
-                starknet_version: CURRENT_STARKNET_VERSION,
+                starknet_version: StarknetVersion::new([0, 13, 1, 1]),
             },
             body: Vec::new(),
         };

--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -17,7 +17,7 @@ use katana_primitives::genesis::constant::{
 use katana_primitives::genesis::Genesis;
 use katana_primitives::state::StateUpdatesWithClasses;
 use katana_primitives::utils::split_u256;
-use katana_primitives::version::CURRENT_STARKNET_VERSION;
+use katana_primitives::version::StarknetVersion;
 use katana_primitives::Felt;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -47,7 +47,6 @@ pub struct ChainSpec {
 impl ChainSpec {
     pub fn block(&self) -> ExecutableBlock {
         let header = PartialHeader {
-            starknet_version: CURRENT_STARKNET_VERSION,
             number: self.genesis.number,
             timestamp: self.genesis.timestamp,
             parent_hash: self.genesis.parent_hash,
@@ -56,6 +55,8 @@ impl ChainSpec {
             l2_gas_prices: GasPrices::MIN,
             l1_data_gas_prices: self.genesis.gas_prices.clone(),
             sequencer_address: self.genesis.sequencer_address,
+            // keep at 0.13.1.1 for backward compatibility reason
+            starknet_version: StarknetVersion::parse("0.13.1.1").unwrap(),
         };
 
         ExecutableBlock { header, body: Vec::new() }

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -16,7 +16,6 @@ use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::{Event, Receipt, ReceiptWithTxHash};
 use katana_primitives::state::{compute_state_diff_hash, StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxWithHash};
-use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::{address, ContractAddress, Felt};
 use katana_provider::providers::EmptyStateProvider;
 use katana_provider::traits::block::{BlockHashProvider, BlockWriter};
@@ -117,7 +116,7 @@ impl<EF: ExecutorFactory> Backend<EF> {
             parent_hash,
             number: block_env.number,
             timestamp: block_env.timestamp,
-            starknet_version: CURRENT_STARKNET_VERSION,
+            starknet_version: block_env.starknet_version,
             l1_da_mode: L1DataAvailabilityMode::Calldata,
             sequencer_address: block_env.sequencer_address,
             l2_gas_prices: block_env.l2_gas_prices.clone(),

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -16,6 +16,7 @@ use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::{Event, Receipt, ReceiptWithTxHash};
 use katana_primitives::state::{compute_state_diff_hash, StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxWithHash};
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::{address, ContractAddress, Felt};
 use katana_provider::providers::EmptyStateProvider;
 use katana_provider::traits::block::{BlockHashProvider, BlockWriter};
@@ -180,6 +181,7 @@ impl<EF: ExecutorFactory> Backend<EF> {
 
         block_env.number += 1;
         block_env.timestamp = timestamp;
+        block_env.starknet_version = CURRENT_STARKNET_VERSION;
 
         // update the gas prices
         self.update_block_gas_prices(block_env);

--- a/crates/core/src/service/block_producer.rs
+++ b/crates/core/src/service/block_producer.rs
@@ -25,7 +25,6 @@ use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
-use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_provider::error::ProviderError;
 use katana_provider::traits::block::{BlockHashProvider, BlockNumberProvider};
 use katana_provider::traits::env::BlockEnvProvider;
@@ -626,7 +625,7 @@ impl<EF: ExecutorFactory> InstantBlockProducer<EF> {
                 parent_hash,
                 number: block_env.number,
                 timestamp: block_env.timestamp,
-                starknet_version: CURRENT_STARKNET_VERSION,
+                starknet_version: block_env.starknet_version,
                 sequencer_address: block_env.sequencer_address,
                 l1_da_mode: L1DataAvailabilityMode::Calldata,
                 l2_gas_prices: block_env.l2_gas_prices.clone(),

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -1,4 +1,14 @@
 /// The currently supported version of the Starknet protocol.
+///
+/// ## IMPORTANT
+///
+/// This version must correspond to the minimum Cairo/Sierra version we want to support. Ideally,
+/// this version should be synchronized with Dojo's Cairo version.
+///
+/// As of Cairo v2.10.0, contracts written with that version are only deployable on Starknet
+/// >=0.13.4. Check out the [release notes] for more info.
+///
+/// [release notes]: https://community.starknet.io/t/cairo-v2-10-0-is-out/115362
 pub const CURRENT_STARKNET_VERSION: StarknetVersion = StarknetVersion::new([0, 13, 4, 0]);
 
 /// Starknet protocol version.

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -1,5 +1,5 @@
 /// The currently supported version of the Starknet protocol.
-pub const CURRENT_STARKNET_VERSION: StarknetVersion = StarknetVersion::new([0, 13, 1, 1]); // version 0.13.1.1
+pub const CURRENT_STARKNET_VERSION: StarknetVersion = StarknetVersion::new([0, 13, 4, 0]);
 
 /// Starknet protocol version.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/crates/sync/stage/src/blocks.rs
+++ b/crates/sync/stage/src/blocks.rs
@@ -273,6 +273,7 @@ mod tests {
     use crate::{Stage, StageExecutionInput};
 
     #[tokio::test]
+    #[ignore = "require external network"]
     async fn fetch_blocks() {
         let from_block = 308919;
         let to_block = from_block + 2;


### PR DESCRIPTION
Starknet version ties heavily to the minimum Cairo version the network supports - deploying a Cairo contract that was compiled with unsupported compiler version may result in an error. 

Assuming that Dojo wants to use Cairo compiler version >=2.10, Katana should at least be using Starknet version **0.13.4** as Cairo 2.10 introduces new changes that are only supported starting from **0.13.4**.

We maintain the default Starknet version used in the genesis block - this is to ensure we change the computed genesis block hash.

---

The issue for this particular case, currently Katana is failing with a `Syscall gas cost must be greater than base syscall gas cost` error when executing a contract that uses the `get_class_hash_at_syscall`. The syscall was first introduced in Cairo **2.10.0**, and thus requires at least Starknet **0.13.4** as mentioned in the [release notes](https://community.starknet.io/t/cairo-v2-10-0-is-out/115362). 