### PR TITLE
feat(node-bindings): provide bindings for all available flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,6 +6638,7 @@ name = "katana-node-bindings"
 version = "1.6.3"
 dependencies = [
  "criterion",
+ "katana-tracing",
  "pprof",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6939,6 +6939,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stackdriver",
  "opentelemetry_sdk",
+ "rstest 0.18.2",
  "rustls 0.23.27",
  "serde",
  "thiserror 1.0.69",

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -9,6 +9,8 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+katana-tracing.workspace = true
+
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -12,6 +12,7 @@ use std::process::{Child, Command};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
+pub use katana_tracing::LogFormat;
 use starknet::core::types::{Felt, FromStrError};
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet::macros::short_string;
@@ -158,12 +159,12 @@ const CHAIN_ID_LOG_SUBSTR: &str = "Starting node.";
 /// # Example
 ///
 /// ```no_run
-/// use katana_node_bindings::Katana;
+/// use katana_node_bindings::{Katana, LogFormat};
 ///
 /// let port = 5050u16;
 /// let url = format!("http://localhost:{}", port).to_string();
 ///
-/// let katana = Katana::new().port(port).spawn();
+/// let katana = Katana::new().port(port).log_format(LogFormat::Json).spawn();
 ///
 /// drop(katana); // this will kill the instance
 /// ```
@@ -173,24 +174,42 @@ pub struct Katana {
     // General options
     dev: bool,
     no_mining: bool,
-    json_log: bool,
+    silent: bool,
+    log_format: Option<LogFormat>,
     block_time: Option<u64>,
+    sequencing_block_max_cairo_steps: Option<u64>,
     db_dir: Option<PathBuf>,
-    l1_provider: Option<String>,
-    fork_block_number: Option<u64>,
+    config: Option<PathBuf>,
     messaging: Option<PathBuf>,
 
+    // Forking options
+    fork_provider: Option<String>,
+    fork_block: Option<u64>,
+    l1_provider: Option<String>, // Keep for backward compatibility
+
+    // Tracer options
+    tracer_gcloud: bool,
+    tracer_otlp: bool,
+    tracer_gcloud_project: Option<String>,
+    tracer_otlp_endpoint: Option<String>,
+
     // Metrics options
+    metrics: bool,
     metrics_addr: Option<SocketAddr>,
     metrics_port: Option<u16>,
 
     // Server options
     http_addr: Option<SocketAddr>,
     http_port: Option<u16>,
+    http_cors_origins: Option<String>,
+    http_api: Option<String>,
     rpc_max_connections: Option<u64>,
-    rpc_timeout_ms: Option<u64>,
+    rpc_max_request_body_size: Option<u64>,
+    rpc_max_response_body_size: Option<u64>,
+    rpc_timeout: Option<u64>,
+    rpc_max_event_page_size: Option<u64>,
+    rpc_max_proof_keys: Option<u64>,
     rpc_max_call_gas: Option<u64>,
-    http_cors_domain: Option<String>,
 
     // Dev options
     seed: Option<u64>,
@@ -202,11 +221,31 @@ pub struct Katana {
     chain_id: Option<Felt>,
     validate_max_steps: Option<u64>,
     invoke_max_steps: Option<u64>,
-    eth_gas_price: Option<u64>,
-    strk_gas_price: Option<u64>,
     genesis: Option<PathBuf>,
 
+    // Gas Price Oracle options
+    gpo_l2_eth_gas_price: Option<u64>,
+    gpo_l2_strk_gas_price: Option<u64>,
+    gpo_l1_eth_gas_price: Option<u64>,
+    gpo_l1_strk_gas_price: Option<u64>,
+    gpo_l1_eth_data_gas_price: Option<u64>,
+    gpo_l1_strk_data_gas_price: Option<u64>,
+
+    // Explorer options
+    explorer: bool,
+
     // Cartridge options
+    cartridge_controllers: bool,
+    cartridge_paymaster: bool,
+    cartridge_api: Option<String>,
+
+    // Deprecated options (kept for backward compatibility)
+    json_log: bool,
+    rpc_timeout_ms: Option<u64>,
+    http_cors_domain: Option<String>,
+    fork_block_number: Option<u64>,
+    eth_gas_price: Option<u64>,
+    strk_gas_price: Option<u64>,
     enable_cartridge_paymaster: bool,
     cartridge_api_url: Option<String>,
 
@@ -226,7 +265,7 @@ impl Katana {
     /// fn a() {
     ///  let katana = Katana::default().spawn();
     ///
-    ///  println!("Katana running at `{}`", katana.endpoint());
+    ///  println!("Katana running at `{}`", katana.rpc_addr());
     /// # }
     /// ```
     pub fn new() -> Self {
@@ -242,7 +281,7 @@ impl Katana {
     /// fn a() {
     ///  let katana = Katana::at("~/.katana/bin/katana").spawn();
     ///
-    ///  println!("Katana running at `{}`", katana.endpoint());
+    ///  println!("Katana running at `{}`", katana.rpc_addr());
     /// # }
     /// ```
     pub fn at(path: impl Into<PathBuf>) -> Self {
@@ -277,27 +316,9 @@ impl Katana {
         self
     }
 
-    /// Sets the RPC URL to fork the network from.
-    pub fn l1_provider<T: Into<String>>(mut self, rpc_url: T) -> Self {
-        self.l1_provider = Some(rpc_url.into());
-        self
-    }
-
     /// Enables the dev mode.
     pub const fn dev(mut self, dev: bool) -> Self {
         self.dev = dev;
-        self
-    }
-
-    /// Enables JSON logging.
-    pub const fn json_log(mut self, json_log: bool) -> Self {
-        self.json_log = json_log;
-        self
-    }
-
-    /// Sets the fork block number which will be used when the `katana` instance is launched.
-    pub const fn fork_block_number(mut self, fork_block_number: u64) -> Self {
-        self.fork_block_number = Some(fork_block_number);
         self
     }
 
@@ -332,21 +353,9 @@ impl Katana {
         self
     }
 
-    /// Sets the maximum timeout for the RPC.
-    pub const fn rpc_timeout_ms(mut self, timeout_ms: u64) -> Self {
-        self.rpc_timeout_ms = Some(timeout_ms);
-        self
-    }
-
     /// Sets the maximum gas for the `starknet_call` RPC method.
     pub const fn rpc_max_call_gas(mut self, max_call_gas: u64) -> Self {
         self.rpc_max_call_gas = Some(max_call_gas);
-        self
-    }
-
-    /// Enables the CORS layer and sets the allowed origins, separated by commas.
-    pub fn http_cors_domain<T: Into<String>>(mut self, allowed_origins: T) -> Self {
-        self.http_cors_domain = Some(allowed_origins.into());
         self
     }
 
@@ -394,18 +403,6 @@ impl Katana {
         self
     }
 
-    /// Sets the L1 ETH gas price (denominated in wei).
-    pub const fn eth_gas_price(mut self, eth_gas_price: u64) -> Self {
-        self.eth_gas_price = Some(eth_gas_price);
-        self
-    }
-
-    /// Sets the L1 STRK gas price (denominated in fri).
-    pub const fn strk_gas_price(mut self, strk_gas_price: u64) -> Self {
-        self.strk_gas_price = Some(strk_gas_price);
-        self
-    }
-
     /// Sets the genesis configuration path.
     pub fn genesis<T: Into<PathBuf>>(mut self, genesis: T) -> Self {
         self.genesis = Some(genesis.into());
@@ -424,6 +421,256 @@ impl Katana {
         self
     }
 
+    /// Don't print anything on startup.
+    pub const fn silent(mut self, silent: bool) -> Self {
+        self.silent = silent;
+        self
+    }
+
+    /// Sets the log format to use.
+    pub const fn log_format(mut self, format: LogFormat) -> Self {
+        self.log_format = Some(format);
+        self
+    }
+
+    /// Sets the maximum number of Cairo steps available for block sequencing.
+    pub const fn sequencing_block_max_cairo_steps(mut self, steps: u64) -> Self {
+        self.sequencing_block_max_cairo_steps = Some(steps);
+        self
+    }
+
+    /// Sets the configuration file path.
+    pub fn config<T: Into<PathBuf>>(mut self, config: T) -> Self {
+        self.config = Some(config.into());
+        self
+    }
+
+    /// Sets the RPC URL to fork the network from.
+    pub fn fork_provider<T: Into<String>>(mut self, provider: T) -> Self {
+        self.fork_provider = Some(provider.into());
+        self
+    }
+
+    /// Sets the fork block number.
+    pub const fn fork_block(mut self, block: u64) -> Self {
+        self.fork_block = Some(block);
+        self
+    }
+
+    /// Enable Google Cloud Trace exporter.
+    pub const fn tracer_gcloud(mut self, enable: bool) -> Self {
+        self.tracer_gcloud = enable;
+        self
+    }
+
+    /// Enable OpenTelemetry Protocol (OTLP) exporter.
+    pub const fn tracer_otlp(mut self, enable: bool) -> Self {
+        self.tracer_otlp = enable;
+        self
+    }
+
+    /// Sets the Google Cloud project ID.
+    pub fn tracer_gcloud_project<T: Into<String>>(mut self, project_id: T) -> Self {
+        self.tracer_gcloud_project = Some(project_id.into());
+        self
+    }
+
+    /// Sets the OTLP endpoint URL.
+    pub fn tracer_otlp_endpoint<T: Into<String>>(mut self, endpoint: T) -> Self {
+        self.tracer_otlp_endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Enable metrics collection.
+    pub const fn metrics(mut self, enable: bool) -> Self {
+        self.metrics = enable;
+        self
+    }
+
+    /// Sets the comma separated list of domains from which to accept cross origin requests.
+    pub fn http_cors_origins<T: Into<String>>(mut self, origins: T) -> Self {
+        self.http_cors_origins = Some(origins.into());
+        self
+    }
+
+    /// Sets the API modules offered over the HTTP-RPC interface.
+    pub fn http_api<T: Into<String>>(mut self, modules: T) -> Self {
+        self.http_api = Some(modules.into());
+        self
+    }
+
+    /// Sets the maximum request body size (in bytes).
+    pub const fn rpc_max_request_body_size(mut self, size: u64) -> Self {
+        self.rpc_max_request_body_size = Some(size);
+        self
+    }
+
+    /// Sets the maximum response body size (in bytes).
+    pub const fn rpc_max_response_body_size(mut self, size: u64) -> Self {
+        self.rpc_max_response_body_size = Some(size);
+        self
+    }
+
+    /// Sets the timeout for the RPC server request (in seconds).
+    pub const fn rpc_timeout(mut self, timeout: u64) -> Self {
+        self.rpc_timeout = Some(timeout);
+        self
+    }
+
+    /// Sets the maximum page size for event queries.
+    pub const fn rpc_max_event_page_size(mut self, size: u64) -> Self {
+        self.rpc_max_event_page_size = Some(size);
+        self
+    }
+
+    /// Sets the maximum keys for requesting storage proofs.
+    pub const fn rpc_max_proof_keys(mut self, keys: u64) -> Self {
+        self.rpc_max_proof_keys = Some(keys);
+        self
+    }
+
+    /// Sets the L2 ETH gas price (denominated in wei).
+    pub const fn gpo_l2_eth_gas_price(mut self, price: u64) -> Self {
+        self.gpo_l2_eth_gas_price = Some(price);
+        self
+    }
+
+    /// Sets the L2 STRK gas price (denominated in fri).
+    pub const fn gpo_l2_strk_gas_price(mut self, price: u64) -> Self {
+        self.gpo_l2_strk_gas_price = Some(price);
+        self
+    }
+
+    /// Sets the L1 ETH gas price (denominated in wei).
+    pub const fn gpo_l1_eth_gas_price(mut self, price: u64) -> Self {
+        self.gpo_l1_eth_gas_price = Some(price);
+        self
+    }
+
+    /// Sets the L1 STRK gas price (denominated in fri).
+    pub const fn gpo_l1_strk_gas_price(mut self, price: u64) -> Self {
+        self.gpo_l1_strk_gas_price = Some(price);
+        self
+    }
+
+    /// Sets the L1 ETH data gas price (denominated in wei).
+    pub const fn gpo_l1_eth_data_gas_price(mut self, price: u64) -> Self {
+        self.gpo_l1_eth_data_gas_price = Some(price);
+        self
+    }
+
+    /// Sets the L1 STRK data gas price (denominated in fri).
+    pub const fn gpo_l1_strk_data_gas_price(mut self, price: u64) -> Self {
+        self.gpo_l1_strk_data_gas_price = Some(price);
+        self
+    }
+
+    /// Enable and launch the explorer frontend.
+    pub const fn explorer(mut self, enable: bool) -> Self {
+        self.explorer = enable;
+        self
+    }
+
+    /// Declare all versions of the Controller class at genesis.
+    pub const fn cartridge_controllers(mut self, enable: bool) -> Self {
+        self.cartridge_controllers = enable;
+        self
+    }
+
+    /// Whether to use the Cartridge paymaster.
+    pub const fn cartridge_paymaster(mut self, enable: bool) -> Self {
+        self.cartridge_paymaster = enable;
+        self
+    }
+
+    /// Sets the root URL for the Cartridge API.
+    pub fn cartridge_api<T: Into<String>>(mut self, api: T) -> Self {
+        self.cartridge_api = Some(api.into());
+        self
+    }
+
+    // Deprecated methods for backward compatibility
+    /// Enables JSON logging.
+    ///
+    /// **Deprecated**: Use `log_format(LogFormat::Json)` instead.
+    #[deprecated(since = "0.1.0", note = "Use `log_format(LogFormat::Json)` instead")]
+    pub const fn json_log(mut self, json_log: bool) -> Self {
+        self.json_log = json_log;
+        self
+    }
+
+    /// Sets the fork block number which will be used when the `katana` instance is launched.
+    ///
+    /// **Deprecated**: Use `fork_block()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `fork_block()` instead")]
+    pub const fn fork_block_number(mut self, fork_block_number: u64) -> Self {
+        self.fork_block_number = Some(fork_block_number);
+        self
+    }
+
+    /// Sets the RPC URL to fork the network from.
+    ///
+    /// **Deprecated**: Use `fork_provider()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `fork_provider()` instead")]
+    pub fn l1_provider<T: Into<String>>(mut self, rpc_url: T) -> Self {
+        self.l1_provider = Some(rpc_url.into());
+        self
+    }
+
+    /// Sets the maximum timeout for the RPC.
+    ///
+    /// **Deprecated**: Use `rpc_timeout()` instead (note: units changed from ms to seconds).
+    #[deprecated(since = "0.1.0", note = "Use `rpc_timeout()` instead")]
+    pub const fn rpc_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.rpc_timeout_ms = Some(timeout_ms);
+        self
+    }
+
+    /// Enables the CORS layer and sets the allowed origins, separated by commas.
+    ///
+    /// **Deprecated**: Use `http_cors_origins()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `http_cors_origins()` instead")]
+    pub fn http_cors_domain<T: Into<String>>(mut self, allowed_origins: T) -> Self {
+        self.http_cors_domain = Some(allowed_origins.into());
+        self
+    }
+
+    /// Sets the L1 ETH gas price (denominated in wei).
+    ///
+    /// **Deprecated**: Use `gpo_l2_eth_gas_price()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `gpo_l2_eth_gas_price()` instead")]
+    pub const fn eth_gas_price(mut self, eth_gas_price: u64) -> Self {
+        self.eth_gas_price = Some(eth_gas_price);
+        self
+    }
+
+    /// Sets the L1 STRK gas price (denominated in fri).
+    ///
+    /// **Deprecated**: Use `gpo_l2_strk_gas_price()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `gpo_l2_strk_gas_price()` instead")]
+    pub const fn strk_gas_price(mut self, strk_gas_price: u64) -> Self {
+        self.strk_gas_price = Some(strk_gas_price);
+        self
+    }
+
+    /// Whether to use the Cartridge paymaster.
+    ///
+    /// **Deprecated**: Use `cartridge_paymaster()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `cartridge_paymaster()` instead")]
+    pub const fn enable_cartridge_paymaster(mut self, enable: bool) -> Self {
+        self.enable_cartridge_paymaster = enable;
+        self
+    }
+
+    /// Sets the root URL for the Cartridge API.
+    ///
+    /// **Deprecated**: Use `cartridge_api()` instead.
+    #[deprecated(since = "0.1.0", note = "Use `cartridge_api()` instead")]
+    pub fn cartridge_api_url<T: Into<String>>(mut self, url: T) -> Self {
+        self.cartridge_api_url = Some(url.into());
+        self
+    }
+
     /// Consumes the builder and spawns `katana`.
     ///
     /// # Panics
@@ -439,14 +686,10 @@ impl Katana {
         let mut cmd = self.program.as_ref().map_or_else(|| Command::new("katana"), Command::new);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
 
-        if let Some(host) = self.http_addr {
-            cmd.arg("--http.addr").arg(host.to_string());
+        // Node options
+        if self.silent {
+            cmd.arg("--silent");
         }
-
-        // In the case where port 0 is set, we will need to extract the actual port number
-        // from the logs.
-        let mut port = self.http_port.unwrap_or(0);
-        cmd.arg("--http.port").arg(port.to_string());
 
         if self.no_mining {
             cmd.arg("--no-mining");
@@ -456,12 +699,71 @@ impl Katana {
             cmd.arg("-b").arg(block_time.to_string());
         }
 
+        if let Some(steps) = self.sequencing_block_max_cairo_steps {
+            cmd.arg("--sequencing.block-max-cairo-steps").arg(steps.to_string());
+        }
+
         if let Some(db_dir) = self.db_dir {
             cmd.arg("--db-dir").arg(db_dir);
         }
 
+        if let Some(config) = self.config {
+            cmd.arg("--config").arg(config);
+        }
+
+        if let Some(messaging) = self.messaging {
+            cmd.arg("--messaging").arg(messaging);
+        }
+
+        // Handle backward compatibility for l1_provider
         if let Some(url) = self.l1_provider {
             cmd.arg("--l1.provider").arg(url);
+        }
+
+        // Logging options
+        if let Some(ref format) = self.log_format {
+            cmd.arg("--log.format").arg(format.to_string());
+        } else if self.json_log {
+            // Backward compatibility
+            cmd.arg("--log.format").arg("json");
+        }
+
+        // Tracer options
+        if self.tracer_gcloud {
+            cmd.arg("--tracer.gcloud");
+        }
+
+        if self.tracer_otlp {
+            cmd.arg("--tracer.otlp");
+        }
+
+        if let Some(project_id) = self.tracer_gcloud_project {
+            cmd.arg("--tracer.gcloud-project").arg(project_id);
+        }
+
+        if let Some(endpoint) = self.tracer_otlp_endpoint {
+            cmd.arg("--tracer.otlp-endpoint").arg(endpoint);
+        }
+
+        // Server options
+        if let Some(host) = self.http_addr {
+            cmd.arg("--http.addr").arg(host.to_string());
+        }
+
+        // In the case where port 0 is set, we will need to extract the actual port number
+        // from the logs.
+        let mut port = self.http_port.unwrap_or(0);
+        cmd.arg("--http.port").arg(port.to_string());
+
+        if let Some(origins) = self.http_cors_origins {
+            cmd.arg("--http.cors_origins").arg(origins);
+        } else if let Some(domain) = self.http_cors_domain {
+            // Backward compatibility
+            cmd.arg("--http.cors_origins").arg(domain);
+        }
+
+        if let Some(modules) = self.http_api {
+            cmd.arg("--http.api").arg(modules);
         }
 
         // Need to make sure that the `--dev` is not being set twice.
@@ -507,52 +809,71 @@ impl Katana {
             cmd.arg("--dev.no-account-validation");
         }
 
-        if self.json_log {
-            cmd.args(["--log.format", "json"]);
-        }
-
-        if let Some(fork_block_number) = self.fork_block_number {
-            cmd.args(["--fork", "--fork.block"]).arg(fork_block_number.to_string());
-        }
-
-        if let Some(messaging) = self.messaging {
-            cmd.arg("--messaging").arg(messaging);
-        }
-
-        // Need to make sure that the `--metrics` is not being set twice.
-        let mut metrics_enabled = false;
-
-        if let Some(addr) = self.metrics_addr {
-            if !metrics_enabled {
-                cmd.arg("--metrics");
-                metrics_enabled = true;
-            }
-
-            cmd.arg("--metrics.addr").arg(addr.to_string());
-        }
-
-        if let Some(port) = self.metrics_port {
-            if !metrics_enabled {
-                cmd.arg("--metrics");
-            }
-
-            cmd.arg("--metrics.port").arg(port.to_string());
-        }
-
+        // RPC options
         if let Some(max_connections) = self.rpc_max_connections {
             cmd.arg("--rpc.max-connections").arg(max_connections.to_string());
         }
 
-        if let Some(timeout_ms) = self.rpc_timeout_ms {
-            cmd.arg("--rpc.timeout-ms").arg(timeout_ms.to_string());
+        if let Some(size) = self.rpc_max_request_body_size {
+            cmd.arg("--rpc.max-request-body-size").arg(size.to_string());
+        }
+
+        if let Some(size) = self.rpc_max_response_body_size {
+            cmd.arg("--rpc.max-response-body-size").arg(size.to_string());
+        }
+
+        if let Some(timeout) = self.rpc_timeout {
+            cmd.arg("--rpc.timeout").arg(timeout.to_string());
+        } else if let Some(timeout_ms) = self.rpc_timeout_ms {
+            // Backward compatibility - convert ms to seconds
+            cmd.arg("--rpc.timeout").arg((timeout_ms / 1000).to_string());
+        }
+
+        if let Some(size) = self.rpc_max_event_page_size {
+            cmd.arg("--rpc.max-event-page-size").arg(size.to_string());
+        }
+
+        if let Some(keys) = self.rpc_max_proof_keys {
+            cmd.arg("--rpc.max-proof-keys").arg(keys.to_string());
         }
 
         if let Some(max_call_gas) = self.rpc_max_call_gas {
             cmd.arg("--rpc.max-call-gas").arg(max_call_gas.to_string());
         }
 
-        if let Some(allowed_origins) = self.http_cors_domain {
-            cmd.arg("--http.corsdomain").arg(allowed_origins);
+        // Metrics options
+        let mut metrics_enabled = self.metrics;
+
+        if let Some(addr) = self.metrics_addr {
+            if !metrics_enabled {
+                cmd.arg("--metrics");
+                metrics_enabled = true;
+            }
+            cmd.arg("--metrics.addr").arg(addr.to_string());
+        }
+
+        if let Some(port) = self.metrics_port {
+            if !metrics_enabled {
+                cmd.arg("--metrics");
+                metrics_enabled = true;
+            }
+            cmd.arg("--metrics.port").arg(port.to_string());
+        }
+
+        if metrics_enabled && !self.metrics_addr.is_some() && !self.metrics_port.is_some() {
+            cmd.arg("--metrics");
+        }
+
+        // Forking options
+        if let Some(provider) = self.fork_provider {
+            cmd.arg("--fork.provider").arg(provider);
+        }
+
+        if let Some(block) = self.fork_block {
+            cmd.arg("--fork.block").arg(block.to_string());
+        } else if let Some(fork_block_number) = self.fork_block_number {
+            // Backward compatibility
+            cmd.arg("--fork.block").arg(fork_block_number.to_string());
         }
 
         if let Some(chain_id) = self.chain_id {
@@ -564,6 +885,69 @@ impl Katana {
 
         if let Some(validate_max_steps) = self.validate_max_steps {
             cmd.arg("--validate-max-steps").arg(validate_max_steps.to_string());
+        }
+
+        if let Some(invoke_max_steps) = self.invoke_max_steps {
+            cmd.arg("--invoke-max-steps").arg(invoke_max_steps.to_string());
+        }
+
+        if let Some(genesis) = self.genesis {
+            cmd.arg("--genesis").arg(genesis);
+        }
+
+        // Gas Price Oracle options
+        if let Some(price) = self.gpo_l2_eth_gas_price {
+            cmd.arg("--gpo.l2-eth-gas-price").arg(price.to_string());
+        } else if let Some(price) = self.eth_gas_price {
+            // Backward compatibility - assume it's L2 ETH gas price
+            cmd.arg("--gpo.l2-eth-gas-price").arg(price.to_string());
+        }
+
+        if let Some(price) = self.gpo_l2_strk_gas_price {
+            cmd.arg("--gpo.l2-strk-gas-price").arg(price.to_string());
+        } else if let Some(price) = self.strk_gas_price {
+            // Backward compatibility - assume it's L2 STRK gas price
+            cmd.arg("--gpo.l2-strk-gas-price").arg(price.to_string());
+        }
+
+        if let Some(price) = self.gpo_l1_eth_gas_price {
+            cmd.arg("--gpo.l1-eth-gas-price").arg(price.to_string());
+        }
+
+        if let Some(price) = self.gpo_l1_strk_gas_price {
+            cmd.arg("--gpo.l1-strk-gas-price").arg(price.to_string());
+        }
+
+        if let Some(price) = self.gpo_l1_eth_data_gas_price {
+            cmd.arg("--gpo.l1-eth-data-gas-price").arg(price.to_string());
+        }
+
+        if let Some(price) = self.gpo_l1_strk_data_gas_price {
+            cmd.arg("--gpo.l1-strk-data-gas-price").arg(price.to_string());
+        }
+
+        // Explorer options
+        if self.explorer {
+            cmd.arg("--explorer");
+        }
+
+        // Cartridge options
+        if self.cartridge_controllers {
+            cmd.arg("--cartridge.controllers");
+        }
+
+        if self.cartridge_paymaster {
+            cmd.arg("--cartridge.paymaster");
+        } else if self.enable_cartridge_paymaster {
+            // Backward compatibility
+            cmd.arg("--cartridge.paymaster");
+        }
+
+        if let Some(api) = self.cartridge_api {
+            cmd.arg("--cartridge.api").arg(api);
+        } else if let Some(url) = self.cartridge_api_url {
+            // Backward compatibility
+            cmd.arg("--cartridge.api").arg(url);
         }
 
         let mut child = cmd.spawn().map_err(Error::SpawnError)?;
@@ -579,14 +963,6 @@ impl Katana {
         // id) if not specified
         let mut chain_id: Felt = self.chain_id.unwrap_or(short_string!("KATANA"));
 
-        if let Some(url) = self.cartridge_api_url {
-            cmd.arg("--cartridge.api-url").arg(url);
-        }
-
-        if self.enable_cartridge_paymaster {
-            cmd.arg("--cartridge.paymaster");
-        }
-
         loop {
             if start + Duration::from_millis(self.timeout.unwrap_or(KATANA_STARTUP_TIMEOUT_MILLIS))
                 <= Instant::now()
@@ -598,7 +974,7 @@ impl Katana {
             reader.read_line(&mut line).map_err(Error::ReadLineError)?;
             trace!(line);
 
-            if self.json_log {
+            if self.json_log || self.log_format == Some(LogFormat::Json) {
                 // Because we using a concrete type for rpc addr log, we need to parse this first.
                 // Otherwise if we were to inverse the if statements, the else block
                 // would never be executed as all logs can be parsed as `JsonLog`.
@@ -754,7 +1130,8 @@ mod tests {
 
     #[test]
     fn can_launch_katana_with_json_log() {
-        let katana = Katana::new().json_log(true).chain_id(short_string!("SN_SEPOLIA")).spawn();
+        let katana =
+            Katana::new().log_format(LogFormat::Json).chain_id(short_string!("SN_SEPOLIA")).spawn();
         // Assert default values when using JSON logging
         assert_eq!(katana.accounts().len(), 10);
         assert_eq!(katana.chain_id(), short_string!("SN_SEPOLIA"));
@@ -848,5 +1225,90 @@ mod tests {
         let actual_chain_id = provider.chain_id().await.unwrap();
 
         assert_eq!(custom_chain_id, actual_chain_id);
+    }
+
+    #[test]
+    fn test_new_log_format_option() {
+        let katana = Katana::new().log_format(LogFormat::Json);
+        assert_eq!(katana.log_format.as_ref().unwrap(), &LogFormat::Json);
+
+        let katana_full = Katana::new().log_format(LogFormat::Full);
+        assert_eq!(katana_full.log_format.as_ref().unwrap(), &LogFormat::Full);
+    }
+
+    #[test]
+    fn test_log_format_display() {
+        assert_eq!(LogFormat::Json.to_string(), "json");
+        assert_eq!(LogFormat::Full.to_string(), "full");
+    }
+
+    #[test]
+    fn test_log_format_from_str() {
+        assert_eq!("json".parse::<LogFormat>().unwrap(), LogFormat::Json);
+        assert_eq!("JSON".parse::<LogFormat>().unwrap(), LogFormat::Json);
+        assert_eq!("full".parse::<LogFormat>().unwrap(), LogFormat::Full);
+        assert_eq!("FULL".parse::<LogFormat>().unwrap(), LogFormat::Full);
+
+        assert!("invalid".parse::<LogFormat>().is_err());
+    }
+
+    #[test]
+    fn test_log_format_default() {
+        assert_eq!(LogFormat::default(), LogFormat::Full);
+    }
+
+    #[test]
+    fn test_forking_options() {
+        let katana = Katana::new().fork_provider("http://localhost:8545").fork_block(12345);
+        assert_eq!(katana.fork_provider.as_ref().unwrap(), "http://localhost:8545");
+        assert_eq!(katana.fork_block.unwrap(), 12345);
+    }
+
+    #[test]
+    fn test_gas_price_oracle_options() {
+        let katana = Katana::new()
+            .gpo_l2_eth_gas_price(1000)
+            .gpo_l2_strk_gas_price(2000)
+            .gpo_l1_eth_gas_price(3000)
+            .gpo_l1_strk_gas_price(4000);
+
+        assert_eq!(katana.gpo_l2_eth_gas_price.unwrap(), 1000);
+        assert_eq!(katana.gpo_l2_strk_gas_price.unwrap(), 2000);
+        assert_eq!(katana.gpo_l1_eth_gas_price.unwrap(), 3000);
+        assert_eq!(katana.gpo_l1_strk_gas_price.unwrap(), 4000);
+    }
+
+    #[test]
+    fn test_rpc_options() {
+        let katana = Katana::new()
+            .rpc_max_request_body_size(1024)
+            .rpc_max_response_body_size(2048)
+            .rpc_timeout(30)
+            .rpc_max_event_page_size(100)
+            .rpc_max_proof_keys(50);
+
+        assert_eq!(katana.rpc_max_request_body_size.unwrap(), 1024);
+        assert_eq!(katana.rpc_max_response_body_size.unwrap(), 2048);
+        assert_eq!(katana.rpc_timeout.unwrap(), 30);
+        assert_eq!(katana.rpc_max_event_page_size.unwrap(), 100);
+        assert_eq!(katana.rpc_max_proof_keys.unwrap(), 50);
+    }
+
+    #[test]
+    fn test_cartridge_options() {
+        let katana = Katana::new()
+            .cartridge_controllers(true)
+            .cartridge_paymaster(true)
+            .cartridge_api("https://api.cartridge.gg");
+
+        assert!(katana.cartridge_controllers);
+        assert!(katana.cartridge_paymaster);
+        assert_eq!(katana.cartridge_api.as_ref().unwrap(), "https://api.cartridge.gg");
+    }
+
+    #[test]
+    fn test_explorer_option() {
+        let katana = Katana::new().explorer(true);
+        assert!(katana.explorer);
     }
 }

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -423,10 +423,11 @@ impl Katana {
 
     /// Sets the number of pre-funded accounts to generate.
     ///
+    /// Default: `10`
+    ///
     /// ## CLI Flag
     ///
     /// `--dev.accounts <NUM>`
-    /// Default: `10`
     pub fn accounts(mut self, accounts: u16) -> Self {
         self.accounts = Some(accounts);
         self

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -260,13 +260,13 @@ impl Katana {
     ///
     /// # Example
     ///
-    /// ```
-    /// # use katana_node_bindings::Katana;
-    /// fn a() {
-    ///  let katana = Katana::default().spawn();
+    /// ```ignore
+    /// use katana_node_bindings::Katana;
     ///
-    ///  println!("Katana running at `{}`", katana.rpc_addr());
-    /// # }
+    /// fn main() {
+    /// 	let katana = Katana::default().spawn();
+    /// 	println!("Katana running at `{}`", katana.rpc_addr());
+    /// }
     /// ```
     pub fn new() -> Self {
         Self::default()
@@ -276,13 +276,13 @@ impl Katana {
     ///
     /// # Example
     ///
-    /// ```
-    /// # use katana_node_bindings::Katana;
-    /// fn a() {
-    ///  let katana = Katana::at("~/.katana/bin/katana").spawn();
+    /// ```ignore
+    /// use katana_node_bindings::Katana;
     ///
-    ///  println!("Katana running at `{}`", katana.rpc_addr());
-    /// # }
+    /// fn main() {
+    ///     let katana = Katana::at("~/.katana/bin/katana").spawn();
+    ///     println!("Katana running at `{}`", katana.rpc_addr());
+    /// }
     /// ```
     pub fn at(path: impl Into<PathBuf>) -> Self {
         Self::new().path(path)
@@ -300,6 +300,10 @@ impl Katana {
     /// Sets the port which will be used when the `katana` instance is launched.
     ///
     /// Default: `5050`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--http.port <PORT>`
     pub fn port<T: Into<u16>>(mut self, port: T) -> Self {
         self.http_port = Some(port.into());
         self
@@ -307,18 +311,30 @@ impl Katana {
 
     /// Sets the block-time in milliseconds which will be used when the `katana` instance is
     /// launched.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `-b, --block-time <MILLISECONDS>`
     pub const fn block_time(mut self, block_time: u64) -> Self {
         self.block_time = Some(block_time);
         self
     }
 
     /// Sets the database directory path which will be used when the `katana` instance is launched.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--db-dir <PATH>`
     pub fn db_dir<T: Into<PathBuf>>(mut self, db_dir: T) -> Self {
         self.db_dir = Some(db_dir.into());
         self
     }
 
     /// Enables the dev mode.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--dev`
     pub const fn dev(mut self, dev: bool) -> Self {
         self.dev = dev;
         self
@@ -326,6 +342,10 @@ impl Katana {
 
     /// Sets the messaging configuration path which will be used when the `katana` instance is
     /// launched.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--messaging <PATH>`
     pub fn messaging<T: Into<PathBuf>>(mut self, messaging: T) -> Self {
         self.messaging = Some(messaging.into());
         self
@@ -334,6 +354,10 @@ impl Katana {
     /// Enables Prometheus metrics and sets the metrics server address.
     ///
     /// Default: `127.0.0.1`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--metrics.addr <ADDRESS>`
     pub fn metrics_addr<T: Into<SocketAddr>>(mut self, addr: T) -> Self {
         self.metrics_addr = Some(addr.into());
         self
@@ -342,6 +366,10 @@ impl Katana {
     /// Enables Prometheus metrics and sets the metrics server port.
     ///
     /// Default: `9100`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--metrics.port <PORT>`
     pub fn metrics_port<T: Into<u16>>(mut self, port: T) -> Self {
         self.metrics_port = Some(port.into());
         self
@@ -350,12 +378,20 @@ impl Katana {
     /// Sets the host IP address the server will listen on.
     ///
     /// Default: `127.0.0.1`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--http.addr <ADDRESS>`
     pub fn http_addr<T: Into<SocketAddr>>(mut self, addr: T) -> Self {
         self.http_addr = Some(addr.into());
         self
     }
 
     /// Sets the maximum number of concurrent connections allowed.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.max-connections <MAX>`
     pub const fn rpc_max_connections(mut self, max_connections: u64) -> Self {
         self.rpc_max_connections = Some(max_connections);
         self
@@ -364,6 +400,10 @@ impl Katana {
     /// Sets the maximum gas for the `starknet_call` RPC method.
     ///
     /// Default: `1000000000`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.max-call-gas <GAS>`
     pub const fn rpc_max_call_gas(mut self, max_call_gas: u64) -> Self {
         self.rpc_max_call_gas = Some(max_call_gas);
         self
@@ -372,6 +412,10 @@ impl Katana {
     /// Sets the seed for randomness of accounts to be predeployed.
     ///
     /// Default: `0`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--dev.seed <SEED>`
     pub const fn seed(mut self, seed: u64) -> Self {
         self.seed = Some(seed);
         self
@@ -379,6 +423,9 @@ impl Katana {
 
     /// Sets the number of pre-funded accounts to generate.
     ///
+    /// ## CLI Flag
+    ///
+    /// `--dev.accounts <NUM>`
     /// Default: `10`
     pub fn accounts(mut self, accounts: u16) -> Self {
         self.accounts = Some(accounts);
@@ -387,6 +434,10 @@ impl Katana {
 
     /// Enable or disable charging fee when executing transactions.
     /// Enabled by default.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--dev.no-fee` (when disabled)
     pub const fn fee(mut self, enable: bool) -> Self {
         self.disable_fee = !enable;
         self
@@ -394,12 +445,20 @@ impl Katana {
 
     /// Enables or disable transaction validation.
     /// Enabled by default.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--dev.no-account-validation` (when disabled)
     pub const fn validate(mut self, enable: bool) -> Self {
         self.disable_validate = !enable;
         self
     }
 
     /// Sets the chain ID.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--chain-id <CHAIN_ID>`
     pub const fn chain_id(mut self, id: Felt) -> Self {
         self.chain_id = Some(id);
         self
@@ -408,6 +467,10 @@ impl Katana {
     /// Sets the maximum number of steps available for the account validation logic.
     ///
     /// Default: `1000000`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--validate-max-steps <VALIDATE_MAX_STEPS>`
     pub const fn validate_max_steps(mut self, validate_max_steps: u64) -> Self {
         self.validate_max_steps = Some(validate_max_steps);
         self
@@ -416,30 +479,48 @@ impl Katana {
     /// Sets the maximum number of steps available for the account execution logic.
     ///
     /// Default: `10000000`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--invoke-max-steps <INVOKE_MAX_STEPS>`
     pub const fn invoke_max_steps(mut self, invoke_max_steps: u64) -> Self {
         self.invoke_max_steps = Some(invoke_max_steps);
         self
     }
 
     /// Sets the genesis configuration path.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--genesis <GENESIS>`
     pub fn genesis<T: Into<PathBuf>>(mut self, genesis: T) -> Self {
         self.genesis = Some(genesis.into());
         self
     }
 
     /// Sets the timeout which will be used when the `katana` instance is launched.
+    ///
+    /// Note: This is an internal timeout for the bindings, not a CLI flag.
     pub const fn timeout(mut self, timeout: u64) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
     /// Disable auto and interval mining, and mine on demand instead via an endpoint.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--no-mining`
     pub const fn no_mining(mut self, no_mining: bool) -> Self {
         self.no_mining = no_mining;
         self
     }
 
     /// Don't print anything on startup.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--silent`
     pub const fn silent(mut self, silent: bool) -> Self {
         self.silent = silent;
         self
@@ -448,90 +529,150 @@ impl Katana {
     /// Sets the log format to use.
     ///
     /// Default: `LogFormat::Full`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--log.format <FORMAT>`
     pub const fn log_format(mut self, format: LogFormat) -> Self {
         self.log_format = Some(format);
         self
     }
 
     /// Sets the maximum number of Cairo steps available for block sequencing.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--sequencing.block-max-cairo-steps <TOTAL>`
     pub const fn sequencing_block_max_cairo_steps(mut self, steps: u64) -> Self {
         self.sequencing_block_max_cairo_steps = Some(steps);
         self
     }
 
     /// Sets the configuration file path.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--config <CONFIG>`
     pub fn config<T: Into<PathBuf>>(mut self, config: T) -> Self {
         self.config = Some(config.into());
         self
     }
 
     /// Sets the RPC URL to fork the network from.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--fork.provider <URL>`
     pub fn fork_provider<T: Into<String>>(mut self, provider: T) -> Self {
         self.fork_provider = Some(provider.into());
         self
     }
 
     /// Sets the fork block number.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--fork.block <BLOCK>`
     pub const fn fork_block(mut self, block: u64) -> Self {
         self.fork_block = Some(block);
         self
     }
 
     /// Enable Google Cloud Trace exporter.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--tracer.gcloud`
     pub const fn tracer_gcloud(mut self, enable: bool) -> Self {
         self.tracer_gcloud = enable;
         self
     }
 
     /// Enable OpenTelemetry Protocol (OTLP) exporter.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--tracer.otlp`
     pub const fn tracer_otlp(mut self, enable: bool) -> Self {
         self.tracer_otlp = enable;
         self
     }
 
     /// Sets the Google Cloud project ID.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--tracer.gcloud-project <PROJECT_ID>`
     pub fn tracer_gcloud_project<T: Into<String>>(mut self, project_id: T) -> Self {
         self.tracer_gcloud_project = Some(project_id.into());
         self
     }
 
     /// Sets the OTLP endpoint URL.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--tracer.otlp-endpoint <URL>`
     pub fn tracer_otlp_endpoint<T: Into<String>>(mut self, endpoint: T) -> Self {
         self.tracer_otlp_endpoint = Some(endpoint.into());
         self
     }
 
     /// Enable metrics collection.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--metrics`
     pub const fn metrics(mut self, enable: bool) -> Self {
         self.metrics = enable;
         self
     }
 
     /// Sets the comma separated list of domains from which to accept cross origin requests.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--http.cors_origins <HTTP_CORS_ORIGINS>`
     pub fn http_cors_origins<T: Into<String>>(mut self, origins: T) -> Self {
         self.http_cors_origins = Some(origins.into());
         self
     }
 
     /// Sets the API modules offered over the HTTP-RPC interface.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--http.api <MODULES>`
     pub fn http_api<T: Into<String>>(mut self, modules: T) -> Self {
         self.http_api = Some(modules.into());
         self
     }
 
     /// Sets the maximum request body size (in bytes).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.max-request-body-size <SIZE>`
     pub const fn rpc_max_request_body_size(mut self, size: u64) -> Self {
         self.rpc_max_request_body_size = Some(size);
         self
     }
 
     /// Sets the maximum response body size (in bytes).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.max-response-body-size <SIZE>`
     pub const fn rpc_max_response_body_size(mut self, size: u64) -> Self {
         self.rpc_max_response_body_size = Some(size);
         self
     }
 
     /// Sets the timeout for the RPC server request (in seconds).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.timeout <TIMEOUT>`
     pub const fn rpc_timeout(mut self, timeout: u64) -> Self {
         self.rpc_timeout = Some(timeout);
         self
@@ -540,6 +681,10 @@ impl Katana {
     /// Sets the maximum page size for event queries.
     ///
     /// Default: `1024`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.max-event-page-size <SIZE>`
     pub const fn rpc_max_event_page_size(mut self, size: u64) -> Self {
         self.rpc_max_event_page_size = Some(size);
         self
@@ -548,60 +693,100 @@ impl Katana {
     /// Sets the maximum keys for requesting storage proofs.
     ///
     /// Default: `100`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--rpc.max-proof-keys <SIZE>`
     pub const fn rpc_max_proof_keys(mut self, keys: u64) -> Self {
         self.rpc_max_proof_keys = Some(keys);
         self
     }
 
     /// Sets the L2 ETH gas price (denominated in wei).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--gpo.l2-eth-gas-price <WEI>`
     pub const fn gpo_l2_eth_gas_price(mut self, price: u64) -> Self {
         self.gpo_l2_eth_gas_price = Some(price);
         self
     }
 
     /// Sets the L2 STRK gas price (denominated in fri).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--gpo.l2-strk-gas-price <FRI>`
     pub const fn gpo_l2_strk_gas_price(mut self, price: u64) -> Self {
         self.gpo_l2_strk_gas_price = Some(price);
         self
     }
 
     /// Sets the L1 ETH gas price (denominated in wei).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--gpo.l1-eth-gas-price <WEI>`
     pub const fn gpo_l1_eth_gas_price(mut self, price: u64) -> Self {
         self.gpo_l1_eth_gas_price = Some(price);
         self
     }
 
     /// Sets the L1 STRK gas price (denominated in fri).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--gpo.l1-strk-gas-price <FRI>`
     pub const fn gpo_l1_strk_gas_price(mut self, price: u64) -> Self {
         self.gpo_l1_strk_gas_price = Some(price);
         self
     }
 
     /// Sets the L1 ETH data gas price (denominated in wei).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--gpo.l1-eth-data-gas-price <WEI>`
     pub const fn gpo_l1_eth_data_gas_price(mut self, price: u64) -> Self {
         self.gpo_l1_eth_data_gas_price = Some(price);
         self
     }
 
     /// Sets the L1 STRK data gas price (denominated in fri).
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--gpo.l1-strk-data-gas-price <FRI>`
     pub const fn gpo_l1_strk_data_gas_price(mut self, price: u64) -> Self {
         self.gpo_l1_strk_data_gas_price = Some(price);
         self
     }
 
     /// Enable and launch the explorer frontend.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--explorer`
     pub const fn explorer(mut self, enable: bool) -> Self {
         self.explorer = enable;
         self
     }
 
     /// Declare all versions of the Controller class at genesis.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--cartridge.controllers`
     pub const fn cartridge_controllers(mut self, enable: bool) -> Self {
         self.cartridge_controllers = enable;
         self
     }
 
     /// Whether to use the Cartridge paymaster.
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--cartridge.paymaster`
     pub const fn cartridge_paymaster(mut self, enable: bool) -> Self {
         self.cartridge_paymaster = enable;
         self
@@ -610,6 +795,10 @@ impl Katana {
     /// Sets the root URL for the Cartridge API.
     ///
     /// Default: `https://api.cartridge.gg`
+    ///
+    /// ## CLI Flag
+    ///
+    /// `--cartridge.api <API>`
     pub fn cartridge_api<T: Into<String>>(mut self, api: T) -> Self {
         self.cartridge_api = Some(api.into());
         self

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -808,7 +808,7 @@ impl Katana {
     /// Enables JSON logging.
     ///
     /// **Deprecated**: Use `log_format(LogFormat::Json)` instead.
-    #[deprecated(since = "0.1.0", note = "Use `log_format(LogFormat::Json)` instead")]
+    #[deprecated(note = "Use `log_format(LogFormat::Json)` instead")]
     pub const fn json_log(mut self, json_log: bool) -> Self {
         self.json_log = json_log;
         self
@@ -817,7 +817,7 @@ impl Katana {
     /// Sets the fork block number which will be used when the `katana` instance is launched.
     ///
     /// **Deprecated**: Use `fork_block()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `fork_block()` instead")]
+    #[deprecated(note = "Use `fork_block()` instead")]
     pub const fn fork_block_number(mut self, fork_block_number: u64) -> Self {
         self.fork_block_number = Some(fork_block_number);
         self
@@ -826,7 +826,7 @@ impl Katana {
     /// Sets the RPC URL to fork the network from.
     ///
     /// **Deprecated**: Use `fork_provider()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `fork_provider()` instead")]
+    #[deprecated(note = "Use `fork_provider()` instead")]
     pub fn l1_provider<T: Into<String>>(mut self, rpc_url: T) -> Self {
         self.l1_provider = Some(rpc_url.into());
         self
@@ -835,7 +835,7 @@ impl Katana {
     /// Sets the maximum timeout for the RPC.
     ///
     /// **Deprecated**: Use `rpc_timeout()` instead (note: units changed from ms to seconds).
-    #[deprecated(since = "0.1.0", note = "Use `rpc_timeout()` instead")]
+    #[deprecated(note = "Use `rpc_timeout()` instead")]
     pub const fn rpc_timeout_ms(mut self, timeout_ms: u64) -> Self {
         self.rpc_timeout_ms = Some(timeout_ms);
         self
@@ -844,7 +844,7 @@ impl Katana {
     /// Enables the CORS layer and sets the allowed origins, separated by commas.
     ///
     /// **Deprecated**: Use `http_cors_origins()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `http_cors_origins()` instead")]
+    #[deprecated(note = "Use `http_cors_origins()` instead")]
     pub fn http_cors_domain<T: Into<String>>(mut self, allowed_origins: T) -> Self {
         self.http_cors_domain = Some(allowed_origins.into());
         self
@@ -853,7 +853,7 @@ impl Katana {
     /// Sets the L1 ETH gas price (denominated in wei).
     ///
     /// **Deprecated**: Use `gpo_l2_eth_gas_price()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `gpo_l2_eth_gas_price()` instead")]
+    #[deprecated(note = "Use `gpo_l2_eth_gas_price()` instead")]
     pub const fn eth_gas_price(mut self, eth_gas_price: u64) -> Self {
         self.eth_gas_price = Some(eth_gas_price);
         self
@@ -862,7 +862,7 @@ impl Katana {
     /// Sets the L1 STRK gas price (denominated in fri).
     ///
     /// **Deprecated**: Use `gpo_l2_strk_gas_price()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `gpo_l2_strk_gas_price()` instead")]
+    #[deprecated(note = "Use `gpo_l2_strk_gas_price()` instead")]
     pub const fn strk_gas_price(mut self, strk_gas_price: u64) -> Self {
         self.strk_gas_price = Some(strk_gas_price);
         self
@@ -871,7 +871,7 @@ impl Katana {
     /// Whether to use the Cartridge paymaster.
     ///
     /// **Deprecated**: Use `cartridge_paymaster()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `cartridge_paymaster()` instead")]
+    #[deprecated(note = "Use `cartridge_paymaster()` instead")]
     pub const fn enable_cartridge_paymaster(mut self, enable: bool) -> Self {
         self.enable_cartridge_paymaster = enable;
         self
@@ -880,7 +880,7 @@ impl Katana {
     /// Sets the root URL for the Cartridge API.
     ///
     /// **Deprecated**: Use `cartridge_api()` instead.
-    #[deprecated(since = "0.1.0", note = "Use `cartridge_api()` instead")]
+    #[deprecated(note = "Use `cartridge_api()` instead")]
     pub fn cartridge_api_url<T: Into<String>>(mut self, url: T) -> Self {
         self.cartridge_api_url = Some(url.into());
         self

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -298,6 +298,8 @@ impl Katana {
     }
 
     /// Sets the port which will be used when the `katana` instance is launched.
+    ///
+    /// Default: `5050`
     pub fn port<T: Into<u16>>(mut self, port: T) -> Self {
         self.http_port = Some(port.into());
         self
@@ -330,18 +332,24 @@ impl Katana {
     }
 
     /// Enables Prometheus metrics and sets the metrics server address.
+    ///
+    /// Default: `127.0.0.1`
     pub fn metrics_addr<T: Into<SocketAddr>>(mut self, addr: T) -> Self {
         self.metrics_addr = Some(addr.into());
         self
     }
 
     /// Enables Prometheus metrics and sets the metrics server port.
+    ///
+    /// Default: `9100`
     pub fn metrics_port<T: Into<u16>>(mut self, port: T) -> Self {
         self.metrics_port = Some(port.into());
         self
     }
 
     /// Sets the host IP address the server will listen on.
+    ///
+    /// Default: `127.0.0.1`
     pub fn http_addr<T: Into<SocketAddr>>(mut self, addr: T) -> Self {
         self.http_addr = Some(addr.into());
         self
@@ -354,18 +362,24 @@ impl Katana {
     }
 
     /// Sets the maximum gas for the `starknet_call` RPC method.
+    ///
+    /// Default: `1000000000`
     pub const fn rpc_max_call_gas(mut self, max_call_gas: u64) -> Self {
         self.rpc_max_call_gas = Some(max_call_gas);
         self
     }
 
     /// Sets the seed for randomness of accounts to be predeployed.
+    ///
+    /// Default: `0`
     pub const fn seed(mut self, seed: u64) -> Self {
         self.seed = Some(seed);
         self
     }
 
     /// Sets the number of pre-funded accounts to generate.
+    ///
+    /// Default: `10`
     pub fn accounts(mut self, accounts: u16) -> Self {
         self.accounts = Some(accounts);
         self
@@ -392,12 +406,16 @@ impl Katana {
     }
 
     /// Sets the maximum number of steps available for the account validation logic.
+    ///
+    /// Default: `1000000`
     pub const fn validate_max_steps(mut self, validate_max_steps: u64) -> Self {
         self.validate_max_steps = Some(validate_max_steps);
         self
     }
 
     /// Sets the maximum number of steps available for the account execution logic.
+    ///
+    /// Default: `10000000`
     pub const fn invoke_max_steps(mut self, invoke_max_steps: u64) -> Self {
         self.invoke_max_steps = Some(invoke_max_steps);
         self
@@ -428,6 +446,8 @@ impl Katana {
     }
 
     /// Sets the log format to use.
+    ///
+    /// Default: `LogFormat::Full`
     pub const fn log_format(mut self, format: LogFormat) -> Self {
         self.log_format = Some(format);
         self
@@ -518,12 +538,16 @@ impl Katana {
     }
 
     /// Sets the maximum page size for event queries.
+    ///
+    /// Default: `1024`
     pub const fn rpc_max_event_page_size(mut self, size: u64) -> Self {
         self.rpc_max_event_page_size = Some(size);
         self
     }
 
     /// Sets the maximum keys for requesting storage proofs.
+    ///
+    /// Default: `100`
     pub const fn rpc_max_proof_keys(mut self, keys: u64) -> Self {
         self.rpc_max_proof_keys = Some(keys);
         self
@@ -584,6 +608,8 @@ impl Katana {
     }
 
     /// Sets the root URL for the Cartridge API.
+    ///
+    /// Default: `https://api.cartridge.gg`
     pub fn cartridge_api<T: Into<String>>(mut self, api: T) -> Self {
         self.cartridge_api = Some(api.into());
         self

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-clap.workspace = true
+clap = { workspace = true, features = [ "string" ] }
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -28,3 +28,6 @@ tower-http = { workspace = true, features = [ "trace" ] }
 
 bytes.workspace = true
 http-body-util = "0.1.3"
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/tracing/src/fmt.rs
+++ b/crates/tracing/src/fmt.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
@@ -21,15 +22,55 @@ impl Display for LogFormat {
     }
 }
 
+impl FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(LogFormat::Json),
+            "full" => Ok(LogFormat::Full),
+            _ => Err(format!("invalid log format: '{s}'. Valid options are 'json' or 'full'")),
+        }
+    }
+}
+
 impl clap::ValueEnum for LogFormat {
     fn value_variants<'a>() -> &'a [Self] {
         &[Self::Json, Self::Full]
     }
 
     fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
-        match self {
-            Self::Json => Some(clap::builder::PossibleValue::new("json")),
-            Self::Full => Some(clap::builder::PossibleValue::new("full")),
-        }
+        let value = self.to_string();
+        Some(clap::builder::PossibleValue::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rstest::rstest]
+    #[case("json", LogFormat::Json)]
+    #[case("full", LogFormat::Full)]
+    #[case("JSON", LogFormat::Json)]
+    #[case("FULL", LogFormat::Full)]
+    #[case("Json", LogFormat::Json)]
+    #[case("Full", LogFormat::Full)]
+    fn log_format_from_str(#[case] input: &str, #[case] expected: LogFormat) {
+        assert_eq!(LogFormat::from_str(input).unwrap(), expected);
+    }
+
+    #[rstest::rstest]
+    #[case("invalid")]
+    #[case("")]
+    fn log_format_from_str_errors(#[case] input: &str) {
+        assert!(LogFormat::from_str(input).is_err());
+    }
+
+    #[rstest::rstest]
+    #[case(LogFormat::Json, "json")]
+    #[case(LogFormat::Full, "full")]
+    fn log_format_to_string(#[case] format: LogFormat, #[case] expected: &str) {
+        assert_eq!(format.to_string(), expected);
     }
 }


### PR DESCRIPTION
Currently, the node-bindings don't cover all available flags in the `katana` binary. This updates the bindings to the latest version of the binary.