### PR TITLE
chore: bump `starknet` crate to `0.16.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,24 +2472,24 @@ dependencies = [
 
 [[package]]
 name = "cainome"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd7cc8b7674f2285ea36cdf883c14f7c6bfedf12a9643d77dd618e43d34345"
+checksum = "6c3a9993ce9d20bd56a93069f9a5b03fa9e8410e10950e72b9b3be7692fcd70c"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome-cairo-serde 0.2.1",
+ "cainome-cairo-serde 0.3.0",
  "cainome-cairo-serde-derive",
- "cainome-parser 0.3.0",
- "cainome-rs 0.3.1",
- "cainome-rs-macro 0.3.0",
+ "cainome-parser 0.5.0",
+ "cainome-rs 0.4.0",
+ "cainome-rs-macro 0.4.0",
  "camino",
  "clap",
  "clap_complete",
  "convert_case 0.8.0",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-types-core",
  "thiserror 2.0.11",
  "tracing",
@@ -2512,14 +2512,14 @@ dependencies = [
 
 [[package]]
 name = "cainome-cairo-serde"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da490d99e84c141e9f5646965de176d6fbfcc7a525f17b6b08e208cd65e6fe35"
+checksum = "94986d430c62ae5f07783c671f3a4fbd56e6f563c720d76e612ae7371621ad9e"
 dependencies = [
  "num-bigint",
  "serde",
  "serde_with 3.12.0",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 2.0.11",
 ]
 
@@ -2551,16 +2551,16 @@ dependencies = [
 
 [[package]]
 name = "cainome-parser"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaf4e3cba66ccc85bca9726e09ffd69d3b1be37f1305ed59e1b1d5a6e86fabc"
+checksum = "fffc4c67b8b5d9f45886d569edba87b45789458d6421f607c7c3c949e198d2f4"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case 0.8.0",
  "quote",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.16.0",
  "syn 2.0.98",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2584,19 +2584,19 @@ dependencies = [
 
 [[package]]
 name = "cainome-rs"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24e87fcf544b3112f70e36eb560c78c0f7e18ca5d6a1483fdf7b05e7e8302e9"
+checksum = "c417e6cab161738793d2a443093290a62938d567573e9aac005a0587778e054b"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.2.1",
- "cainome-parser 0.3.0",
+ "cainome-cairo-serde 0.3.0",
+ "cainome-parser 0.5.0",
  "camino",
  "prettyplease",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "syn 2.0.98",
  "thiserror 2.0.11",
 ]
@@ -2622,21 +2622,21 @@ dependencies = [
 
 [[package]]
 name = "cainome-rs-macro"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919354b1142e3ca398313b842a5f95b081b0261270164a8fcdf13c8c633193fd"
+checksum = "e4531c64b63e6e204cea65b53e7b26d9400e42249325ebb3b0bc0b5671c2f8e4"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.2.1",
- "cainome-parser 0.3.0",
- "cainome-rs 0.3.1",
+ "cainome-cairo-serde 0.3.0",
+ "cainome-parser 0.5.0",
+ "cainome-rs 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.16.0",
  "syn 2.0.98",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3357,7 +3357,7 @@ version = "1.6.3"
 dependencies = [
  "anyhow",
  "ark-ec 0.4.2",
- "cainome 0.8.0",
+ "cainome 0.9.0",
  "katana-primitives",
  "num-bigint",
  "parking_lot",
@@ -3365,7 +3365,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stark-vrf",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-crypto 0.7.4",
  "thiserror 1.0.69",
  "tracing",
@@ -4049,7 +4049,7 @@ dependencies = [
  "katana-node",
  "katana-primitives",
  "katana-provider",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "tokio",
 ]
 
@@ -6226,7 +6226,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "byte-unit",
- "cainome 0.8.0",
+ "cainome 0.9.0",
  "clap",
  "clap_complete",
  "colored_json 5.0.0",
@@ -6249,7 +6249,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "spinoff",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "strum_macros 0.25.3",
  "tempfile",
  "thiserror 1.0.69",
@@ -6277,7 +6277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "tempfile",
  "thiserror 1.0.69",
  "toml",
@@ -6306,7 +6306,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "tokio",
  "toml",
  "tracing",
@@ -6338,7 +6338,7 @@ dependencies = [
  "katana-contracts-macro",
  "katana-primitives",
  "lazy_static",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
 ]
 
@@ -6386,7 +6386,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rstest 0.18.2",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-types-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -6416,7 +6416,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
@@ -6450,7 +6450,7 @@ dependencies = [
  "rstest_reuse 0.6.0",
  "serde_json",
  "similar-asserts",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "thiserror 1.0.69",
  "tokio",
@@ -6492,7 +6492,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6509,7 +6509,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "parking_lot",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6530,7 +6530,7 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "reqwest 0.12.15",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6565,7 +6565,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-crypto 0.7.4",
  "thiserror 1.0.69",
  "tokio",
@@ -6619,7 +6619,7 @@ dependencies = [
  "katana-tracing",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -6642,7 +6642,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6675,7 +6675,7 @@ dependencies = [
  "katana-provider",
  "parking_lot",
  "rand 0.8.5",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6691,7 +6691,7 @@ dependencies = [
  "assert_matches",
  "base64 0.21.7",
  "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "cainome-cairo-serde 0.2.1",
+ "cainome-cairo-serde 0.3.0",
  "cairo-lang-starknet-classes",
  "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion",
@@ -6709,7 +6709,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with 3.12.0",
  "similar-asserts",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-crypto 0.7.4",
  "starknet-types-core",
  "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
@@ -6740,7 +6740,7 @@ dependencies = [
  "rstest 0.18.2",
  "rstest_reuse 0.6.0",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-types-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -6757,7 +6757,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "assert_matches",
- "cainome 0.8.0",
+ "cainome 0.9.0",
  "cairo-lang-starknet-classes",
  "cartridge",
  "dojo-utils",
@@ -6790,7 +6790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-crypto 0.7.4",
  "tempfile",
  "thiserror 1.0.69",
@@ -6815,7 +6815,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
 ]
 
@@ -6825,8 +6825,8 @@ version = "1.6.3"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
- "cainome 0.8.0",
- "cainome-cairo-serde 0.2.1",
+ "cainome 0.9.0",
+ "cainome-cairo-serde 0.3.0",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "flate2",
@@ -6839,7 +6839,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with 3.12.0",
  "similar-asserts",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "thiserror 1.0.69",
 ]
@@ -6853,7 +6853,7 @@ dependencies = [
  "katana-primitives",
  "katana-provider",
  "katana-rpc-types",
- "starknet 0.15.1",
+ "starknet 0.16.0",
 ]
 
 [[package]]
@@ -6865,7 +6865,7 @@ dependencies = [
  "jsonrpsee",
  "katana-node-bindings",
  "katana-runner-macro",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "tokio",
 ]
 
@@ -6904,7 +6904,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "num-traits",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6958,7 +6958,7 @@ dependencies = [
  "katana-primitives",
  "serde",
  "slab",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-types-core",
  "thiserror 1.0.69",
 ]
@@ -6981,7 +6981,7 @@ dependencies = [
  "katana-rpc",
  "katana-utils-macro",
  "rand 0.8.5",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6993,7 +6993,7 @@ dependencies = [
  "async-trait",
  "proc-macro2",
  "quote",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "syn 2.0.98",
  "tokio",
 ]
@@ -8309,10 +8309,10 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "piltover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/piltover.git?rev=3bed7ac554259668dbdce6a5f56de5b2bf7faf43#3bed7ac554259668dbdce6a5f56de5b2bf7faf43"
+source = "git+https://github.com/kariy/piltover.git?branch=starknet0.16.0#0c447b643825653996353880171a288e262e5675"
 dependencies = [
- "cainome 0.8.0",
- "starknet 0.15.1",
+ "cainome 0.9.0",
+ "starknet 0.16.0",
 ]
 
 [[package]]
@@ -10466,7 +10466,7 @@ dependencies = [
  "katana-primitives",
  "katana-provider",
  "prove_block",
- "starknet 0.15.1",
+ "starknet 0.16.0",
  "starknet-os",
  "tokio",
 ]
@@ -10613,34 +10613,18 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e2e53e7705c9a9aad7f118a4bac7386afeb8db272b3eb445a464ca4c3dfee5"
+checksum = "94e0e01a3e521a53138b774591bacb63032cfb1c4c98c93d5ce4dda96457222b"
 dependencies = [
- "starknet-accounts 0.13.0",
- "starknet-contract 0.13.0",
- "starknet-core 0.13.0",
+ "starknet-accounts 0.15.0",
+ "starknet-contract 0.15.0",
+ "starknet-core 0.15.0",
  "starknet-core-derive",
  "starknet-crypto 0.7.4",
  "starknet-macros",
- "starknet-providers 0.13.0",
- "starknet-signers 0.11.0",
-]
-
-[[package]]
-name = "starknet"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ec983c56ce05b2d7679fa860b37b2ade21004c343ff49374a591b40ee8ee1d"
-dependencies = [
- "starknet-accounts 0.14.0",
- "starknet-contract 0.14.0",
- "starknet-core 0.14.0",
- "starknet-core-derive",
- "starknet-crypto 0.7.4",
- "starknet-macros",
- "starknet-providers 0.14.1",
- "starknet-signers 0.12.0",
+ "starknet-providers 0.15.0",
+ "starknet-signers 0.13.0",
 ]
 
 [[package]]
@@ -10690,31 +10674,16 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca52534db01eda3bf3250f398bd4597aed3856d0d17d84070efbc7919abad71"
+checksum = "7961299fe73e642f1c2c6b8297cc5702740b000ce2b3956c1ab349f53654107e"
 dependencies = [
  "async-trait",
  "auto_impl",
- "starknet-core 0.13.0",
+ "starknet-core 0.15.0",
  "starknet-crypto 0.7.4",
- "starknet-providers 0.13.0",
- "starknet-signers 0.11.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7adf55fa08ffed413614df3171632e45dcba72cc53706b147ba08e5b7b4e4fb"
-dependencies = [
- "async-trait",
- "auto_impl",
- "starknet-core 0.14.0",
- "starknet-crypto 0.7.4",
- "starknet-providers 0.14.1",
- "starknet-signers 0.12.0",
+ "starknet-providers 0.15.0",
+ "starknet-signers 0.13.0",
  "thiserror 1.0.69",
 ]
 
@@ -10765,31 +10734,16 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d8d5a5306527eedcb4bd70afecfc6824add631a08eac8fd1cf9c2bdfd21e77"
+checksum = "94e91bb0ec9b25b8cd0579540f66fb3eb965b43fbf65789a4bda65073aa43662"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.12.0",
- "starknet-accounts 0.13.0",
- "starknet-core 0.13.0",
- "starknet-providers 0.13.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72746fa496e352ef16b4a8fd11e415ada6b7b5a9107fc6e845eeb921b8bb2a69"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with 3.12.0",
- "starknet-accounts 0.14.0",
- "starknet-core 0.14.0",
- "starknet-providers 0.14.1",
+ "starknet-accounts 0.15.0",
+ "starknet-core 0.15.0",
+ "starknet-providers 0.15.0",
  "thiserror 1.0.69",
 ]
 
@@ -10837,32 +10791,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a16799e4a75173839d868a1a48ff5d3e10456febd4dec91b04ba6521741d5"
-dependencies = [
- "base64 0.21.7",
- "crypto-bigint",
- "flate2",
- "foldhash",
- "hex",
- "indexmap 2.7.1",
- "num-traits",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with 3.12.0",
- "sha3",
- "starknet-core-derive",
- "starknet-crypto 0.7.4",
- "starknet-types-core",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2091a08ebfc65c5a6b8bd2c66e32780739854b813af0b4348b6dbf3a887865"
+checksum = "2ebd248c1503f89d74f98bfb38119f6421ffb81b23f3404f33b268539d0c4cb6"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
@@ -10998,11 +10929,11 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dd27bb42d53bd7948a32d4a88c04e799bfcc011b87448756bb0643e6ec0e6d"
+checksum = "4ebbaa813de0006d0ef21c00ed4395fa06ea4fec3ef0bdaad212aded2a1dd11f"
 dependencies = [
- "starknet-core 0.14.0",
+ "starknet-core 0.15.0",
  "syn 2.0.98",
 ]
 
@@ -11123,30 +11054,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74c3850a661fa1ffd3c3e2cb9db6e28c94ab9aaaa0496503014a814f09cd455"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethereum-types",
- "flate2",
- "getrandom 0.2.15",
- "log",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_with 3.12.0",
- "starknet-core 0.13.0",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce77bf215b70673264bc875d59c45fb7da500e7e6f71d2608ad25a1f7280671"
+checksum = "a11aa3094e646d6fe49d2cfdc49b99b42b280b170518eeb50f759d62cccbf4ae"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -11158,7 +11068,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.12.0",
- "starknet-core 0.14.0",
+ "starknet-core 0.15.0",
  "thiserror 1.0.69",
  "url",
 ]
@@ -11199,9 +11109,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aeca13b8c61165b69d4775880d74ff9bbb9bafa36a297899e0f160619631b3"
+checksum = "32e60350b8a56451cd937bdea01bee50519a38611f277c06bc2bdc7eaf103a6a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -11209,24 +11119,7 @@ dependencies = [
  "eth-keystore",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "starknet-core 0.13.0",
- "starknet-crypto 0.7.4",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-signers"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd831176f8a217694895fd69be17f985e5e28f00bc8044eb54b55656f3a7f1"
-dependencies = [
- "async-trait",
- "auto_impl",
- "crypto-bigint",
- "eth-keystore",
- "getrandom 0.2.15",
- "rand 0.8.5",
- "starknet-core 0.14.0",
+ "starknet-core 0.15.0",
  "starknet-crypto 0.7.4",
  "thiserror 1.0.69",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8309,7 +8309,7 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "piltover"
 version = "0.1.0"
-source = "git+https://github.com/kariy/piltover.git?branch=starknet0.16.0#0c447b643825653996353880171a288e262e5675"
+source = "git+https://github.com/kariy/piltover.git?rev=ff4a519#ff4a5194b1555577c723314432771b13bf2a1930"
 dependencies = [
  "cainome 0.9.0",
  "starknet 0.16.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,8 @@ backon = { version = "1.5", features = [ "tokio-sleep" ] }
 base64 = "0.21.2"
 bigdecimal = "0.4.1"
 bitvec = "1.0.1"
-cainome = { version = "0.8.0", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { version = "0.2.1" }
+cainome = { version = "0.9.0", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { version = "0.3.0" }
 camino = { version = "1.1.2", features = [ "serde1" ] }
 chrono = { version = "0.4.24", features = [ "serde" ] }
 clap = { version = "4.5.16", features = [ "derive", "env" ] }
@@ -208,7 +208,7 @@ opentelemetry-http = "0.30.0"
 opentelemetry-stackdriver = { version = "0.27.0", features = [ "propagator" ] }
 
 # starknet
-starknet = "0.15.1"
+starknet = "0.16"
 starknet-crypto = "0.7.1"
 starknet-types-core = { version = "0.1.8", features = [ "arbitrary", "hash" ] }
 # Some types that we used from cairo-vm implements the `Arbitrary` trait,

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -24,8 +24,6 @@ comfy-table = "7.1.1"
 const_format = "0.2.33"
 indicatif = "0.17.8"
 inquire = "0.7.5"
-# Rev on branch starknet 0.15.1.
-piltover = { git = "https://github.com/cartridge-gg/piltover.git", rev = "3bed7ac554259668dbdce6a5f56de5b2bf7faf43" }
 rand.workspace = true
 shellexpand = "3.1.0"
 spinoff.workspace = true
@@ -39,6 +37,11 @@ url.workspace = true
 colored_json = { version = "5.0", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+
+# Branch with starknet 0.16.0
+#
+# Use the cartridge-gg fork once this PR is merged: <https://github.com/cartridge-gg/piltover/pull/10>
+piltover = { git = "https://github.com/kariy/piltover.git", branch = "starknet0.16.0" }
 
 [build-dependencies]
 vergen = { version = "9.0.0", features = [ "build", "cargo", "emit_and_set" ] }

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -38,10 +38,8 @@ colored_json = { version = "5.0", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
-# Branch with starknet 0.16.0
-#
-# Use the cartridge-gg fork once this PR is merged: <https://github.com/cartridge-gg/piltover/pull/10>
-piltover = { git = "https://github.com/kariy/piltover.git", branch = "starknet0.16.0" }
+# piltover rev with starknet 0.16.0
+piltover = { git = "https://github.com/kariy/piltover.git", rev = "ff4a519" }
 
 [build-dependencies]
 vergen = { version = "9.0.0", features = [ "build", "cargo", "emit_and_set" ] }

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -568,7 +568,10 @@ where
 
                     // TODO: should impl From<ExecutionResult> for TransactionStatus
                     let status = match res {
-                        ExecutionResult::Failed { .. } => TransactionStatus::Rejected,
+                        ExecutionResult::Failed { error } => {
+                            TransactionStatus::Rejected { reason: error.to_string() }
+                        }
+
                         ExecutionResult::Success { receipt, .. } => {
                             if let Some(reason) = receipt.revert_reason() {
                                 TransactionStatus::AcceptedOnL2(

--- a/crates/utils/src/tx_waiter.rs
+++ b/crates/utils/src/tx_waiter.rs
@@ -26,8 +26,8 @@ pub enum TxWaitingError {
     #[error("transaction reverted with reason: {0}")]
     TransactionReverted(String),
 
-    #[error("transaction rejected")]
-    TransactionRejected,
+    #[error("transaction rejected with reason: {0}")]
+    TransactionRejected(String),
 
     #[error(transparent)]
     Provider(ProviderError),
@@ -210,8 +210,9 @@ impl<P: Provider + Send> Future for TxWaiter<'_, P> {
                                 ));
                             }
 
-                            TransactionStatus::Rejected => {
-                                return Poll::Ready(Err(TxWaitingError::TransactionRejected));
+                            TransactionStatus::Rejected { reason } => {
+                                let error = TxWaitingError::TransactionRejected(reason);
+                                return Poll::Ready(Err(error));
                             }
 
                             TransactionStatus::Received => {}


### PR DESCRIPTION
General `starknet` dependency version bump.