### PR TITLE
feat(rpc): Starknet RPC extensions 

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -44,6 +44,7 @@ use katana_rpc::{RpcServer, RpcServerHandle};
 use katana_rpc_api::cartridge::CartridgeApiServer;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::starknet::{StarknetApiServer, StarknetTraceApiServer, StarknetWriteApiServer};
+#[cfg(feature = "cartridge")]
 use katana_rpc_api::starknet_ext::StarknetApiExtServer;
 use katana_stage::Sequencing;
 use katana_tasks::TaskManager;
@@ -261,6 +262,7 @@ impl Node {
                 StarknetApi::new(backend.clone(), pool.clone(), Some(block_producer.clone()), cfg)
             };
 
+            #[cfg(feature = "explorer")]
             if config.rpc.explorer {
                 rpc_modules.merge(StarknetApiExtServer::into_rpc(api.clone()))?;
             }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -44,6 +44,7 @@ use katana_rpc::{RpcServer, RpcServerHandle};
 use katana_rpc_api::cartridge::CartridgeApiServer;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::starknet::{StarknetApiServer, StarknetTraceApiServer, StarknetWriteApiServer};
+use katana_rpc_api::starknet_ext::StarknetApiExtServer;
 use katana_stage::Sequencing;
 use katana_tasks::TaskManager;
 use tracing::info;
@@ -259,6 +260,10 @@ impl Node {
             } else {
                 StarknetApi::new(backend.clone(), pool.clone(), Some(block_producer.clone()), cfg)
             };
+
+            if config.rpc.explorer {
+                rpc_modules.merge(StarknetApiExtServer::into_rpc(api.clone()))?;
+            }
 
             rpc_modules.merge(StarknetApiServer::into_rpc(api.clone()))?;
             rpc_modules.merge(StarknetWriteApiServer::into_rpc(api.clone()))?;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -44,7 +44,7 @@ use katana_rpc::{RpcServer, RpcServerHandle};
 use katana_rpc_api::cartridge::CartridgeApiServer;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::starknet::{StarknetApiServer, StarknetTraceApiServer, StarknetWriteApiServer};
-#[cfg(feature = "cartridge")]
+#[cfg(feature = "explorer")]
 use katana_rpc_api::starknet_ext::StarknetApiExtServer;
 use katana_stage::Sequencing;
 use katana_tasks::TaskManager;

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod dev;
 pub mod error;
 pub mod starknet;
+pub mod starknet_ext;
 
 #[cfg(feature = "cartridge")]
 pub mod cartridge;

--- a/crates/rpc/rpc-api/src/starknet_ext.rs
+++ b/crates/rpc/rpc-api/src/starknet_ext.rs
@@ -1,0 +1,43 @@
+//! Extension to the Starknet JSON-RPC API for list endpoints. These endpoints shouldn't be relied upon as they may change or be removed in the future.
+
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use katana_primitives::transaction::TxNumber;
+use katana_rpc_types::list::{
+    GetBlocksRequest, GetBlocksResponse, GetTransactionsRequest, GetTransactionsResponse,
+};
+
+/// Extension API for retrieving lists of blocks and transactions.
+///
+/// These endpoints are primarily intended for stateless blockchain explorers
+/// to display lists of blocks and transactions with range-based queries.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "starknet"))]
+#[cfg_attr(feature = "client", rpc(client, server, namespace = "starknet"))]
+pub trait StarknetApiExt {
+    /// Returns a list of blocks within the specified range.
+    ///
+    /// This endpoint accepts a range of block numbers and returns blocks
+    /// within that range. Set `descending: true` to get results in
+    /// descending order (newest first). Use `limit` to control the
+    /// maximum number of blocks returned.
+    #[method(name = "getBlocks")]
+    async fn get_blocks(&self, request: GetBlocksRequest) -> RpcResult<GetBlocksResponse>;
+
+    /// Returns a list of transactions within the specified range.
+    ///
+    /// This endpoint accepts a range of transaction numbers and returns
+    /// transactions within that range. Set `descending: true` to get
+    /// results in descending order (newest first). Use `limit` to control
+    /// the maximum number of transactions returned.
+    #[method(name = "getTransactions")]
+    async fn get_transactions(
+        &self,
+        request: GetTransactionsRequest,
+    ) -> RpcResult<GetTransactionsResponse>;
+
+    /// Get the most recent accepted transaction number.
+    ///
+    /// Similar to `starknet_blockNumber` but for transaction.
+    #[method(name = "transactionNumber")]
+    async fn transaction_number(&self) -> RpcResult<TxNumber>;
+}

--- a/crates/rpc/rpc-api/src/starknet_ext.rs
+++ b/crates/rpc/rpc-api/src/starknet_ext.rs
@@ -1,4 +1,5 @@
-//! Extension to the Starknet JSON-RPC API for list endpoints. These endpoints shouldn't be relied upon as they may change or be removed in the future.
+//! Extension to the Starknet JSON-RPC API for list endpoints. These endpoints shouldn't be relied
+//! upon as they may change or be removed in the future.
 
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;

--- a/crates/rpc/rpc-api/src/starknet_ext.rs
+++ b/crates/rpc/rpc-api/src/starknet_ext.rs
@@ -16,20 +16,10 @@ use katana_rpc_types::list::{
 #[cfg_attr(feature = "client", rpc(client, server, namespace = "starknet"))]
 pub trait StarknetApiExt {
     /// Returns a list of blocks within the specified range.
-    ///
-    /// This endpoint accepts a range of block numbers and returns blocks
-    /// within that range. Set `descending: true` to get results in
-    /// descending order (newest first). Use `limit` to control the
-    /// maximum number of blocks returned.
     #[method(name = "getBlocks")]
     async fn get_blocks(&self, request: GetBlocksRequest) -> RpcResult<GetBlocksResponse>;
 
     /// Returns a list of transactions within the specified range.
-    ///
-    /// This endpoint accepts a range of transaction numbers and returns
-    /// transactions within that range. Set `descending: true` to get
-    /// results in descending order (newest first). Use `limit` to control
-    /// the maximum number of transactions returned.
     #[method(name = "getTransactions")]
     async fn get_transactions(
         &self,

--- a/crates/rpc/rpc-types/src/block.rs
+++ b/crates/rpc/rpc-types/src/block.rs
@@ -121,7 +121,7 @@ impl From<starknet::core::types::MaybePreConfirmedBlockWithTxs> for MaybePreConf
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct BlockWithTxHashes(starknet::core::types::BlockWithTxHashes);
+pub struct BlockWithTxHashes(pub starknet::core::types::BlockWithTxHashes);
 
 impl BlockWithTxHashes {
     pub fn new(

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block;
 pub mod broadcasted;
 pub mod class;
 pub mod event;
+pub mod list;
 pub mod message;
 pub mod outside_execution;
 pub mod receipt;

--- a/crates/rpc/rpc-types/src/list.rs
+++ b/crates/rpc/rpc-types/src/list.rs
@@ -1,0 +1,137 @@
+//! Types for list endpoints (blocks and transactions)
+
+use core::fmt;
+use std::num::ParseIntError;
+
+use katana_primitives::block::BlockNumber;
+use katana_primitives::transaction::TxNumber;
+use serde::{Deserialize, Serialize};
+
+use crate::block::BlockWithTxHashes;
+use crate::transaction::Tx;
+
+/// Represents a continuation token for implementing paging in block and transaction queries.
+///
+/// This struct stores the necessary information to resume fetching blocks or transactions
+/// from a specific point relative to the given filter passed as parameter to the
+/// `starknet_getBlocks` or `starknet_getTransactions` API.
+///
+/// The JSON-RPC specification does not specify the format of the continuation token,
+/// so how the node should handle it is implementation specific.
+#[derive(PartialEq, Eq, Debug, Clone, Default)]
+pub struct ContinuationToken {
+    /// The item (block/transaction) number to continue from.
+    pub item_n: u64,
+}
+
+#[derive(PartialEq, Eq, Debug, thiserror::Error)]
+pub enum ContinuationTokenError {
+    #[error("Invalid data")]
+    InvalidToken,
+    #[error("Invalid format: {0}")]
+    ParseFailed(ParseIntError),
+}
+
+impl ContinuationToken {
+    pub fn parse(token: &str) -> Result<Self, ContinuationTokenError> {
+        let item_n = u64::from_str_radix(token, 16).map_err(ContinuationTokenError::ParseFailed)?;
+        Ok(ContinuationToken { item_n })
+    }
+}
+
+impl fmt::Display for ContinuationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x}", self.item_n)
+    }
+}
+
+/// Request parameters for the `starknet_getBlocks` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetBlocksRequest {
+    /// The starting block number (inclusive). For descending order, this should be higher than `end_block`.
+    pub from: BlockNumber,
+
+    /// The ending block number (inclusive). If not provided, returns blocks starting from `start_block`.
+    /// For descending order, this should be lower than `start_block`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<BlockNumber>,
+
+    /// The maximum number of blocks to return. If not provided, returns all blocks in the range.
+    /// This acts as a limit to prevent excessively large responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_size: Option<u64>,
+}
+
+/// Response for the `starknet_getBlocks` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetBlocksResponse {
+    /// The list of blocks.
+    pub blocks: Vec<BlockWithTxHashes>,
+
+    /// A pointer to the last element of the delivered page, use this token in a subsequent query to
+    /// obtain the next page. If the value is `None`, don't add it to the response as clients might
+    /// use `contains_key` as a check for the last page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation_token: Option<String>,
+}
+
+/// Request parameters for the `starknet_getTransactions` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetTransactionsRequest {
+    /// The starting transaction number (inclusive). For descending order, this should be higher than `end_tx`.
+    pub from: TxNumber,
+
+    /// The ending transaction number (inclusive). If not provided, returns transactions starting from `start_tx`.
+    /// For descending order, this should be lower than `start_tx`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<TxNumber>,
+
+    /// The maximum number of transactions to return. If not provided, returns all transactions in the range.
+    /// This acts as a limit to prevent excessively large responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_size: Option<u64>,
+}
+
+/// Response for the `starknet_getTransactions` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetTransactionsResponse {
+    /// The list of transactions.
+    pub transactions: Vec<Tx>,
+
+    /// A pointer to the last element of the delivered page, use this token in a subsequent query to
+    /// obtain the next page. If the value is `None`, don't add it to the response as clients might
+    /// use `contains_key` as a check for the last page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation_token: Option<String>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn list_continuation_token_parse_works() {
+        assert_eq!(ContinuationToken::parse("0").unwrap(), ContinuationToken { item_n: 0 });
+        assert_eq!(ContinuationToken::parse("1e").unwrap(), ContinuationToken { item_n: 30 });
+    }
+
+    #[test]
+    fn list_continuation_token_parse_should_fail() {
+        assert_eq!(
+            ContinuationToken::parse("0,").unwrap_err(),
+            ContinuationTokenError::InvalidToken
+        );
+        assert_eq!(
+            ContinuationToken::parse("0,0,0").unwrap_err(),
+            ContinuationTokenError::InvalidToken
+        );
+    }
+
+    #[test]
+    fn list_continuation_token_parse_u64_should_fail() {
+        matches!(
+            ContinuationToken::parse("2y").unwrap_err(),
+            ContinuationTokenError::ParseFailed(_)
+        );
+    }
+}

--- a/crates/rpc/rpc-types/src/list.rs
+++ b/crates/rpc/rpc-types/src/list.rs
@@ -66,11 +66,6 @@ pub struct GetBlocksRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<BlockNumber>,
 
-    /// The maximum number of blocks to return. If not provided, returns all blocks in the range.
-    /// This acts as a limit to prevent excessively large responses.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub chunk_size: Option<u64>,
-
     pub result_page_request: ResultPageRequest,
 }
 
@@ -98,11 +93,6 @@ pub struct GetTransactionsRequest {
     /// from `start_tx`. For descending order, this should be lower than `start_tx`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<TxNumber>,
-
-    /// The maximum number of transactions to return. If not provided, returns all transactions in
-    /// the range. This acts as a limit to prevent excessively large responses.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub chunk_size: Option<u64>,
 
     pub result_page_request: ResultPageRequest,
 }

--- a/crates/rpc/rpc-types/src/list.rs
+++ b/crates/rpc/rpc-types/src/list.rs
@@ -9,6 +9,7 @@ use starknet::core::types::ResultPageRequest;
 
 use crate::block::BlockWithTxHashes;
 use crate::receipt::TxReceiptWithBlockInfo;
+use crate::transaction::Tx;
 
 /// Represents a continuation token for implementing paging in block and transaction queries.
 ///
@@ -100,13 +101,21 @@ pub struct GetTransactionsRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetTransactionsResponse {
     /// The list of transactions.
-    pub transactions: Vec<TxReceiptWithBlockInfo>,
+    pub transactions: Vec<TransactionListItem>,
 
     /// A pointer to the last element of the delivered page, use this token in a subsequent query
     /// to obtain the next page. If the value is `None`, don't add it to the response as
     /// clients might use `contains_key` as a check for the last page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionListItem {
+    /// The transaction - same object returned by `starknet_getTransactionByHash`.
+    pub transaction: Tx,
+    /// The transaction receipt - same object returned by `starknet_getTransactionReceipt`.
+    pub receipt: TxReceiptWithBlockInfo,
 }
 
 #[cfg(test)]

--- a/crates/rpc/rpc-types/src/list.rs
+++ b/crates/rpc/rpc-types/src/list.rs
@@ -6,6 +6,7 @@ use std::num::ParseIntError;
 use katana_primitives::block::BlockNumber;
 use katana_primitives::transaction::TxNumber;
 use serde::{Deserialize, Serialize};
+use starknet::core::types::ResultPageRequest;
 
 use crate::block::BlockWithTxHashes;
 use crate::transaction::Tx;
@@ -34,7 +35,15 @@ pub enum ContinuationTokenError {
 
 impl ContinuationToken {
     pub fn parse(token: &str) -> Result<Self, ContinuationTokenError> {
-        let item_n = u64::from_str_radix(token, 16).map_err(ContinuationTokenError::ParseFailed)?;
+        token.parse()
+    }
+}
+
+impl std::str::FromStr for ContinuationToken {
+    type Err = ContinuationTokenError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let item_n = u64::from_str_radix(s, 16).map_err(ContinuationTokenError::ParseFailed)?;
         Ok(ContinuationToken { item_n })
     }
 }
@@ -48,11 +57,12 @@ impl fmt::Display for ContinuationToken {
 /// Request parameters for the `starknet_getBlocks` endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetBlocksRequest {
-    /// The starting block number (inclusive). For descending order, this should be higher than `end_block`.
+    /// The starting block number (inclusive). For descending order, this should be higher than
+    /// `end_block`.
     pub from: BlockNumber,
 
-    /// The ending block number (inclusive). If not provided, returns blocks starting from `start_block`.
-    /// For descending order, this should be lower than `start_block`.
+    /// The ending block number (inclusive). If not provided, returns blocks starting from
+    /// `start_block`. For descending order, this should be lower than `start_block`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<BlockNumber>,
 
@@ -60,6 +70,8 @@ pub struct GetBlocksRequest {
     /// This acts as a limit to prevent excessively large responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chunk_size: Option<u64>,
+
+    pub result_page_request: ResultPageRequest,
 }
 
 /// Response for the `starknet_getBlocks` endpoint.
@@ -68,9 +80,9 @@ pub struct GetBlocksResponse {
     /// The list of blocks.
     pub blocks: Vec<BlockWithTxHashes>,
 
-    /// A pointer to the last element of the delivered page, use this token in a subsequent query to
-    /// obtain the next page. If the value is `None`, don't add it to the response as clients might
-    /// use `contains_key` as a check for the last page.
+    /// A pointer to the last element of the delivered page, use this token in a subsequent query
+    /// to obtain the next page. If the value is `None`, don't add it to the response as
+    /// clients might use `contains_key` as a check for the last page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
 }
@@ -78,18 +90,21 @@ pub struct GetBlocksResponse {
 /// Request parameters for the `starknet_getTransactions` endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetTransactionsRequest {
-    /// The starting transaction number (inclusive). For descending order, this should be higher than `end_tx`.
+    /// The starting transaction number (inclusive). For descending order, this should be higher
+    /// than `end_tx`.
     pub from: TxNumber,
 
-    /// The ending transaction number (inclusive). If not provided, returns transactions starting from `start_tx`.
-    /// For descending order, this should be lower than `start_tx`.
+    /// The ending transaction number (inclusive). If not provided, returns transactions starting
+    /// from `start_tx`. For descending order, this should be lower than `start_tx`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<TxNumber>,
 
-    /// The maximum number of transactions to return. If not provided, returns all transactions in the range.
-    /// This acts as a limit to prevent excessively large responses.
+    /// The maximum number of transactions to return. If not provided, returns all transactions in
+    /// the range. This acts as a limit to prevent excessively large responses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chunk_size: Option<u64>,
+
+    pub result_page_request: ResultPageRequest,
 }
 
 /// Response for the `starknet_getTransactions` endpoint.
@@ -98,9 +113,9 @@ pub struct GetTransactionsResponse {
     /// The list of transactions.
     pub transactions: Vec<Tx>,
 
-    /// A pointer to the last element of the delivered page, use this token in a subsequent query to
-    /// obtain the next page. If the value is `None`, don't add it to the response as clients might
-    /// use `contains_key` as a check for the last page.
+    /// A pointer to the last element of the delivered page, use this token in a subsequent query
+    /// to obtain the next page. If the value is `None`, don't add it to the response as
+    /// clients might use `contains_key` as a check for the last page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
 }

--- a/crates/rpc/rpc-types/src/list.rs
+++ b/crates/rpc/rpc-types/src/list.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use starknet::core::types::ResultPageRequest;
 
 use crate::block::BlockWithTxHashes;
-use crate::transaction::Tx;
+use crate::receipt::TxReceiptWithBlockInfo;
 
 /// Represents a continuation token for implementing paging in block and transaction queries.
 ///
@@ -100,7 +100,7 @@ pub struct GetTransactionsRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetTransactionsResponse {
     /// The list of transactions.
-    pub transactions: Vec<Tx>,
+    pub transactions: Vec<TxReceiptWithBlockInfo>,
 
     /// A pointer to the last element of the delivered page, use this token in a subsequent query
     /// to obtain the next page. If the value is `None`, don't add it to the response as

--- a/crates/rpc/rpc/src/starknet/list.rs
+++ b/crates/rpc/rpc/src/starknet/list.rs
@@ -1,0 +1,37 @@
+//! Implementation of list endpoints for the Starknet API.
+
+use std::ops::Range;
+
+use jsonrpsee::core::{async_trait, RpcResult};
+use katana_primitives::transaction::TxNumber;
+use katana_provider::traits::block::{BlockNumberProvider, BlockProvider};
+use katana_provider::traits::transaction::TransactionProvider;
+use katana_rpc_api::error::starknet::StarknetApiError;
+use katana_rpc_api::starknet_ext::StarknetApiExtServer;
+use katana_rpc_types::list::{
+    GetBlocksRequest, GetBlocksResponse, GetTransactionsRequest, GetTransactionsResponse,
+};
+use katana_rpc_types::transaction::Tx;
+
+use super::{StarknetApi, StarknetApiResult};
+
+#[async_trait]
+impl<EF> StarknetApiExtServer for StarknetApi<EF>
+where
+    EF: katana_executor::ExecutorFactory,
+{
+    async fn get_blocks(&self, request: GetBlocksRequest) -> RpcResult<GetBlocksResponse> {
+        Ok(self.blocks(request).await?)
+    }
+
+    async fn get_transactions(
+        &self,
+        request: GetTransactionsRequest,
+    ) -> RpcResult<GetTransactionsResponse> {
+        Ok(self.get_transactions(request).await?)
+    }
+
+    async fn transaction_number(&self) -> RpcResult<TxNumber> {
+        Ok(self.total_transactions().await?)
+    }
+}

--- a/crates/rpc/rpc/src/starknet/list.rs
+++ b/crates/rpc/rpc/src/starknet/list.rs
@@ -1,19 +1,13 @@
 //! Implementation of list endpoints for the Starknet API.
 
-use std::ops::Range;
-
 use jsonrpsee::core::{async_trait, RpcResult};
 use katana_primitives::transaction::TxNumber;
-use katana_provider::traits::block::{BlockNumberProvider, BlockProvider};
-use katana_provider::traits::transaction::TransactionProvider;
-use katana_rpc_api::error::starknet::StarknetApiError;
 use katana_rpc_api::starknet_ext::StarknetApiExtServer;
 use katana_rpc_types::list::{
     GetBlocksRequest, GetBlocksResponse, GetTransactionsRequest, GetTransactionsResponse,
 };
-use katana_rpc_types::transaction::Tx;
 
-use super::{StarknetApi, StarknetApiResult};
+use super::StarknetApi;
 
 #[async_trait]
 impl<EF> StarknetApiExtServer for StarknetApi<EF>
@@ -28,7 +22,7 @@ where
         &self,
         request: GetTransactionsRequest,
     ) -> RpcResult<GetTransactionsResponse> {
-        Ok(self.get_transactions(request).await?)
+        Ok(self.transactions(request).await?)
     }
 
     async fn transaction_number(&self) -> RpcResult<TxNumber> {

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -1,5 +1,6 @@
 //! Server implementation for the Starknet JSON-RPC API.
 
+use std::ops::Range;
 use std::sync::Arc;
 
 use katana_core::backend::Backend;
@@ -14,16 +15,18 @@ use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageVal
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::env::BlockEnv;
 use katana_primitives::event::MaybeForkedContinuationToken;
-use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
+use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxNumber, TxWithHash};
 use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::Felt;
 use katana_provider::error::ProviderError;
-use katana_provider::traits::block::{BlockHashProvider, BlockIdReader, BlockNumberProvider};
+use katana_provider::traits::block::{
+    BlockHashProvider, BlockIdReader, BlockNumberProvider, BlockProvider,
+};
 use katana_provider::traits::contract::ContractClassProvider;
 use katana_provider::traits::env::BlockEnvProvider;
 use katana_provider::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider};
 use katana_provider::traits::transaction::{
-    ReceiptProvider, TransactionProvider, TransactionStatusProvider,
+    ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionsProviderExt,
 };
 use katana_rpc_api::error::starknet::StarknetApiError;
 use katana_rpc_types::block::{
@@ -33,6 +36,9 @@ use katana_rpc_types::block::{
 };
 use katana_rpc_types::class::Class;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
+use katana_rpc_types::list::{
+    GetBlocksRequest, GetBlocksResponse, GetTransactionsRequest, GetTransactionsResponse,
+};
 use katana_rpc_types::receipt::{ReceiptBlock, TxReceiptWithBlockInfo};
 use katana_rpc_types::state_update::MaybePreConfirmedStateUpdate;
 use katana_rpc_types::transaction::Tx;
@@ -41,7 +47,7 @@ use katana_rpc_types::trie::{
     GetStorageProofResponse, GlobalRoots, Nodes,
 };
 use katana_rpc_types::FeeEstimate;
-use katana_rpc_types_builder::ReceiptBuilder;
+use katana_rpc_types_builder::{BlockBuilder, ReceiptBuilder};
 use katana_tasks::{BlockingTaskPool, TokioTaskSpawner};
 use starknet::core::types::{ResultPageRequest, TransactionStatus};
 
@@ -52,6 +58,7 @@ use crate::{utils, DEFAULT_ESTIMATE_FEE_MAX_CONCURRENT_REQUESTS};
 mod blockifier;
 mod config;
 pub mod forking;
+mod list;
 mod read;
 mod trace;
 mod write;
@@ -1226,6 +1233,122 @@ where
                 contracts_proof,
                 contracts_storage_proofs,
             })
+        })
+        .await
+    }
+
+    /////////////////////////////////////////////////////
+    // `StarknetApiExt` Implementations
+    /////////////////////////////////////////////////////
+
+    async fn blocks(&self, request: GetBlocksRequest) -> StarknetApiResult<GetBlocksResponse> {
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.backend.blockchain.provider();
+            let continuation_token;
+
+            let range_start = request.from;
+            let mut range_end =
+                if let Some(to) = request.to { to } else { provider.latest_number()? };
+
+            if let Some(limit) = request.chunk_size {
+                if limit > 0 {
+                    range_end = range_start.saturating_add(limit.saturating_sub(1)).min(range_end);
+                }
+            }
+
+            let blocks = provider.blocks_in_range(range_start..=range_end)?;
+
+            // Convert to RPC format
+            let mut rpc_blocks = Vec::new();
+            for block in blocks {
+                let block_id = block.header.number.into();
+                if let Some(rpc_block) =
+                    BlockBuilder::new(block_id, &provider).build_with_tx_hash()?
+                {
+                    rpc_blocks.push(rpc_block);
+                }
+            }
+
+            Ok(GetBlocksResponse { blocks: rpc_blocks, continuation_token: None })
+        })
+        .await
+    }
+
+    async fn transactions(
+        &self,
+        request: GetTransactionsRequest,
+    ) -> StarknetApiResult<GetTransactionsResponse> {
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.backend.blockchain.provider();
+
+            // Handle descending vs ascending order
+            let (range_start, range_end) = if request.descending {
+                // For descending order
+                let start = request.from;
+                let end = if let Some(end) = request.to {
+                    end
+                } else if let Some(limit) = request.chunk_size {
+                    start.saturating_sub(limit.saturating_sub(1))
+                } else {
+                    start.saturating_sub(99) // Default to 100 transactions
+                };
+
+                if start < end {
+                    return Err(StarknetApiError::UnexpectedError {
+                        reason: "For descending order, start_tx must be >= end_tx".to_string(),
+                    });
+                }
+
+                (end, start)
+            } else {
+                // For ascending order
+                let start = request.from;
+                let end = if let Some(end) = request.to {
+                    end
+                } else if let Some(limit) = request.chunk_size {
+                    start.saturating_add(limit.saturating_sub(1))
+                } else {
+                    start.saturating_add(99) // Default to 100 transactions
+                };
+
+                if start > end {
+                    return Err(StarknetApiError::UnexpectedError {
+                        reason: "For ascending order, start_tx must be <= end_tx".to_string(),
+                    });
+                }
+
+                (start, end)
+            };
+
+            // Apply limit if specified
+            let mut actual_end = range_end;
+            if let Some(limit) = request.chunk_size {
+                if limit > 0 {
+                    actual_end = range_start.saturating_add(limit.saturating_sub(1)).min(range_end);
+                }
+            }
+
+            let range: Range<TxNumber> = range_start..actual_end.saturating_add(1);
+
+            // Get transactions from provider
+            let transactions = provider.transaction_in_range(range)?;
+
+            // Convert to RPC format
+            let mut rpc_transactions: Vec<Tx> =
+                transactions.into_iter().map(|tx| tx.into()).collect();
+
+            let response = GetTransactionsResponse { transactions: rpc_transactions };
+
+            Ok(response)
+        })
+        .await
+    }
+
+    async fn total_transactions(&self) -> StarknetApiResult<TxNumber> {
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.backend.blockchain.provider();
+            let total = provider.total_transactions()? as TxNumber;
+            Ok(total)
         })
         .await
     }

--- a/crates/rpc/rpc/tests/common/mod.rs
+++ b/crates/rpc/rpc/tests/common/mod.rs
@@ -4,12 +4,15 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use cainome::rs::abigen_legacy;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use katana_primitives::class::CompiledClass;
 use starknet::core::types::contract::SierraClass;
 use starknet::core::types::{Call, Felt, FlattenedSierraClass};
 use starknet::core::utils::get_selector_from_name;
+
+abigen_legacy!(Erc20Contract, "crates/contracts/build/legacy/erc20.json", derives(Clone));
 
 pub fn prepare_contract_declaration_params(
     artifact_path: &PathBuf,

--- a/crates/rpc/rpc/tests/starknet_ext.rs
+++ b/crates/rpc/rpc/tests/starknet_ext.rs
@@ -4,7 +4,7 @@ use katana_rpc_api::starknet_ext::StarknetApiExtClient;
 use katana_rpc_types::list::{ContinuationToken, GetBlocksRequest, GetTransactionsRequest};
 use katana_utils::TestNode;
 use starknet::accounts::ConnectedAccount;
-use starknet::core::types::{Felt, ResultPageRequest};
+use starknet::core::types::{Felt, ResultPageRequest, TransactionReceipt};
 
 mod common;
 
@@ -242,7 +242,9 @@ async fn get_transactions_with_chunk_size() {
     assert!(response.continuation_token.is_some());
 
     for (expected_hash, actual_tx) in tx_hashes.iter().take(3).zip(response.transactions.iter()) {
-        assert_eq!(expected_hash, actual_tx.0.transaction_hash());
+        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+           assert_eq!(expected_hash, &receipt.transaction_hash);
+        });
     }
 }
 
@@ -280,7 +282,9 @@ async fn get_transactions_pagination() {
     for (expected_hash, actual_tx) in
         tx_hashes.iter().take(2).zip(first_response.transactions.iter())
     {
-        assert_eq!(expected_hash, actual_tx.0.transaction_hash());
+        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+           assert_eq!(expected_hash, &receipt.transaction_hash);
+        });
     }
 
     // Second page using continuation token
@@ -300,7 +304,9 @@ async fn get_transactions_pagination() {
     for (expected_hash, actual_tx) in
         tx_hashes.iter().skip(2).zip(second_response.transactions.iter())
     {
-        assert_eq!(expected_hash, actual_tx.0.transaction_hash());
+        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+           assert_eq!(expected_hash, &receipt.transaction_hash);
+        });
     }
 }
 
@@ -337,7 +343,9 @@ async fn get_transactions_no_to_parameter() {
     assert_eq!(response.transactions.len(), 2);
 
     for (expected_hash, actual_tx) in tx_hashes.iter().skip(1).zip(response.transactions.iter()) {
-        assert_eq!(expected_hash, actual_tx.0.transaction_hash());
+        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+           assert_eq!(expected_hash, &receipt.transaction_hash);
+        });
     }
 }
 

--- a/crates/rpc/rpc/tests/starknet_ext.rs
+++ b/crates/rpc/rpc/tests/starknet_ext.rs
@@ -5,7 +5,7 @@ use katana_rpc_types::list::{ContinuationToken, GetBlocksRequest, GetTransaction
 use katana_utils::node::Provider;
 use katana_utils::TestNode;
 use starknet::accounts::ConnectedAccount;
-use starknet::core::types::{Felt, ResultPageRequest, TransactionReceipt};
+use starknet::core::types::{Felt, ResultPageRequest, Transaction, TransactionReceipt};
 
 mod common;
 
@@ -279,7 +279,11 @@ async fn get_transactions_with_chunk_size() {
     });
 
     for (expected_hash, actual_tx) in tx_hashes.iter().take(3).zip(response.transactions.iter()) {
-        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+        assert_matches!(&actual_tx.transaction.0, Transaction::Invoke(tx) => {
+           assert_eq!(expected_hash, tx.transaction_hash());
+        });
+
+        assert_matches!(&actual_tx.receipt.0.receipt, TransactionReceipt::Invoke(receipt) => {
            assert_eq!(expected_hash, &receipt.transaction_hash);
         });
     }
@@ -326,7 +330,11 @@ async fn get_transactions_pagination() {
     for (expected_hash, actual_tx) in
         tx_hashes.iter().take(2).zip(first_response.transactions.iter())
     {
-        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+        assert_matches!(&actual_tx.transaction.0, Transaction::Invoke(tx) => {
+           assert_eq!(expected_hash, tx.transaction_hash());
+        });
+
+        assert_matches!(&actual_tx.receipt.0.receipt, TransactionReceipt::Invoke(receipt) => {
            assert_eq!(expected_hash, &receipt.transaction_hash);
         });
     }
@@ -355,7 +363,11 @@ async fn get_transactions_pagination() {
     for (expected_hash, actual_tx) in
         tx_hashes.iter().skip(2).zip(second_response.transactions.iter())
     {
-        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+        assert_matches!(&actual_tx.transaction.0, Transaction::Invoke(tx) => {
+           assert_eq!(expected_hash, tx.transaction_hash());
+        });
+
+        assert_matches!(&actual_tx.receipt.0.receipt, TransactionReceipt::Invoke(receipt) => {
            assert_eq!(expected_hash, &receipt.transaction_hash);
         });
     }
@@ -377,7 +389,11 @@ async fn get_transactions_pagination() {
     for (expected_hash, actual_tx) in
         tx_hashes.iter().skip(4).zip(third_response.transactions.iter())
     {
-        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+        assert_matches!(&actual_tx.transaction.0, Transaction::Invoke(tx) => {
+           assert_eq!(expected_hash, tx.transaction_hash());
+        });
+
+        assert_matches!(&actual_tx.receipt.0.receipt, TransactionReceipt::Invoke(receipt) => {
            assert_eq!(expected_hash, &receipt.transaction_hash);
         });
     }
@@ -417,7 +433,11 @@ async fn get_transactions_no_to_parameter() {
     assert!(response.continuation_token.is_none());
 
     for (expected_hash, actual_tx) in tx_hashes.iter().skip(1).zip(response.transactions.iter()) {
-        assert_matches!(&actual_tx.0.receipt, TransactionReceipt::Invoke(receipt) => {
+        assert_matches!(&actual_tx.transaction.0, Transaction::Invoke(tx) => {
+           assert_eq!(expected_hash, tx.transaction_hash());
+        });
+
+        assert_matches!(&actual_tx.receipt.0.receipt, TransactionReceipt::Invoke(receipt) => {
            assert_eq!(expected_hash, &receipt.transaction_hash);
         });
     }

--- a/crates/rpc/rpc/tests/starknet_ext.rs
+++ b/crates/rpc/rpc/tests/starknet_ext.rs
@@ -1,0 +1,380 @@
+use assert_matches::assert_matches;
+use katana_primitives::genesis::constant::DEFAULT_STRK_FEE_TOKEN_ADDRESS;
+use katana_rpc_api::starknet_ext::StarknetApiExtClient;
+use katana_rpc_types::list::{ContinuationToken, GetBlocksRequest, GetTransactionsRequest};
+use katana_utils::TestNode;
+use starknet::accounts::ConnectedAccount;
+use starknet::core::types::{Felt, ResultPageRequest};
+
+mod common;
+
+use common::{Erc20Contract, Uint256};
+
+#[tokio::test]
+async fn get_blocks_basic_range() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate some blocks by sending transactions. Each transaction will generate a block. So we
+    // expect to have 3 blocks - block 0 to 2.
+    for _ in 0..3 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // Test getting blocks in range
+    let request = GetBlocksRequest {
+        from: 0,
+        to: Some(2),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 10 },
+    };
+
+    let response = client.get_blocks(request).await.unwrap();
+
+    // Should return blocks 0, 1, 2 (3 blocks total)
+    assert_eq!(response.blocks.len(), 3);
+    assert_eq!(response.blocks[0].0.block_number, 0);
+    assert_eq!(response.blocks[1].0.block_number, 1);
+    assert_eq!(response.blocks[2].0.block_number, 2);
+    assert!(response.continuation_token.is_none());
+}
+
+#[tokio::test]
+async fn get_blocks_with_chunk_size() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate some blocks by sending transactions. Each transaction will generate a block. So we
+    // expect to have 5 blocks - block 0 to 4.
+    for _ in 0..5 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // Request with chunk size limit
+    let request = GetBlocksRequest {
+        from: 0,
+        to: Some(5),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 3 },
+    };
+
+    let response = client.get_blocks(request).await.unwrap();
+
+    // Should return only first 3 blocks due to chunk size limit
+    assert_eq!(response.blocks.len(), 3);
+    assert_eq!(response.blocks[0].0.block_number, 0);
+    assert_eq!(response.blocks[1].0.block_number, 1);
+    assert_eq!(response.blocks[2].0.block_number, 2);
+
+    // Should have continuation token since more blocks are available - starting from block 3
+    // because we've only gotten until block 2.
+    let expected_token = ContinuationToken { item_n: 3 };
+
+    // Should have continuation token since more blocks are available
+    assert_matches!(response.continuation_token, Some(token) => {
+        let actual_token = ContinuationToken::parse(&token).unwrap();
+        assert_eq!(actual_token, expected_token);
+    });
+}
+
+#[tokio::test]
+async fn get_blocks_pagination() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate blocks
+    for _ in 0..5 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // First page
+    let request = GetBlocksRequest {
+        from: 0,
+        to: Some(5),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 2 },
+    };
+
+    let first_response = client.get_blocks(request).await.unwrap();
+    assert_eq!(first_response.blocks.len(), 2);
+    assert_eq!(first_response.blocks[0].0.block_number, 0);
+    assert_eq!(first_response.blocks[1].0.block_number, 1);
+    assert!(first_response.continuation_token.is_some());
+
+    // Second page using continuation token
+    let request = GetBlocksRequest {
+        from: 0,
+        to: Some(5),
+        result_page_request: ResultPageRequest {
+            continuation_token: first_response.continuation_token.clone(),
+            chunk_size: 2,
+        },
+    };
+
+    let second_response = client.get_blocks(request).await.unwrap();
+    assert_eq!(second_response.blocks.len(), 2);
+    assert_eq!(second_response.blocks[0].0.block_number, 2);
+    assert_eq!(second_response.blocks[1].0.block_number, 3);
+    assert!(second_response.continuation_token.is_some());
+}
+
+#[tokio::test]
+async fn get_blocks_no_to_parameter() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate some blocks
+    for _ in 0..3 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // Test without 'to' parameter (should get from start to latest)
+    let request = GetBlocksRequest {
+        from: 1,
+        to: None,
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 10 },
+    };
+
+    let response = client.get_blocks(request).await.unwrap();
+
+    // Should return blocks from 1 to latest
+    assert!(response.blocks.len() >= 3); // At least blocks 1, 2, 3
+    assert_eq!(response.blocks[0].0.block_number, 1);
+}
+
+#[tokio::test]
+async fn get_transactions_basic_range() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate some transactions
+    let mut tx_hashes = Vec::new();
+    for _ in 0..3 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        let tx_hash = result.transaction_hash;
+        tx_hashes.push(tx_hash);
+
+        katana_utils::TxWaiter::new(tx_hash, &account.provider()).await.unwrap();
+    }
+
+    // Test getting transactions in range
+    let request = GetTransactionsRequest {
+        from: 0,
+        to: Some(2),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 10 },
+    };
+
+    let response = client.get_transactions(request).await.unwrap();
+
+    // Should return transactions 0, 1, 2
+    assert_eq!(response.transactions.len(), 3);
+    assert!(response.continuation_token.is_none());
+}
+
+#[tokio::test]
+async fn get_transactions_with_chunk_size() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate some transactions
+    let mut tx_hashes = Vec::new();
+    for _ in 0..5 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        let tx_hash = result.transaction_hash;
+        tx_hashes.push(tx_hash);
+
+        katana_utils::TxWaiter::new(tx_hash, &account.provider()).await.unwrap();
+    }
+
+    // Request with chunk size limit
+    let request = GetTransactionsRequest {
+        from: 0,
+        to: Some(5),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 3 },
+    };
+
+    let response = client.get_transactions(request).await.unwrap();
+    let txs = response.transactions;
+
+    // Should return only first 3 transactions due to chunk size limit
+    assert_eq!(txs.len(), 3);
+    // Should have continuation token since more transactions are available
+    assert!(response.continuation_token.is_some());
+
+    for (expected_hash, actual_tx) in tx_hashes.iter().zip(txs.iter()) {
+        assert_eq!(expected_hash, actual_tx.0.transaction_hash());
+    }
+}
+
+#[tokio::test]
+async fn get_transactions_pagination() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate transactions
+    for _ in 0..5 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // First page
+    let request = GetTransactionsRequest {
+        from: 0,
+        to: Some(5),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 2 },
+    };
+
+    let first_response = client.get_transactions(request).await.unwrap();
+    assert_eq!(first_response.transactions.len(), 2);
+    assert!(first_response.continuation_token.is_some());
+
+    // Second page using continuation token
+    let request = GetTransactionsRequest {
+        from: 0,
+        to: Some(5),
+        result_page_request: ResultPageRequest {
+            continuation_token: first_response.continuation_token.clone(),
+            chunk_size: 2,
+        },
+    };
+
+    let second_response = client.get_transactions(request).await.unwrap();
+    assert_eq!(second_response.transactions.len(), 2);
+    assert!(second_response.continuation_token.is_some());
+}
+
+#[tokio::test]
+async fn get_transactions_no_to_parameter() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Generate some transactions
+    for _ in 0..3 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // Test without 'to' parameter (should get from start to latest)
+    let request = GetTransactionsRequest {
+        from: 1,
+        to: None,
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 10 },
+    };
+
+    let response = client.get_transactions(request).await.unwrap();
+
+    // Should return transactions from 1 to latest
+    assert!(response.transactions.len() >= 3);
+}
+
+#[tokio::test]
+async fn transaction_number() {
+    let sequencer = TestNode::new().await;
+
+    let client = sequencer.rpc_http_client();
+    let account = sequencer.account();
+    let erc20 = Erc20Contract::new(DEFAULT_STRK_FEE_TOKEN_ADDRESS.into(), &account);
+
+    // function call params
+    let recipient = Felt::ONE;
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    // Initially should be 0 transactions
+    let initial_count = client.transaction_number().await.unwrap();
+    assert_eq!(initial_count, 0);
+
+    // Generate some transactions
+    for _ in 0..3 {
+        let result = erc20.transfer(&recipient, &amount).send().await.unwrap();
+        katana_utils::TxWaiter::new(result.transaction_hash, &account.provider()).await.unwrap();
+    }
+
+    // Should now have 3 more transactions
+    let final_count = client.transaction_number().await.unwrap();
+    assert_eq!(final_count, initial_count + 3);
+}
+
+#[tokio::test]
+async fn empty_range_requests() {
+    let sequencer = TestNode::new().await;
+    let client = sequencer.rpc_http_client();
+
+    // Test empty blocks range
+    let blocks_request = GetBlocksRequest {
+        from: 100, // Non-existent block
+        to: Some(200),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 10 },
+    };
+
+    let blocks_response = client.get_blocks(blocks_request).await.unwrap();
+    assert_eq!(blocks_response.blocks.len(), 0);
+    assert!(blocks_response.continuation_token.is_none());
+
+    // Test empty transactions range
+    let txs_request = GetTransactionsRequest {
+        from: 100, // Non-existent transaction
+        to: Some(200),
+        result_page_request: ResultPageRequest { continuation_token: None, chunk_size: 10 },
+    };
+
+    let txs_response = client.get_transactions(txs_request).await.unwrap();
+    assert_eq!(txs_response.transactions.len(), 0);
+    assert!(txs_response.continuation_token.is_none());
+}

--- a/crates/rpc/rpc/tests/starknet_ext.rs
+++ b/crates/rpc/rpc/tests/starknet_ext.rs
@@ -382,7 +382,7 @@ async fn empty_range_requests() {
 
     let blocks_response = client.get_blocks(blocks_request).await.unwrap();
     assert_eq!(blocks_response.blocks.len(), 0);
-    assert!(blocks_response.continuation_token).is_none();
+    assert!(blocks_response.continuation_token.is_none());
 
     // Test empty transactions range
     let txs_request = GetTransactionsRequest {

--- a/crates/rpc/rpc/tests/starknet_ext.rs
+++ b/crates/rpc/rpc/tests/starknet_ext.rs
@@ -333,10 +333,10 @@ async fn get_transactions_no_to_parameter() {
 
     let response = client.get_transactions(request).await.unwrap();
 
-    // Should return transactions from 1 to latest
-    assert!(response.transactions.len() >= 3);
+    // Should return transactions from 1 to latest (3)
+    assert_eq!(response.transactions.len(), 2);
 
-    for (expected_hash, actual_tx) in tx_hashes.iter().zip(response.transactions.iter()) {
+    for (expected_hash, actual_tx) in tx_hashes.iter().skip(1).zip(response.transactions.iter()) {
         assert_eq!(expected_hash, actual_tx.0.transaction_hash());
     }
 }
@@ -382,7 +382,7 @@ async fn empty_range_requests() {
 
     let blocks_response = client.get_blocks(blocks_request).await.unwrap();
     assert_eq!(blocks_response.blocks.len(), 0);
-    assert!(blocks_response.continuation_token.is_none());
+    assert!(blocks_response.continuation_token).is_none();
 
     // Test empty transactions range
     let txs_request = GetTransactionsRequest {

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -231,6 +231,10 @@ where
     fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>> {
         TransactionsProviderExt::transaction_hashes_in_range(&self.provider, range)
     }
+
+    fn total_transactions(&self) -> ProviderResult<usize> {
+        TransactionsProviderExt::total_transactions(&self.provider)
+    }
 }
 
 impl<Db> ReceiptProvider for BlockchainProvider<Db>

--- a/crates/storage/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/src/providers/db/mod.rs
@@ -536,6 +536,13 @@ impl<Db: Database> TransactionsProviderExt for DbProvider<Db> {
         db_tx.commit()?;
         Ok(hashes)
     }
+
+    fn total_transactions(&self) -> ProviderResult<usize> {
+        let tx = self.0.tx()?;
+        let total = tx.entries::<tables::Transactions>()?;
+        tx.commit()?;
+        Ok(total)
+    }
 }
 
 impl<Db: Database> TransactionStatusProvider for DbProvider<Db> {

--- a/crates/storage/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/src/providers/db/mod.rs
@@ -524,7 +524,7 @@ impl<Db: Database> TransactionsProviderExt for DbProvider<Db> {
     fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>> {
         let db_tx = self.0.tx()?;
 
-        let total = range.end - range.start;
+        let total = range.end.saturating_sub(range.start);
         let mut hashes = Vec::with_capacity(total as usize);
 
         for i in range {

--- a/crates/storage/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/src/providers/db/mod.rs
@@ -220,7 +220,7 @@ impl<Db: Database> BlockProvider for DbProvider<Db> {
     fn blocks_in_range(&self, range: RangeInclusive<u64>) -> ProviderResult<Vec<Block>> {
         let db_tx = self.0.tx()?;
 
-        let total = range.end() - range.start() + 1;
+        let total = range.end().saturating_sub(*range.start()) + 1;
         let mut blocks = Vec::with_capacity(total as usize);
 
         for num in range {
@@ -445,7 +445,7 @@ impl<Db: Database> TransactionProvider for DbProvider<Db> {
     fn transaction_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>> {
         let db_tx = self.0.tx()?;
 
-        let total = range.end - range.start;
+        let total = range.end.saturating_sub(range.start);
         let mut transactions = Vec::with_capacity(total as usize);
 
         for i in range {

--- a/crates/storage/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/src/providers/fork/mod.rs
@@ -194,6 +194,10 @@ impl<Db: Database> TransactionsProviderExt for ForkedProvider<Db> {
     fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>> {
         self.provider.transaction_hashes_in_range(range)
     }
+
+    fn total_transactions(&self) -> ProviderResult<usize> {
+        self.provider.total_transactions()
+    }
 }
 
 impl<Db: Database> TransactionStatusProvider for ForkedProvider<Db> {

--- a/crates/storage/provider/src/traits/transaction.rs
+++ b/crates/storage/provider/src/traits/transaction.rs
@@ -45,6 +45,9 @@ pub trait TransactionProvider: Send + Sync {
 pub trait TransactionsProviderExt: TransactionProvider + Send + Sync {
     /// Retrieves the tx hashes for the given range of tx numbers.
     fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>>;
+
+    /// Retrieves the total number of transactions.
+    fn total_transactions(&self) -> ProviderResult<usize>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]

--- a/crates/utils/src/node.rs
+++ b/crates/utils/src/node.rs
@@ -107,6 +107,7 @@ pub fn test_config() -> Config {
 
     let rpc = RpcConfig {
         port: 0,
+        explorer: true,
         addr: DEFAULT_RPC_ADDR,
         apis: RpcModulesList::all(),
         max_proof_keys: Some(100),


### PR DESCRIPTION
Resolves: #186 

Extending the Starknet JSON-RPC server to include several new methods: `starknet_getBlocks`, `starknet_getTransactions`, `starknet_transactionNumber`. These methods are added primarily to support a feature on Explorer (https://github.com/cartridge-gg/explorer/issues/184) - to display a list of blocks and transactions which aren't possible with the existing set of Starknet JSON-RPC (which Explorer solely rely upon atm).

`starknet_getBlocks`, and `starknet_getTransactions` are intended to be the block and tranasctions equivalent of `starknet_getEvents` - where instead of returning events, they return blocks and transactions repsectively. 

While `starknet_transactionNumber` is the equivalent of `starknet_blockNumber` but for transaction. In this case, the transaction number is a key that is assigned to every transactions and used mainly for indexing purpose in the Katana database. As such its semantic is very much internal to Katana. Considering Katana only stores executed (i.e., mined transactions), the transaction number can also be seen as the order of inclusion relative to all mined transactions ever.

This is intended to be a temporary solution until we've implemented a more efficient solution for querying this type of data from Katana. Ideally, as GraphQL queries with an underlying database that allows for efficient sequential queries.