### PR TITLE
fix(rpc): ensure cairo serde for outside execution matches contract

### DIFF
--- a/crates/rpc/rpc-types/src/outside_execution.rs
+++ b/crates/rpc/rpc-types/src/outside_execution.rs
@@ -5,6 +5,12 @@
 //! fee subsidy, and other advanced transaction patterns.
 //!
 //! Based on [SNIP-9](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md).
+//!
+//! An important note is that the `execute_from_outside_[v2/v3]` functions are not expecting
+//! the serialized enum [`OutsideExecution`] but instead the variant already serialized for the
+//! matching version.
+//! This is why [`OutsideExecution`] is not deriving `CairoSerde` directly.
+//! <https://github.com/cartridge-gg/argent-contracts-starknet/blob/35f21a533e7636f926484546652fb3470d2d478d/src/outside_execution/interface.cairo#L38>
 
 use cainome::cairo_serde::{deserialize_from_hex, serialize_as_hex};
 use cainome::cairo_serde_derive::CairoSerde;
@@ -63,7 +69,7 @@ pub struct OutsideExecutionV3 {
     pub calls: Vec<Call>,
 }
 
-#[derive(Clone, CairoSerde, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum OutsideExecution {
     /// SNIP-9 standard version.

--- a/crates/rpc/rpc/src/cartridge/mod.rs
+++ b/crates/rpc/rpc/src/cartridge/mod.rs
@@ -66,7 +66,9 @@ use katana_primitives::{ContractAddress, Felt};
 use katana_provider::traits::state::{StateFactoryProvider, StateProvider};
 use katana_rpc_api::cartridge::CartridgeApiServer;
 use katana_rpc_api::error::starknet::StarknetApiError;
-use katana_rpc_types::outside_execution::OutsideExecution;
+use katana_rpc_types::outside_execution::{
+    OutsideExecution, OutsideExecutionV2, OutsideExecutionV3,
+};
 use katana_rpc_types::transaction::InvokeTxResult;
 use katana_tasks::TokioTaskSpawner;
 use serde::Deserialize;
@@ -211,8 +213,15 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
                 nonce += Nonce::ONE;
             }
 
-            let mut inner_calldata =
-                OutsideExecution::cairo_serialize(&outside_execution);
+            let mut inner_calldata = match &outside_execution {
+                OutsideExecution::V2(v2) => {
+                    OutsideExecutionV2::cairo_serialize(v2)
+                }
+                OutsideExecution::V3(v3) => {
+                    OutsideExecutionV3::cairo_serialize(v3)
+                }
+            };
+
             inner_calldata.extend(Vec::<Felt>::cairo_serialize(&signature));
 
             let execute_from_outside_call = Call { to: address.into(), selector: entrypoint, calldata: inner_calldata };


### PR DESCRIPTION
This PR provides a fix to match the contract entrypoint input when it comes to `execute_from_outside_v2/v3` as shown [here](https://github.com/cartridge-gg/argent-contracts-starknet/blob/35f21a533e7636f926484546652fb3470d2d478d/src/outside_execution/interface.cairo#L38).

The variant is not included in the input, but since `CairoSerde` doesn't have an `untagged` like `serde`, the variant index is always included.

The suggestion in this PR is to directly use the variant based on the detected version.