### PR TITLE
refactor(rpc-types): local function call request definition

### DIFF
--- a/bin/katana/src/cli/rpc/starknet.rs
+++ b/bin/katana/src/cli/rpc/starknet.rs
@@ -5,8 +5,7 @@ use clap::{Args, Subcommand};
 use katana_primitives::block::BlockNumber;
 use katana_primitives::transaction::TxHash;
 use katana_primitives::Felt;
-use katana_rpc_types::FunctionCall;
-use starknet::core::types::{BlockId, BlockTag};
+use starknet::core::types::{BlockId, BlockTag, FunctionCall};
 
 use super::client::Client;
 

--- a/crates/executor/src/abstraction/mod.rs
+++ b/crates/executor/src/abstraction/mod.rs
@@ -5,7 +5,6 @@ use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::TxWithHash;
-use katana_primitives::{ContractAddress, Felt};
 
 pub use crate::error::*;
 
@@ -101,16 +100,6 @@ pub struct ExecutionOutput {
     pub states: StateUpdatesWithClasses,
     /// The transactions that have been executed.
     pub transactions: Vec<(TxWithHash, ExecutionResult)>,
-}
-
-#[derive(Debug, Clone)]
-pub struct EntryPointCall {
-    /// The address of the contract whose function you're calling.
-    pub contract_address: ContractAddress,
-    /// The input to the function.
-    pub calldata: Vec<Felt>,
-    /// The contract function name.
-    pub entry_point_selector: Felt,
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/crates/executor/src/implementation/blockifier/call.rs
+++ b/crates/executor/src/implementation/blockifier/call.rs
@@ -15,17 +15,18 @@ use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::StateReader;
 use blockifier::transaction::objects::{DeprecatedTransactionInfo, TransactionInfo};
 use cairo_vm::vm::runners::cairo_runner::RunResources;
+use katana_primitives::execution::FunctionCall;
 use katana_primitives::Felt;
 use starknet_api::core::EntryPointSelector;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::transaction::fields::Calldata;
 
 use super::utils::to_blk_address;
-use crate::{EntryPointCall, ExecutionError};
+use crate::ExecutionError;
 
 /// Perform a function call on a contract and retrieve the return values.
 pub fn execute_call<S: StateReader>(
-    request: EntryPointCall,
+    request: FunctionCall,
     state: &mut CachedState<S>,
     block_context: Arc<BlockContext>,
     max_gas: u64,
@@ -35,7 +36,7 @@ pub fn execute_call<S: StateReader>(
 }
 
 fn execute_call_inner<S: StateReader>(
-    request: EntryPointCall,
+    request: FunctionCall,
     state: &mut CachedState<S>,
     block_context: Arc<BlockContext>,
     max_gas: u64,
@@ -110,6 +111,7 @@ mod tests {
     use blockifier::execution::errors::EntryPointExecutionError;
     use blockifier::state::cached_state::{self};
     use katana_primitives::class::ContractClass;
+    use katana_primitives::execution::FunctionCall;
     use katana_primitives::{address, felt, ContractAddress};
     use katana_provider::test_utils;
     use katana_provider::traits::contract::ContractClassWriter;
@@ -118,7 +120,6 @@ mod tests {
 
     use super::execute_call_inner;
     use crate::implementation::blockifier::state::StateProviderDb;
-    use crate::EntryPointCall;
 
     #[test]
     fn max_steps() {
@@ -148,7 +149,7 @@ mod tests {
         let mut state = cached_state::CachedState::new(state);
         let ctx = Arc::new(BlockContext::create_for_testing());
 
-        let mut req = EntryPointCall {
+        let mut req = FunctionCall {
             calldata: Vec::new(),
             contract_address: address,
             entry_point_selector: selector!("bounded_call"),
@@ -226,7 +227,7 @@ mod tests {
         let mut state = cached_state::CachedState::new(state);
         let ctx = Arc::new(BlockContext::create_for_testing());
 
-        let req = EntryPointCall {
+        let req = FunctionCall {
             calldata: Vec::new(),
             contract_address: address,
             entry_point_selector: selector!("call_with_panic"),

--- a/crates/primitives/src/execution.rs
+++ b/crates/primitives/src/execution.rs
@@ -18,6 +18,21 @@ pub use starknet_api::execution_resources::{GasAmount, GasVector};
 pub use starknet_api::transaction::fields::{Fee, Resource};
 
 use crate::transaction::TxType;
+use crate::{ContractAddress, Felt};
+
+/// The selector of a contract entry point (ie function selector).
+pub type EntryPointSelector = Felt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FunctionCall {
+    /// The contract function selector.
+    pub entry_point_selector: EntryPointSelector,
+    /// The address of the contract whose function you're calling.
+    pub contract_address: ContractAddress,
+    /// The input to the function.
+    pub calldata: Vec<Felt>,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/rpc/rpc-api/src/cartridge.rs
+++ b/crates/rpc/rpc-api/src/cartridge.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use katana_primitives::{ContractAddress, Felt};
-use katana_rpc_types::broadcasted::AddInvokeTransactionResult;
+use katana_rpc_types::broadcasted::AddInvokeTransactionResponse;
 use katana_rpc_types::outside_execution::OutsideExecution;
 
 /// Cartridge API to support paymaster in local Katana development.
@@ -15,5 +15,5 @@ pub trait CartridgeApi {
         address: ContractAddress,
         outside_execution: OutsideExecution,
         signature: Vec<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult>;
+    ) -> RpcResult<AddInvokeTransactionResponse>;
 }

--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -12,8 +12,9 @@ use katana_rpc_types::block::{
     MaybePendingBlockWithTxs,
 };
 use katana_rpc_types::broadcasted::{
-    AddDeclareTransactionResult, AddDeployAccountTransactionResult, AddInvokeTransactionResult,
-    BroadcastedDeclareTx, BroadcastedDeployAccountTx, BroadcastedInvokeTx, BroadcastedTx,
+    AddDeclareTransactionResponse, AddDeployAccountTransactionResponse,
+    AddInvokeTransactionResponse, BroadcastedDeclareTx, BroadcastedDeployAccountTx,
+    BroadcastedInvokeTx, BroadcastedTx,
 };
 use katana_rpc_types::class::Class;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
@@ -21,7 +22,7 @@ use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
-use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResult};
+use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
 use katana_rpc_types::{
     EstimateFeeSimulationFlag, FeeEstimate, FunctionCall, SimulationFlag, SyncingStatus,
 };
@@ -189,7 +190,7 @@ pub trait StarknetApi {
         class_hashes: Option<Vec<ClassHash>>,
         contract_addresses: Option<Vec<ContractAddress>>,
         contracts_storage_keys: Option<Vec<ContractStorageKeys>>,
-    ) -> RpcResult<GetStorageProofResult>;
+    ) -> RpcResult<GetStorageProofResponse>;
 }
 
 /// Write API.
@@ -201,21 +202,21 @@ pub trait StarknetWriteApi {
     async fn add_invoke_transaction(
         &self,
         invoke_transaction: BroadcastedInvokeTx,
-    ) -> RpcResult<AddInvokeTransactionResult>;
+    ) -> RpcResult<AddInvokeTransactionResponse>;
 
     /// Submit a new class declaration transaction.
     #[method(name = "addDeclareTransaction")]
     async fn add_declare_transaction(
         &self,
         declare_transaction: BroadcastedDeclareTx,
-    ) -> RpcResult<AddDeclareTransactionResult>;
+    ) -> RpcResult<AddDeclareTransactionResponse>;
 
     /// Submit a new deploy account transaction.
     #[method(name = "addDeployAccountTransaction")]
     async fn add_deploy_account_transaction(
         &self,
         deploy_account_transaction: BroadcastedDeployAccountTx,
-    ) -> RpcResult<AddDeployAccountTransactionResult>;
+    ) -> RpcResult<AddDeployAccountTransactionResponse>;
 }
 
 /// Trace API.

--- a/crates/rpc/rpc-types/src/broadcasted.rs
+++ b/crates/rpc/rpc-types/src/broadcasted.rs
@@ -531,14 +531,14 @@ impl BroadcastedDeployAccountTx {
 
 /// Response for broadcasting an `INVOKE` transaction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AddInvokeTransactionResult {
+pub struct AddInvokeTransactionResponse {
     /// The hash of the invoke transaction
     pub transaction_hash: TxHash,
 }
 
 /// Response for broadcasting a `DECLARE` transaction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AddDeclareTransactionResult {
+pub struct AddDeclareTransactionResponse {
     /// The hash of the declare transaction
     pub transaction_hash: TxHash,
     /// The hash of the declared class
@@ -547,7 +547,7 @@ pub struct AddDeclareTransactionResult {
 
 /// Response for broadcasting a `DEPLOY_ACCOUNT` transaction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AddDeployAccountTransactionResult {
+pub struct AddDeployAccountTransactionResponse {
     /// The hash of the deploy transaction
     pub transaction_hash: TxHash,
     /// The address of the new contract
@@ -715,8 +715,9 @@ mod tests {
 
     use super::*;
     use crate::broadcasted::{
-        AddDeclareTransactionResult, AddDeployAccountTransactionResult, AddInvokeTransactionResult,
-        BroadcastedTx, RpcResourceBoundsMapping, UntypedBroadcastedTxError,
+        AddDeclareTransactionResponse, AddDeployAccountTransactionResponse,
+        AddInvokeTransactionResponse, BroadcastedTx, RpcResourceBoundsMapping,
+        UntypedBroadcastedTxError,
     };
 
     #[test]
@@ -1303,7 +1304,7 @@ mod tests {
 
     #[test]
     fn response_types_serde() {
-        let invoke_result = AddInvokeTransactionResult { transaction_hash: felt!("0x123") };
+        let invoke_result = AddInvokeTransactionResponse { transaction_hash: felt!("0x123") };
 
         let expected = json!({
             "transaction_hash": "0x123"
@@ -1312,7 +1313,7 @@ mod tests {
         let actual = serde_json::to_value(&invoke_result).unwrap();
         similar_asserts::assert_eq!(actual, expected);
 
-        let declare_result = AddDeclareTransactionResult {
+        let declare_result = AddDeclareTransactionResponse {
             transaction_hash: felt!("0x456"),
             class_hash: felt!("0x789"),
         };
@@ -1325,7 +1326,7 @@ mod tests {
         let actual = serde_json::to_value(&declare_result).unwrap();
         similar_asserts::assert_eq!(actual, expected);
 
-        let deploy_result = AddDeployAccountTransactionResult {
+        let deploy_result = AddDeployAccountTransactionResponse {
             transaction_hash: felt!("0xabc"),
             contract_address: address!("0xdef"),
         };

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -20,7 +20,8 @@ pub mod trie;
 
 use serde::{Deserialize, Serialize};
 
-pub type FunctionCall = starknet::core::types::FunctionCall;
+/// Request type for `starknet_call` RPC method.
+pub type FunctionCall = katana_primitives::execution::FunctionCall;
 
 pub type FeeEstimate = starknet::core::types::FeeEstimate;
 

--- a/crates/rpc/rpc-types/src/trie.rs
+++ b/crates/rpc/rpc-types/src/trie.rs
@@ -69,7 +69,7 @@ impl MerkleNode {
 /// it may end in an edge node whose path is not a prefix of the requested leaf, thus effectively
 /// proving non-membership
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetStorageProofResult {
+pub struct GetStorageProofResponse {
     pub global_roots: GlobalRoots,
     pub classes_proof: ClassesProof,
     pub contracts_proof: ContractsProof,

--- a/crates/rpc/rpc/src/cartridge/mod.rs
+++ b/crates/rpc/rpc/src/cartridge/mod.rs
@@ -48,7 +48,7 @@ use katana_primitives::{ContractAddress, Felt};
 use katana_provider::traits::state::{StateFactoryProvider, StateProvider};
 use katana_rpc_api::cartridge::CartridgeApiServer;
 use katana_rpc_api::error::starknet::StarknetApiError;
-use katana_rpc_types::broadcasted::AddInvokeTransactionResult;
+use katana_rpc_types::broadcasted::AddInvokeTransactionResponse;
 use katana_rpc_types::outside_execution::{
     OutsideExecution, OutsideExecutionV2, OutsideExecutionV3,
 };
@@ -125,7 +125,7 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
         address: ContractAddress,
         outside_execution: OutsideExecution,
         signature: Vec<Felt>,
-    ) -> Result<AddInvokeTransactionResult, StarknetApiError> {
+    ) -> Result<AddInvokeTransactionResponse, StarknetApiError> {
         debug!(%address, ?outside_execution, "Adding execute outside transaction.");
         self.on_io_blocking_task(move |this| {
             // For now, we use the first predeployed account in the genesis as the paymaster
@@ -265,7 +265,7 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
             let tx = ExecutableTxWithHash::new(ExecutableTx::Invoke(InvokeTx::V3(tx)));
             let transaction_hash = this.pool.add_transaction(tx)?;
 
-            Ok(AddInvokeTransactionResult {transaction_hash})
+            Ok(AddInvokeTransactionResponse {transaction_hash})
         })
         .await
     }
@@ -287,7 +287,7 @@ impl<EF: ExecutorFactory> CartridgeApiServer for CartridgeApi<EF> {
         address: ContractAddress,
         outside_execution: OutsideExecution,
         signature: Vec<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult> {
+    ) -> RpcResult<AddInvokeTransactionResponse> {
         Ok(self.execute_outside(address, outside_execution, signature).await?)
     }
 }

--- a/crates/rpc/rpc/src/starknet/blockifier.rs
+++ b/crates/rpc/rpc/src/starknet/blockifier.rs
@@ -3,15 +3,13 @@ use std::sync::Arc;
 use katana_executor::implementation::blockifier::cache::ClassCache;
 use katana_executor::implementation::blockifier::state::CachedState;
 use katana_executor::implementation::blockifier::utils::{self, block_context_from_envs};
-use katana_executor::{
-    EntryPointCall, ExecutionError, ExecutionFlags, ExecutionResult, ResultAndStates,
-};
+use katana_executor::{ExecutionError, ExecutionFlags, ExecutionResult, ResultAndStates};
 use katana_primitives::env::{BlockEnv, CfgEnv};
 use katana_primitives::fee::{self};
 use katana_primitives::transaction::ExecutableTxWithHash;
 use katana_primitives::Felt;
 use katana_provider::traits::state::StateProvider;
-use katana_rpc_types::FeeEstimate;
+use katana_rpc_types::{FeeEstimate, FunctionCall};
 use starknet::core::types::PriceUnit;
 
 #[tracing::instrument(level = "trace", target = "rpc", skip_all, fields(total_txs = transactions.len()))]
@@ -104,7 +102,7 @@ pub fn call<P: StateProvider>(
     state: P,
     block_env: BlockEnv,
     cfg_env: CfgEnv,
-    call: EntryPointCall,
+    call: FunctionCall,
     max_call_gas: u64,
 ) -> Result<Vec<Felt>, ExecutionError> {
     let block_context = Arc::new(block_context_from_envs(&block_env, &cfg_env));

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -38,7 +38,7 @@ use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
 use katana_rpc_types::trie::{
     ClassesProof, ContractLeafData, ContractStorageKeys, ContractStorageProofs, ContractsProof,
-    GetStorageProofResult, GlobalRoots, Nodes,
+    GetStorageProofResponse, GlobalRoots, Nodes,
 };
 use katana_rpc_types::FeeEstimate;
 use katana_rpc_types_builder::ReceiptBuilder;
@@ -1155,7 +1155,7 @@ where
         class_hashes: Option<Vec<ClassHash>>,
         contract_addresses: Option<Vec<ContractAddress>>,
         contracts_storage_keys: Option<Vec<ContractStorageKeys>>,
-    ) -> StarknetApiResult<GetStorageProofResult> {
+    ) -> StarknetApiResult<GetStorageProofResponse> {
         self.on_io_blocking_task(move |this| {
             let provider = this.inner.backend.blockchain.provider();
 
@@ -1227,7 +1227,7 @@ where
             let contracts_tree_root = state.contracts_root()?;
             let global_roots = GlobalRoots { block_hash, classes_tree_root, contracts_tree_root };
 
-            Ok(GetStorageProofResult {
+            Ok(GetStorageProofResponse {
                 global_roots,
                 classes_proof,
                 contracts_proof,

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::types::ErrorObjectOwned;
-use katana_executor::{EntryPointCall, ExecutorFactory};
+use katana_executor::ExecutorFactory;
 use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{Nonce, StorageKey, StorageValue};
@@ -132,12 +132,6 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
 
     async fn call(&self, request: FunctionCall, block_id: BlockIdOrTag) -> RpcResult<Vec<Felt>> {
         self.on_io_blocking_task(move |this| {
-            let request = EntryPointCall {
-                calldata: request.calldata,
-                contract_address: request.contract_address.into(),
-                entry_point_selector: request.entry_point_selector,
-            };
-
             // get the state and block env at the specified block for function call execution
             let state = this.state(&block_id)?;
             let env = this.block_env_at(&block_id)?;

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -28,7 +28,7 @@ use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
-use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResult};
+use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
 use katana_rpc_types::{EstimateFeeSimulationFlag, FeeEstimate, FunctionCall};
 use starknet::core::types::TransactionStatus;
 
@@ -359,7 +359,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         class_hashes: Option<Vec<ClassHash>>,
         contract_addresses: Option<Vec<ContractAddress>>,
         contracts_storage_keys: Option<Vec<ContractStorageKeys>>,
-    ) -> RpcResult<GetStorageProofResult> {
+    ) -> RpcResult<GetStorageProofResponse> {
         let proofs = self
             .get_proofs(block_id, class_hashes, contract_addresses, contracts_storage_keys)
             .await?;

--- a/crates/rpc/rpc/src/starknet/write.rs
+++ b/crates/rpc/rpc/src/starknet/write.rs
@@ -5,8 +5,9 @@ use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash};
 use katana_rpc_api::error::starknet::StarknetApiError;
 use katana_rpc_api::starknet::StarknetWriteApiServer;
 use katana_rpc_types::broadcasted::{
-    AddDeclareTransactionResult, AddDeployAccountTransactionResult, AddInvokeTransactionResult,
-    BroadcastedDeclareTx, BroadcastedDeployAccountTx, BroadcastedInvokeTx,
+    AddDeclareTransactionResponse, AddDeployAccountTransactionResponse,
+    AddInvokeTransactionResponse, BroadcastedDeclareTx, BroadcastedDeployAccountTx,
+    BroadcastedInvokeTx,
 };
 
 use super::StarknetApi;
@@ -15,7 +16,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
     async fn add_invoke_transaction_impl(
         &self,
         tx: BroadcastedInvokeTx,
-    ) -> Result<AddInvokeTransactionResult, StarknetApiError> {
+    ) -> Result<AddInvokeTransactionResponse, StarknetApiError> {
         self.on_cpu_blocking_task(move |this| {
             if tx.is_query() {
                 return Err(StarknetApiError::UnsupportedTransactionVersion);
@@ -25,7 +26,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
             let tx = ExecutableTxWithHash::new(ExecutableTx::Invoke(tx));
             let transaction_hash = this.inner.pool.add_transaction(tx)?;
 
-            Ok(AddInvokeTransactionResult { transaction_hash })
+            Ok(AddInvokeTransactionResponse { transaction_hash })
         })
         .await
     }
@@ -33,7 +34,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
     async fn add_declare_transaction_impl(
         &self,
         tx: BroadcastedDeclareTx,
-    ) -> Result<AddDeclareTransactionResult, StarknetApiError> {
+    ) -> Result<AddDeclareTransactionResponse, StarknetApiError> {
         self.on_cpu_blocking_task(move |this| {
             if tx.is_query() {
                 return Err(StarknetApiError::UnsupportedTransactionVersion);
@@ -47,7 +48,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
             let tx = ExecutableTxWithHash::new(ExecutableTx::Declare(tx));
             let transaction_hash = this.inner.pool.add_transaction(tx)?;
 
-            Ok(AddDeclareTransactionResult { transaction_hash, class_hash })
+            Ok(AddDeclareTransactionResponse { transaction_hash, class_hash })
         })
         .await
     }
@@ -55,7 +56,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
     async fn add_deploy_account_transaction_impl(
         &self,
         tx: BroadcastedDeployAccountTx,
-    ) -> Result<AddDeployAccountTransactionResult, StarknetApiError> {
+    ) -> Result<AddDeployAccountTransactionResponse, StarknetApiError> {
         self.on_cpu_blocking_task(move |this| {
             if tx.is_query() {
                 return Err(StarknetApiError::UnsupportedTransactionVersion);
@@ -67,7 +68,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
             let tx = ExecutableTxWithHash::new(ExecutableTx::DeployAccount(tx));
             let transaction_hash = this.inner.pool.add_transaction(tx)?;
 
-            Ok(AddDeployAccountTransactionResult { transaction_hash, contract_address })
+            Ok(AddDeployAccountTransactionResponse { transaction_hash, contract_address })
         })
         .await
     }
@@ -78,21 +79,21 @@ impl<EF: ExecutorFactory> StarknetWriteApiServer for StarknetApi<EF> {
     async fn add_invoke_transaction(
         &self,
         invoke_transaction: BroadcastedInvokeTx,
-    ) -> RpcResult<AddInvokeTransactionResult> {
+    ) -> RpcResult<AddInvokeTransactionResponse> {
         Ok(self.add_invoke_transaction_impl(invoke_transaction).await?)
     }
 
     async fn add_declare_transaction(
         &self,
         declare_transaction: BroadcastedDeclareTx,
-    ) -> RpcResult<AddDeclareTransactionResult> {
+    ) -> RpcResult<AddDeclareTransactionResponse> {
         Ok(self.add_declare_transaction_impl(declare_transaction).await?)
     }
 
     async fn add_deploy_account_transaction(
         &self,
         deploy_account_transaction: BroadcastedDeployAccountTx,
-    ) -> RpcResult<AddDeployAccountTransactionResult> {
+    ) -> RpcResult<AddDeployAccountTransactionResponse> {
         Ok(self.add_deploy_account_transaction_impl(deploy_account_transaction).await?)
     }
 }


### PR DESCRIPTION
ref: #198 #209 

Part of an ongoing effort to remove the dependency on starknet-rs for providing the RPC types and define the types locally instead.

