### PR TITLE
fix(blockifier): apply overrides on both tracked resource types

### DIFF
--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -11,6 +11,7 @@ katana-primitives.workspace = true
 katana-provider.workspace = true
 
 blockifier = { workspace = true, features = [ "testing" ] }
+num-traits.workspace = true
 quick_cache = "0.6.10"
 starknet.workspace = true
 thiserror.workspace = true

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -22,6 +22,7 @@ use starknet_api::block::{
     BlockInfo, BlockNumber, BlockTimestamp, GasPriceVector, GasPrices, NonzeroGasPrice,
 };
 use tracing::info;
+use utils::apply_versioned_constant_overrides;
 
 use self::state::CachedState;
 use crate::{
@@ -190,13 +191,7 @@ impl<'a> StarknetVMProcessor<'a> {
 
         let sn_version = header.starknet_version.try_into().expect("valid version");
         let mut versioned_constants = VersionedConstants::get(&sn_version).unwrap().clone();
-
-        // NOTE:
-        // These overrides would potentially make the `snos` run be invalid as it doesn't know about
-        // the new overridden values.
-        versioned_constants.max_recursion_depth = self.cfg_env.max_recursion_depth;
-        versioned_constants.validate_max_n_steps = self.cfg_env.validate_max_n_steps;
-        versioned_constants.invoke_tx_max_n_steps = self.cfg_env.invoke_tx_max_n_steps;
+        apply_versioned_constant_overrides(&self.cfg_env, &mut versioned_constants);
 
         self.starknet_version = header.starknet_version;
         self.block_context = Arc::new(BlockContext::new(


### PR DESCRIPTION
Applies the max execution resources overrides on both Cairo steps and Sierra gas. The Sierra gas are being limited [here](https://github.com/dojoengine/sequencer/blob/5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2/crates/blockifier/src/transaction/account_transaction.rs#L544-L545) where they are used to limit the initial sierra gas that a transaction will use. 
