### PR TITLE
refactor(provider): store class artifacts based on declared classes

### DIFF
--- a/crates/storage/provider/src/error.rs
+++ b/crates/storage/provider/src/error.rs
@@ -61,6 +61,10 @@ pub enum ProviderError {
     #[error("Missing compiled class hash for class hash {0:#x}")]
     MissingCompiledClassHash(ClassHash),
 
+    /// Error when a contract class artifact is not found but the class hash exists.
+    #[error("Missing contract class for class hash {0:#x}")]
+    MissingContractClass(ClassHash),
+
     /// Error when a contract class change entry is not found but the block number of when the
     /// change happen exists in the class change list.
     #[error("Missing contract class change entry")]

--- a/crates/storage/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/src/providers/db/mod.rs
@@ -871,6 +871,7 @@ mod tests {
     use katana_primitives::block::{
         Block, BlockHashOrNumber, FinalityStatus, Header, SealedBlockWithStatus,
     };
+    use katana_primitives::class::ContractClass;
     use katana_primitives::contract::ContractAddress;
     use katana_primitives::execution::TypedTransactionExecutionInfo;
     use katana_primitives::fee::FeeInfo;
@@ -920,6 +921,10 @@ mod tests {
                 )]),
                 ..Default::default()
             },
+            classes: BTreeMap::from([
+                (felt!("3"), ContractClass::Legacy(Default::default())),
+                (felt!("4"), ContractClass::Legacy(Default::default())),
+            ]),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Adds validation to ensure that all declared classes (both normal and deprecated) have their corresponding class artifacts included in the state updates, with proper error handling for missing classes.

This ensure that in a case where the state updates invariant is violated, the `insert_block_with_states_and_receipts` operation should fail accordingly. Not failing would result in an incoherent state.