### PR TITLE
chore(rpc-types): incremental removal of the `starknet-rs` crate dependency

### DIFF
--- a/bin/katana/src/cli/init/deployment.rs
+++ b/bin/katana/src/cli/init/deployment.rs
@@ -8,7 +8,7 @@ use katana_primitives::class::{
     ContractClassFromStrError,
 };
 use katana_primitives::{felt, ContractAddress, Felt};
-use katana_rpc_types::class::RpcContractClass;
+use katana_rpc_types::class::Class;
 use katana_utils::{TxWaiter, TxWaitingError};
 use piltover::{AppchainContract, AppchainContractReader, ProgramInfo};
 use spinoff::{spinners, Color, Spinner};
@@ -403,8 +403,8 @@ fn prepare_contract_declaration_params(
 ) -> Result<(FlattenedSierraClass, CompiledClassHash)> {
     let casm_hash = class.clone().compile()?.class_hash()?;
 
-    let rpc_class = RpcContractClass::try_from(class).expect("should be valid");
-    let RpcContractClass::Class(class) = rpc_class else { unreachable!("unexpected legacy class") };
+    let rpc_class = Class::try_from(class).expect("should be valid");
+    let Class::Sierra(class) = rpc_class else { unreachable!("unexpected legacy class") };
     let flattened: FlattenedSierraClass = class.try_into()?;
 
     Ok((flattened, casm_hash))

--- a/crates/feeder-gateway/src/types/mod.rs
+++ b/crates/feeder-gateway/src/types/mod.rs
@@ -10,7 +10,7 @@ use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::version::StarknetVersion;
 use katana_primitives::{ContractAddress, Felt};
 use katana_rpc_types::class::ConversionError;
-pub use katana_rpc_types::class::RpcSierraContractClass;
+pub use katana_rpc_types::class::SierraClass;
 use serde::Deserialize;
 use starknet::core::types::ResourcePrice;
 use starknet::providers::sequencer::models::BlockStatus;
@@ -26,7 +26,7 @@ pub use transaction::*;
 #[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]
 pub enum ContractClass {
-    Class(RpcSierraContractClass),
+    Class(SierraClass),
     Legacy(LegacyContractClass),
 }
 

--- a/crates/primitives/src/message.rs
+++ b/crates/primitives/src/message.rs
@@ -1,4 +1,7 @@
-use crate::contract::ContractAddress;
+use alloy_primitives::{Keccak256, B256, U256};
+
+use crate::contract::{ContractAddress, Nonce};
+use crate::eth::Address as EthAddress;
 use crate::Felt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -9,4 +12,121 @@ pub struct OrderedL2ToL1Message {
     pub from_address: ContractAddress,
     pub to_address: Felt,
     pub payload: Vec<Felt>,
+}
+
+/// Message from L1.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct L1ToL2Message {
+    /// The address of the L1 contract sending the message
+    pub from_address: EthAddress,
+    /// The target L2 address the message is sent to
+    pub to_address: ContractAddress,
+    /// The selector of the l1_handler in invoke in the target contract
+    pub entry_point_selector: Felt,
+    /// The payload of the message
+    pub payload: Vec<Felt>,
+    /// The nonce of the message
+    pub nonce: Nonce,
+}
+
+impl L1ToL2Message {
+    /// Calculates the message hash.
+    ///
+    /// The hashing algorithm is based on the canonical Solidity [implementation] of Starknet core
+    /// contract on Ethereum. Check out the Starknet [docs] on messaging for more details.
+    ///
+    /// [implementation]: https://github.com/starkware-libs/cairo-lang/blob/8276ac35830148a397e1143389f23253c8b80e93/src/starkware/starknet/solidity/StarknetMessaging.sol#L85-L106
+    /// [docs]: https://docs.starknet.io/architecture/messaging/#l1_l2_message_hashing
+    pub fn hash(&self) -> B256 {
+        // Below is the Solidity implementation of the message hash calculation.
+        //
+        // function l1ToL2MsgHash(
+        //     address fromAddress,
+        //     uint256 toAddress,
+        //     uint256 selector,
+        //     uint256[] calldata payload,
+        //     uint256 nonce
+        // ) public pure returns (bytes32) {
+        //     return
+        //         keccak256(
+        //             abi.encodePacked(
+        //                 uint256(uint160(fromAddress)),
+        //                 toAddress,
+        //                 nonce,
+        //                 selector,
+        //                 payload.length,
+        //                 payload
+        //             )
+        //         );
+        // }
+
+        let mut hasher = Keccak256::new();
+
+        // fromAddress: Cast Ethereum address (20 bytes) to uint256 (32 bytes)
+        // The address is padded with leading zeros to fill 32 bytes
+        let from_address = U256::from_be_slice(self.from_address.0.as_slice());
+        hasher.update(from_address.to_be_bytes::<{ U256::BYTES }>());
+
+        // toAddress: Felt (32 bytes), no padding needed
+        hasher.update(self.to_address.to_bytes_be());
+
+        // nonce: Felt (32 bytes), no padding needed
+        hasher.update(self.nonce.to_bytes_be());
+
+        // selector: Felt (32 bytes), no padding needed
+        hasher.update(self.entry_point_selector.to_bytes_be());
+
+        // payload.length: Encode as uint256 (32 bytes)
+        let payload_len = U256::from(self.payload.len());
+        hasher.update(payload_len.to_be_bytes::<{ U256::BYTES }>());
+
+        // payload: Each element is already a  (32 bytes)
+        // Elements are concatenated sequentially with no additional padding
+        for elem in &self.payload {
+            hasher.update(elem.to_bytes_be());
+        }
+
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::hex;
+
+    use super::*;
+    use crate::{address, felt};
+
+    // L1Handler transaction on mainnet: https://voyager.online/tx/0x5e83f152aabc4caad08589339d2b4cfbc1b688d936ca3e7e919c50a7bab3ba4
+    #[test]
+    fn l1_to_l2_message_hash() {
+        let expected_msg_hash =
+            hex!("0x6708556b516f77ddecce43d49b7a125d73386ba411a3817fcf41d1bf7e16d3b0");
+
+        let nonce = felt!("0x199007");
+
+        let from_address =
+            EthAddress::from_slice(&hex!("f6080d9fbeebcd44d89affbfd42f098cbff92816"));
+
+        let to_address =
+            address!("0x5cd48fccbfd8aa2773fe22c217e808319ffcc1c5a6a463f7d8fa2da48218196");
+
+        let entry_point_selector =
+            felt!("0x1b64b1b3b690b43b9b514fb81377518f4039cd3e4f4914d8a6bdf01d679fb19");
+
+        let payload = vec![
+            felt!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+            felt!("0x25ef9386a96bde9bb47be826155efae7722148c0"),
+            felt!("0x1dffda3b65102d41e645461ffb1abbff20769bad777631a26b7fbeca1b7c2fd"),
+            felt!("0x2e90edd000"),
+            felt!("0x0"),
+        ];
+
+        let msg = L1ToL2Message { from_address, to_address, entry_point_selector, payload, nonce };
+        let actual_hash = msg.hash();
+
+        assert_eq!(actual_hash.0, expected_msg_hash);
+    }
 }

--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -4,6 +4,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use katana_primitives::block::{BlockIdOrTag, BlockNumber};
 use katana_primitives::class::ClassHash;
+use katana_primitives::contract::{Nonce, StorageKey};
 use katana_primitives::transaction::TxHash;
 use katana_primitives::{ContractAddress, Felt};
 use katana_rpc_types::block::{
@@ -70,8 +71,8 @@ pub trait StarknetApi {
     #[method(name = "getStorageAt")]
     async fn get_storage_at(
         &self,
-        contract_address: Felt,
-        key: Felt,
+        contract_address: ContractAddress,
+        key: StorageKey,
         block_id: BlockIdOrTag,
     ) -> RpcResult<Felt>;
 
@@ -107,7 +108,7 @@ pub trait StarknetApi {
     async fn get_class(
         &self,
         block_id: BlockIdOrTag,
-        class_hash: Felt,
+        class_hash: ClassHash,
     ) -> RpcResult<RpcContractClass>;
 
     /// Get the contract class hash in the given block for the contract deployed at the given
@@ -116,7 +117,7 @@ pub trait StarknetApi {
     async fn get_class_hash_at(
         &self,
         block_id: BlockIdOrTag,
-        contract_address: Felt,
+        contract_address: ContractAddress,
     ) -> RpcResult<Felt>;
 
     /// Get the contract class definition in the given block at the given address.
@@ -124,7 +125,7 @@ pub trait StarknetApi {
     async fn get_class_at(
         &self,
         block_id: BlockIdOrTag,
-        contract_address: Felt,
+        contract_address: ContractAddress,
     ) -> RpcResult<RpcContractClass>;
 
     /// Get the number of transactions in a block given a block id.
@@ -176,7 +177,11 @@ pub trait StarknetApi {
 
     /// Get the nonce associated with the given address in the given block.
     #[method(name = "getNonce")]
-    async fn get_nonce(&self, block_id: BlockIdOrTag, contract_address: Felt) -> RpcResult<Felt>;
+    async fn get_nonce(
+        &self,
+        block_id: BlockIdOrTag,
+        contract_address: ContractAddress,
+    ) -> RpcResult<Nonce>;
 
     /// Get merkle paths in one of the state tries: global state, classes, individual contract. A
     /// single request can query for any mix of the three types of storage proofs (classes,

--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -15,7 +15,7 @@ use katana_rpc_types::broadcasted::{
     AddDeclareTransactionResult, AddDeployAccountTransactionResult, AddInvokeTransactionResult,
     BroadcastedDeclareTx, BroadcastedDeployAccountTx, BroadcastedInvokeTx, BroadcastedTx,
 };
-use katana_rpc_types::class::RpcContractClass;
+use katana_rpc_types::class::Class;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
 use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
@@ -105,11 +105,7 @@ pub trait StarknetApi {
 
     /// Get the contract class definition in the given block associated with the given hash.
     #[method(name = "getClass")]
-    async fn get_class(
-        &self,
-        block_id: BlockIdOrTag,
-        class_hash: ClassHash,
-    ) -> RpcResult<RpcContractClass>;
+    async fn get_class(&self, block_id: BlockIdOrTag, class_hash: ClassHash) -> RpcResult<Class>;
 
     /// Get the contract class hash in the given block for the contract deployed at the given
     /// address.
@@ -126,7 +122,7 @@ pub trait StarknetApi {
         &self,
         block_id: BlockIdOrTag,
         contract_address: ContractAddress,
-    ) -> RpcResult<RpcContractClass>;
+    ) -> RpcResult<Class>;
 
     /// Get the number of transactions in a block given a block id.
     #[method(name = "getBlockTransactionCount")]

--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -22,7 +22,7 @@ use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
 use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
 use katana_rpc_types::{
-    EstimateFeeSimulationFlag, FeeEstimate, FeltAsHex, FunctionCall, SimulationFlag, SyncingStatus,
+    EstimateFeeSimulationFlag, FeeEstimate, FunctionCall, SimulationFlag, SyncingStatus,
 };
 use starknet::core::types::{
     SimulatedTransaction, TransactionStatus, TransactionTrace, TransactionTraceWithHash,
@@ -73,7 +73,7 @@ pub trait StarknetApi {
         contract_address: Felt,
         key: Felt,
         block_id: BlockIdOrTag,
-    ) -> RpcResult<FeltAsHex>;
+    ) -> RpcResult<Felt>;
 
     /// Gets the transaction status (possibly reflecting that the tx is still in the mempool, or
     /// dropped from it).
@@ -117,7 +117,7 @@ pub trait StarknetApi {
         &self,
         block_id: BlockIdOrTag,
         contract_address: Felt,
-    ) -> RpcResult<FeltAsHex>;
+    ) -> RpcResult<Felt>;
 
     /// Get the contract class definition in the given block at the given address.
     #[method(name = "getClassAt")]
@@ -133,11 +133,7 @@ pub trait StarknetApi {
 
     /// Call a starknet function without creating a StarkNet transaction.
     #[method(name = "call")]
-    async fn call(
-        &self,
-        request: FunctionCall,
-        block_id: BlockIdOrTag,
-    ) -> RpcResult<Vec<FeltAsHex>>;
+    async fn call(&self, request: FunctionCall, block_id: BlockIdOrTag) -> RpcResult<Vec<Felt>>;
 
     /// Estimate the fee for of StarkNet transactions.
     #[method(name = "estimateFee")]
@@ -166,7 +162,7 @@ pub trait StarknetApi {
 
     /// Return the currently configured StarkNet chain id.
     #[method(name = "chainId")]
-    async fn chain_id(&self) -> RpcResult<FeltAsHex>;
+    async fn chain_id(&self) -> RpcResult<Felt>;
 
     /// Returns an object about the sync status, or false if the node is not synching.
     #[method(name = "syncing")]
@@ -180,11 +176,7 @@ pub trait StarknetApi {
 
     /// Get the nonce associated with the given address in the given block.
     #[method(name = "getNonce")]
-    async fn get_nonce(
-        &self,
-        block_id: BlockIdOrTag,
-        contract_address: Felt,
-    ) -> RpcResult<FeltAsHex>;
+    async fn get_nonce(&self, block_id: BlockIdOrTag, contract_address: Felt) -> RpcResult<Felt>;
 
     /// Get merkle paths in one of the state tries: global state, classes, individual contract. A
     /// single request can query for any mix of the three types of storage proofs (classes,

--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -20,7 +20,7 @@ use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
-use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
+use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResult};
 use katana_rpc_types::{
     EstimateFeeSimulationFlag, FeeEstimate, FunctionCall, SimulationFlag, SyncingStatus,
 };
@@ -188,7 +188,7 @@ pub trait StarknetApi {
         class_hashes: Option<Vec<ClassHash>>,
         contract_addresses: Option<Vec<ContractAddress>>,
         contracts_storage_keys: Option<Vec<ContractStorageKeys>>,
-    ) -> RpcResult<GetStorageProofResponse>;
+    ) -> RpcResult<GetStorageProofResult>;
 }
 
 /// Write API.

--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -22,8 +22,7 @@ use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
 use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
 use katana_rpc_types::{
-    FeeEstimate, FeltAsHex, FunctionCall, SimulationFlag, SimulationFlagForEstimateFee,
-    SyncingStatus,
+    EstimateFeeSimulationFlag, FeeEstimate, FeltAsHex, FunctionCall, SimulationFlag, SyncingStatus,
 };
 use starknet::core::types::{
     SimulatedTransaction, TransactionStatus, TransactionTrace, TransactionTraceWithHash,
@@ -145,7 +144,7 @@ pub trait StarknetApi {
     async fn estimate_fee(
         &self,
         request: Vec<BroadcastedTx>,
-        simulation_flags: Vec<SimulationFlagForEstimateFee>,
+        simulation_flags: Vec<EstimateFeeSimulationFlag>,
         block_id: BlockIdOrTag,
     ) -> RpcResult<Vec<FeeEstimate>>;
 

--- a/crates/rpc/rpc-types/src/broadcasted.rs
+++ b/crates/rpc/rpc-types/src/broadcasted.rs
@@ -18,7 +18,7 @@ use katana_primitives::{ContractAddress, Felt};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use starknet::core::utils::get_contract_address;
 
-use crate::class::RpcSierraContractClass;
+use crate::class::SierraClass;
 
 const QUERY_VERSION_OFFSET: Felt =
     Felt::from_raw([576460752142434320, 18446744073709551584, 17407, 18446744073700081665]);
@@ -79,7 +79,7 @@ pub struct UntypedBroadcastedTx {
     pub compiled_class_hash: Option<CompiledClassHash>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contract_class: Option<Arc<RpcSierraContractClass>>,
+    pub contract_class: Option<Arc<SierraClass>>,
 
     // Invoke & Declare only field
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -421,7 +421,7 @@ pub struct BroadcastedDeclareTx {
     /// a transaction to be valid for execution, the nonce must be equal to the account's current
     /// nonce.
     pub nonce: Nonce,
-    pub contract_class: Arc<RpcSierraContractClass>,
+    pub contract_class: Arc<SierraClass>,
     /// Data needed to allow the paymaster to pay for the transaction in native tokens.
     pub paymaster_data: Vec<Felt>,
     /// The tip for the transaction.

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -18,36 +18,7 @@ pub mod trace;
 pub mod transaction;
 pub mod trie;
 
-use std::ops::Deref;
-
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use starknet::core::serde::unsigned_field_element::UfeHex;
-
-/// A wrapper around [`FieldElement`](katana_primitives::FieldElement) that serializes to hex as
-/// default.
-#[serde_as]
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FeltAsHex(#[serde_as(serialize_as = "UfeHex")] katana_primitives::Felt);
-
-impl From<katana_primitives::Felt> for FeltAsHex {
-    fn from(value: katana_primitives::Felt) -> Self {
-        Self(value)
-    }
-}
-
-impl From<FeltAsHex> for katana_primitives::Felt {
-    fn from(value: FeltAsHex) -> Self {
-        value.0
-    }
-}
-
-impl Deref for FeltAsHex {
-    type Target = katana_primitives::Felt;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 pub type FunctionCall = starknet::core::types::FunctionCall;
 
@@ -73,24 +44,22 @@ pub type SyncingStatus = starknet::core::types::SyncStatusType;
 
 #[cfg(test)]
 mod tests {
+    use katana_primitives::{felt, Felt};
     use rstest::rstest;
     use serde_json::{json, Value};
-    use starknet::macros::felt;
 
-    use super::{EstimateFeeSimulationFlag, FeltAsHex, SimulationFlag};
+    use super::{EstimateFeeSimulationFlag, SimulationFlag};
 
-    #[test]
-    fn serde_felt() {
-        let value = felt!("0x12345");
-        let value_as_dec = json!(value);
-        let value_as_hex = json!(format!("{value:#x}"));
-
-        let expected_value = FeltAsHex(value);
-        let actual_des_value: FeltAsHex = serde_json::from_value(value_as_dec).unwrap();
-        assert_eq!(expected_value, actual_des_value, "should deserialize to decimal");
-
-        let actual_ser_value = serde_json::to_value(expected_value).unwrap();
-        assert_eq!(value_as_hex, actual_ser_value, "should serialize to hex");
+    #[rstest::rstest]
+    #[case(felt!("0x0"), json!("0x0"))]
+    #[case(felt!("0xa"), json!("0xa"))]
+    #[case(felt!("0x1337"), json!("0x1337"))]
+    #[case(felt!("0x12345"), json!("0x12345"))]
+    fn felt_serde_hex(#[case] felt: Felt, #[case] json: Value) {
+        let serialized = serde_json::to_value(&felt).unwrap();
+        assert_eq!(serialized, json);
+        let deserialized: Felt = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized, felt);
     }
 
     #[rstest]

--- a/crates/rpc/rpc-types/src/message.rs
+++ b/crates/rpc/rpc-types/src/message.rs
@@ -1,17 +1,37 @@
 use katana_primitives::chain::ChainId;
+use katana_primitives::eth::Address as EthAddress;
+use katana_primitives::message::L1ToL2Message;
 use katana_primitives::transaction::L1HandlerTx;
-use katana_primitives::utils::transaction::compute_l2_to_l1_message_hash;
-use katana_primitives::Felt;
+use katana_primitives::{ContractAddress, Felt};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MsgFromL1(starknet::core::types::MsgFromL1);
+/// Message from L1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsgFromL1 {
+    /// The address of the L1 contract sending the message
+    pub from_address: EthAddress,
+    /// The target L2 address the message is sent to
+    pub to_address: ContractAddress,
+    /// The selector of the l1_handler in invoke in the target contract
+    pub entry_point_selector: Felt,
+    /// The payload of the message
+    pub payload: Vec<Felt>,
+}
 
 impl MsgFromL1 {
     pub fn into_tx_with_chain_id(self, chain_id: ChainId) -> L1HandlerTx {
         // Set the L1 to L2 message nonce to 0, because this is just used
-        // for the `estimateMessageFee` RPC.
+        // for the `starknet_estimateMessageFee` RPC.
         let nonce = Felt::ZERO;
+
+        let message_hash = L1ToL2Message {
+            nonce,
+            to_address: self.to_address,
+            payload: self.payload.clone(),
+            from_address: self.from_address,
+            entry_point_selector: self.entry_point_selector,
+        }
+        .hash();
 
         // When executing a l1 handler tx, blockifier just assert that the paid_fee_on_l1 is
         // anything but 0. See: https://github.com/dojoengine/sequencer/blob/d6951f24fc2082c7aa89cdbc063648915b131d74/crates/blockifier/src/transaction/transaction_execution.rs#L140-L145
@@ -19,18 +39,11 @@ impl MsgFromL1 {
         // For fee estimation, this value is basically irrelevant.
         let paid_fee_on_l1 = 1u128;
 
-        let message_hash = compute_l2_to_l1_message_hash(
-            // This conversion will never fail bcs `from_address` is 20 bytes and the it will only
-            // fail if the slice is > 32 bytes
-            Felt::from_bytes_be_slice(self.0.from_address.as_bytes()),
-            self.0.to_address,
-            &self.0.payload,
-        );
-
         // In an l1_handler transaction, the first element of the calldata is always the Ethereum
         // address of the sender (msg.sender). https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/messaging-mechanism/#l1-l2-messages
-        let mut calldata = vec![Felt::from(self.0.from_address)];
-        calldata.extend(self.0.payload);
+        let from_address = Felt::from_bytes_be_slice(&self.from_address.into_array());
+        let mut calldata = vec![from_address];
+        calldata.extend(self.payload);
 
         L1HandlerTx {
             nonce,
@@ -39,8 +52,8 @@ impl MsgFromL1 {
             message_hash,
             paid_fee_on_l1,
             version: Felt::ZERO,
-            contract_address: self.0.to_address.into(),
-            entry_point_selector: self.0.entry_point_selector,
+            contract_address: self.to_address,
+            entry_point_selector: self.entry_point_selector,
         }
     }
 }

--- a/crates/rpc/rpc-types/src/trie.rs
+++ b/crates/rpc/rpc-types/src/trie.rs
@@ -69,7 +69,7 @@ impl MerkleNode {
 /// it may end in an edge node whose path is not a prefix of the requested leaf, thus effectively
 /// proving non-membership
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetStorageProofResponse {
+pub struct GetStorageProofResult {
     pub global_roots: GlobalRoots,
     pub classes_proof: ClassesProof,
     pub contracts_proof: ContractsProof,

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -38,7 +38,7 @@ use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
 use katana_rpc_types::trie::{
     ClassesProof, ContractLeafData, ContractStorageKeys, ContractStorageProofs, ContractsProof,
-    GetStorageProofResponse, GlobalRoots, Nodes,
+    GetStorageProofResult, GlobalRoots, Nodes,
 };
 use katana_rpc_types::FeeEstimate;
 use katana_rpc_types_builder::ReceiptBuilder;
@@ -1155,7 +1155,7 @@ where
         class_hashes: Option<Vec<ClassHash>>,
         contract_addresses: Option<Vec<ContractAddress>>,
         contracts_storage_keys: Option<Vec<ContractStorageKeys>>,
-    ) -> StarknetApiResult<GetStorageProofResponse> {
+    ) -> StarknetApiResult<GetStorageProofResult> {
         self.on_io_blocking_task(move |this| {
             let provider = this.inner.backend.blockchain.provider();
 
@@ -1227,7 +1227,7 @@ where
             let contracts_tree_root = state.contracts_root()?;
             let global_roots = GlobalRoots { block_hash, classes_tree_root, contracts_tree_root };
 
-            Ok(GetStorageProofResponse {
+            Ok(GetStorageProofResult {
                 global_roots,
                 classes_proof,
                 contracts_proof,

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -31,7 +31,7 @@ use katana_rpc_types::block::{
     MaybePendingBlockWithTxs, PendingBlockWithReceipts, PendingBlockWithTxHashes,
     PendingBlockWithTxs,
 };
-use katana_rpc_types::class::RpcContractClass;
+use katana_rpc_types::class::Class;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
 use katana_rpc_types::receipt::{ReceiptBlock, TxReceiptWithBlockInfo};
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
@@ -260,7 +260,7 @@ where
         &self,
         block_id: BlockIdOrTag,
         class_hash: ClassHash,
-    ) -> StarknetApiResult<RpcContractClass> {
+    ) -> StarknetApiResult<Class> {
         self.on_io_blocking_task(move |this| {
             let state = this.state(&block_id)?;
 
@@ -268,7 +268,7 @@ where
                 return Err(StarknetApiError::ClassHashNotFound);
             };
 
-            Ok(RpcContractClass::try_from(class).unwrap())
+            Ok(Class::try_from(class).unwrap())
         })
         .await
     }
@@ -296,7 +296,7 @@ where
         &self,
         block_id: BlockIdOrTag,
         contract_address: ContractAddress,
-    ) -> StarknetApiResult<RpcContractClass> {
+    ) -> StarknetApiResult<Class> {
         let hash = self.class_hash_at_address(block_id, contract_address).await?;
         let class = self.class_at_hash(block_id, hash).await?;
         Ok(class)

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -7,8 +7,7 @@ use katana_core::service::block_producer::{BlockProducer, BlockProducerMode, Pen
 use katana_executor::{ExecutionResult, ExecutorFactory};
 use katana_pool::{TransactionPool, TxPool};
 use katana_primitives::block::{
-    BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag, FinalityStatus,
-    PartialHeader,
+    BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag, FinalityStatus, PartialHeader,
 };
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
@@ -28,8 +27,9 @@ use katana_provider::traits::transaction::{
 };
 use katana_rpc_api::error::starknet::StarknetApiError;
 use katana_rpc_types::block::{
-    MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
-    PendingBlockWithReceipts, PendingBlockWithTxHashes, PendingBlockWithTxs,
+    BlockHashAndNumber, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
+    MaybePendingBlockWithTxs, PendingBlockWithReceipts, PendingBlockWithTxHashes,
+    PendingBlockWithTxs,
 };
 use katana_rpc_types::class::RpcContractClass;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
@@ -249,11 +249,11 @@ where
         env.ok_or(StarknetApiError::BlockNotFound)
     }
 
-    fn block_hash_and_number(&self) -> StarknetApiResult<(BlockHash, BlockNumber)> {
+    fn block_hash_and_number(&self) -> StarknetApiResult<BlockHashAndNumber> {
         let provider = self.inner.backend.blockchain.provider();
         let hash = provider.latest_hash()?;
         let number = provider.latest_number()?;
-        Ok((hash, number))
+        Ok(BlockHashAndNumber::new(hash, number))
     }
 
     async fn class_at_hash(

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -22,7 +22,7 @@ use katana_rpc_types::block::{
     MaybePendingBlockWithTxs,
 };
 use katana_rpc_types::broadcasted::BroadcastedTx;
-use katana_rpc_types::class::RpcContractClass;
+use katana_rpc_types::class::Class;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
 use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
@@ -66,7 +66,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         &self,
         block_id: BlockIdOrTag,
         contract_address: ContractAddress,
-    ) -> RpcResult<RpcContractClass> {
+    ) -> RpcResult<Class> {
         Ok(self.class_at_address(block_id, contract_address).await?)
     }
 
@@ -122,11 +122,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         Ok(self.class_hash_at_address(block_id, contract_address).await?)
     }
 
-    async fn get_class(
-        &self,
-        block_id: BlockIdOrTag,
-        class_hash: ClassHash,
-    ) -> RpcResult<RpcContractClass> {
+    async fn get_class(&self, block_id: BlockIdOrTag, class_hash: ClassHash) -> RpcResult<Class> {
         Ok(self.class_at_hash(block_id, class_hash).await?)
     }
 

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -70,11 +70,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
     }
 
     async fn block_hash_and_number(&self) -> RpcResult<BlockHashAndNumber> {
-        self.on_io_blocking_task(move |this| {
-            let res = this.block_hash_and_number()?;
-            Ok(res.into())
-        })
-        .await
+        self.on_io_blocking_task(move |this| Ok(this.block_hash_and_number()?)).await
     }
 
     async fn get_block_with_tx_hashes(

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -28,7 +28,7 @@ use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
 use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
-use katana_rpc_types::{FeeEstimate, FeltAsHex, FunctionCall, SimulationFlagForEstimateFee};
+use katana_rpc_types::{EstimateFeeSimulationFlag, FeeEstimate, FeltAsHex, FunctionCall};
 use starknet::core::types::TransactionStatus;
 
 use super::StarknetApi;
@@ -177,7 +177,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
     async fn estimate_fee(
         &self,
         request: Vec<BroadcastedTx>,
-        simulation_flags: Vec<SimulationFlagForEstimateFee>,
+        simulation_flags: Vec<EstimateFeeSimulationFlag>,
         block_id: BlockIdOrTag,
     ) -> RpcResult<Vec<FeeEstimate>> {
         let chain_id = self.inner.backend.chain_spec.id();
@@ -212,7 +212,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let skip_validate = simulation_flags.contains(&SimulationFlagForEstimateFee::SkipValidate);
+        let skip_validate = simulation_flags.contains(&EstimateFeeSimulationFlag::SkipValidate);
 
         // If the node is run with transaction validation disabled, then we should not validate
         // transactions when estimating the fee even if the `SKIP_VALIDATE` flag is not set.

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -27,7 +27,7 @@ use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
-use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
+use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResult};
 use katana_rpc_types::{EstimateFeeSimulationFlag, FeeEstimate, FunctionCall};
 use starknet::core::types::TransactionStatus;
 
@@ -364,7 +364,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         class_hashes: Option<Vec<ClassHash>>,
         contract_addresses: Option<Vec<ContractAddress>>,
         contracts_storage_keys: Option<Vec<ContractStorageKeys>>,
-    ) -> RpcResult<GetStorageProofResponse> {
+    ) -> RpcResult<GetStorageProofResult> {
         let proofs = self
             .get_proofs(block_id, class_hashes, contract_addresses, contracts_storage_keys)
             .await?;

--- a/crates/storage/fork/src/lib.rs
+++ b/crates/storage/fork/src/lib.rs
@@ -21,7 +21,7 @@ use katana_primitives::class::{
 };
 use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
 use katana_primitives::Felt;
-use katana_rpc_types::class::RpcContractClass;
+use katana_rpc_types::class::Class;
 use parking_lot::Mutex;
 use starknet::core::types::{BlockId, ContractClass as StarknetRsClass, StarknetError};
 use starknet::providers::{Provider, ProviderError as StarknetProviderError};
@@ -468,7 +468,7 @@ impl BackendClient {
         match rx.recv()? {
             BackendResponse::ClassAt(res) => {
                 if let Some(class) = handle_not_found_err(res)? {
-                    let class = RpcContractClass::try_from(class)?;
+                    let class = Class::try_from(class)?;
                     Ok(Some(ContractClass::try_from(class)?))
                 } else {
                     Ok(None)


### PR DESCRIPTION
ref: #198 

Part of an ongoing effort to remove the dependency on `starknet-rs` for providing the RPC types and define the types locally instead.