### PR TITLE
chore(utils): remove dependency on `dojo-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,25 +3585,13 @@ dependencies = [
 
 [[package]]
 name = "colored_json"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cb9ce6b86f6e54bfa9518df2eeeef65d424ec7244d083ed97229185e366a91"
-dependencies = [
- "is-terminal",
- "serde",
- "serde_json",
- "yansi 0.5.1",
-]
-
-[[package]]
-name = "colored_json"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35980a1b846f8e3e359fd18099172a0857140ba9230affc4f71348081e039b6"
 dependencies = [
  "serde",
  "serde_json",
- "yansi 1.0.1",
+ "yansi",
 ]
 
 [[package]]
@@ -4311,23 +4299,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "dojo-utils"
-version = "1.2.2"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.2.2#aafa6669b750cec99aed145640dd6c9a9a946562"
-dependencies = [
- "anyhow",
- "colored_json 3.2.0",
- "futures",
- "reqwest 0.11.27",
- "rpassword",
- "serde_json",
- "starknet 0.12.0",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "downcast"
@@ -6229,7 +6200,7 @@ dependencies = [
  "cainome 0.9.0",
  "clap",
  "clap_complete",
- "colored_json 5.0.0",
+ "colored_json",
  "comfy-table",
  "const_format",
  "indicatif",
@@ -6293,7 +6264,6 @@ dependencies = [
  "assert_matches",
  "clap",
  "console",
- "dojo-utils",
  "katana-chain-spec",
  "katana-core",
  "katana-gas-price-oracle",
@@ -6303,6 +6273,7 @@ dependencies = [
  "katana-rpc",
  "katana-slot-controller",
  "katana-tracing",
+ "katana-utils",
  "serde",
  "serde_json",
  "shellexpand",
@@ -6596,7 +6567,6 @@ version = "1.6.3"
 dependencies = [
  "anyhow",
  "clap",
- "dojo-utils",
  "futures",
  "http 1.3.1",
  "jsonrpsee",
@@ -6760,7 +6730,6 @@ dependencies = [
  "cainome 0.9.0",
  "cairo-lang-starknet-classes",
  "cartridge",
- "dojo-utils",
  "futures",
  "http 1.3.1",
  "indexmap 2.7.1",
@@ -8524,7 +8493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
- "yansi 1.0.1",
+ "yansi",
 ]
 
 [[package]]
@@ -9357,17 +9326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
-name = "rpassword"
-version = "7.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rpc-client"
 version = "0.1.0"
 source = "git+https://github.com/cartridge-gg/snos?rev=962c263#962c263d9af5d68945874cc2d5b39ccf604d61bd"
@@ -9487,16 +9445,6 @@ dependencies = [
  "quote",
  "rand 0.8.5",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10582,21 +10530,6 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0c9ac3809cc7630784e8c8565fa3013af819d83c97aa2720d566016d439011"
-dependencies = [
- "starknet-accounts 0.11.0",
- "starknet-contract 0.11.0",
- "starknet-core 0.12.1",
- "starknet-crypto 0.7.4",
- "starknet-macros",
- "starknet-providers 0.12.1",
- "starknet-signers 0.10.2",
-]
-
-[[package]]
-name = "starknet"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9b221c99a1ea1d65fb130e5b0dbaa6d362698430232902ebeb2a898a1ab531"
@@ -10644,21 +10577,6 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee27ded58ade61da410fccafd57ed5429b0e79a9d62a4ae8b65818cb9d6f400"
-dependencies = [
- "async-trait",
- "auto_impl",
- "starknet-core 0.12.1",
- "starknet-crypto 0.7.4",
- "starknet-providers 0.12.1",
- "starknet-signers 0.10.2",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-accounts"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3fc4364f5684e4a5dcb100847a9ea023deae3815f45526721a6fa94ab595651"
@@ -10699,21 +10617,6 @@ dependencies = [
  "starknet-accounts 0.10.0",
  "starknet-core 0.11.1",
  "starknet-providers 0.11.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6ee5762d24c4f06ab7e9406550925df406712e73719bd2de905c879c674a87"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with 3.12.0",
- "starknet-accounts 0.11.0",
- "starknet-core 0.12.1",
- "starknet-providers 0.12.1",
  "thiserror 1.0.69",
 ]
 
@@ -13452,12 +13355,6 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,6 @@ clap_complete = "4.3"
 colored = "2.0.0"
 console = "0.15.7"
 derive_more = "0.99.17"
-dojo-utils = { git = "https://github.com/dojoengine/dojo", tag = "v1.2.2" }
 flate2 = "1.0.35"
 futures = "0.3.30"
 futures-util = "0.3.30"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,12 +14,12 @@ katana-primitives.workspace = true
 katana-rpc.workspace = true
 katana-slot-controller = { workspace = true, optional = true }
 katana-tracing.workspace = true
+katana-utils.workspace = true
 
 alloy-primitives.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 console.workspace = true
-dojo-utils.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shellexpand = "3.1.0"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -147,7 +147,7 @@ impl NodeArgs {
 
         // Wait until an OS signal (ie SIGINT, SIGTERM) is received or the node is shutdown.
         tokio::select! {
-            _ = dojo_utils::signal::wait_signals() => {
+            _ = katana_utils::wait_shutdown_signals() => {
                 // Gracefully shutdown the node before exiting
                 handle.stop().await?;
             },

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -41,7 +41,6 @@ strum.workspace = true
 strum_macros.workspace = true
 
 clap = { workspace = true, optional = true }
-dojo-utils = { workspace = true, optional = true }
 katana-feeder-gateway = { workspace = true, optional = true }
 tokio = { workspace = true, features = [ "time" ], optional = true }
 tracing-log = { workspace = true, optional = true }

--- a/crates/node/src/full/node.rs
+++ b/crates/node/src/full/node.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     let node = Node::build(config)?.launch()?;
 
     tokio::select! {
-        _ = dojo_utils::signal::wait_signals() => {
+        _ = katana_utils::wait_shutdown_signals() => {
             // Gracefully shutdown the node before exiting
             node.stop().await?;
         },

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -52,7 +52,6 @@ alloy-primitives = { workspace = true, features = [ "serde" ] }
 assert_matches.workspace = true
 cainome.workspace = true
 cairo-lang-starknet-classes.workspace = true
-dojo-utils.workspace = true
 indexmap.workspace = true
 jsonrpsee = { workspace = true, features = [ "client" ] }
 num-traits.workspace = true

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -23,4 +23,4 @@ futures.workspace = true
 rand.workspace = true
 starknet.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = [ "time" ] }
+tokio = { workspace = true, features = [ "macros", "signal", "time" ], default-features = false }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,10 +1,12 @@
-pub mod node;
-mod tx_waiter;
-
-// Re-export the Arbitrary trait and related types
 pub use arbitrary::{Arbitrary, Unstructured};
 pub use katana_utils_macro::mock_provider;
+
+pub mod node;
+mod signal;
+mod tx_waiter;
+
 pub use node::TestNode;
+pub use signal::wait_shutdown_signals;
 pub use tx_waiter::*;
 
 /// Generate a random bytes vector of the given size.

--- a/crates/utils/src/signal.rs
+++ b/crates/utils/src/signal.rs
@@ -1,0 +1,27 @@
+use std::io;
+
+use tokio::signal::ctrl_c;
+
+/// Returns a future for awaiting on OS signals to be received - `SIGTERM` (Unix only), `SIGINT`.
+///
+/// Can be used to handle graceful shutdowns.
+pub async fn wait_shutdown_signals() {
+    #[cfg(unix)]
+    tokio::select! {
+        _ = ctrl_c() => {},
+        _ = sigterm() => {},
+    }
+
+    #[cfg(not(unix))]
+    tokio::select! {
+        _ = ctrl_c() => {},
+    }
+}
+
+/// Returns a future that can be awaited to wait for the `SIGTERM` signal.
+#[cfg(unix)]
+async fn sigterm() -> io::Result<()> {
+    use tokio::signal::unix::{signal, SignalKind};
+    signal(SignalKind::terminate())?.recv().await;
+    Ok(())
+}


### PR DESCRIPTION
The motivation to remove the reliance on `dojo-utils` is so to avoid having version conflicts when bumping shared dependencies (primarily `starknet`). 

In some cases, when we're attempting to bump `starknet` crate version on Katana, it'd conflict with the version of `starknet` required by `dojo-utils`. Even though the stuff we're importing from `dojo-utils` doesn't rely on `starknet` at all (this is the case with the `dojo_utils::signal::wait_signals` function).