### PR TITLE
Bump Rust version to 1.86.0

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - ".github/Dockerfile"
 
+env:
+  RUST_VERSION: 1.86.0
+  CLIPPY_VERSION: nightly-2025-02-20
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -65,8 +69,8 @@ jobs:
           file: .github/Dockerfile
           tags: ghcr.io/${{ github.repository }}-dev:${{ needs.setup.outputs.tag_name }}-amd64,ghcr.io/${{ github.repository }}-dev:latest-amd64
           build-args: |
-            RUST_VERSION=1.85.0
-            CLIPPY_VERSION=nightly-2025-02-20
+            RUST_VERSION=${{ env.RUST_VERSION }}
+            CLIPPY_VERSION=${{ env.CLIPPY_VERSION }}
           platforms: linux/amd64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-dev:latest-amd64
 
@@ -98,8 +102,8 @@ jobs:
           file: .github/Dockerfile
           tags: ghcr.io/${{ github.repository }}-dev:${{ needs.setup.outputs.tag_name }}-arm64,ghcr.io/${{ github.repository }}-dev:latest-arm64
           build-args: |
-            RUST_VERSION=1.85.0
-            CLIPPY_VERSION=nightly-2025-02-20
+            RUST_VERSION=${{ env.RUST_VERSION }}
+            CLIPPY_VERSION=${{ env.CLIPPY_VERSION }}
           platforms: linux/arm64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-dev:latest-arm64
 

--- a/.github/workflows/dockerfile-build-test.yml
+++ b/.github/workflows/dockerfile-build-test.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - ".github/Dockerfile"
 
+env:
+  RUST_VERSION: 1.86.0
+  CLIPPY_VERSION: nightly-2025-02-20
+
 jobs:
   build-dev-image:
     runs-on: ubuntu-latest
@@ -25,7 +29,7 @@ jobs:
           file: .github/Dockerfile
           platforms: ${{ matrix.platform }}
           build-args: |
-            RUST_VERSION=1.85.0
-            CLIPPY_VERSION=nightly-2025-02-20
+            RUST_VERSION=${{ env.RUST_VERSION }}
+            CLIPPY_VERSION=${{ env.CLIPPY_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -5,7 +5,15 @@ on:
       version:
         description: Version to release
         required: true
-        type: string
+        type: choice
+        options:
+          - major
+          - minor
+          - patch,
+          - release
+          - rc
+          - beta
+          - alpha
 
 jobs:
   propose-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
       - main
 
 env:
+  RUST_VERSION: 1.86.0
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
 
@@ -135,7 +136,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         name: Rust Toolchain Setup
         with:
-          toolchain: "1.85.0"
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.job.target }}
           cache-on-failure: true
           cache-key: ${{ matrix.job.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.85.0
 
 jobs:
   fmt:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"


### PR DESCRIPTION
ref #215 

Increase the MSRV (minimum supported Rust version) to 1.86.0 in order to bump alloy version to `1.0.*`.