### PR TITLE
ci(release): allow specify custom version

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -2,18 +2,24 @@ name: release-dispatch
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: Version to release
-        required: true
+      version_type:
+        description: Version type to release
+        required: false
         type: choice
+        default: custom
         options:
           - major
           - minor
-          - patch,
+          - patch
           - release
           - rc
           - beta
           - alpha
+          - custom
+      custom_version:
+        description: Custom version (used when `version_type` is 'custom')
+        required: false
+        type: string
 
 jobs:
   propose-release:
@@ -26,6 +32,18 @@ jobs:
     env:
       VERSION: ""
     steps:
+      - name: "Validate inputs"
+        run: |
+          if [ "${{ inputs.version_type }}" = "custom" ] && [ -z "${{ inputs.custom_version }}" ]; then
+            echo "error: custom_version is required when version_type is 'custom'"
+            exit 1
+          fi
+
+          if [ "${{ inputs.version_type }}" != "custom" ] && [ -n "${{ inputs.custom_version }}" ]; then
+            echo "error: custom_version should be empty when version_type is not 'custom'"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
       - run: git config --global --add safe.directory "*"
 
@@ -35,7 +53,11 @@ jobs:
           toolchain: "stable"
 
       - run: |
-          VERSION=${{ inputs.version }}
+          if [ "${{ inputs.version_type }}" = "custom" ]; then
+            VERSION=${{ inputs.custom_version }}
+          else
+            VERSION=${{ inputs.version_type }}
+          fi
           VERSION=${VERSION#v}
           cargo release version $VERSION --execute --no-confirm && cargo release replace --execute --no-confirm
 


### PR DESCRIPTION
Right now when running the `release-dispatch.yml` workflow, we can only choose from a set of options for the `version_type` input. This is fine if we have an ideal and linear history where every releases are made against the `main` branch, but sometime we break this rule and create a release at a commit that doesn't belong to the `main` branch (e.g., https://github.com/dojoengine/katana/releases/tag/v1.7.0-alpha.0). 

Due to my own negligence, I should've made the git history of the releases clean - the commit of each git tag (ie release version) and its predecessor can be tracked within the same branch. But now I've decided to abandon the branch of which the `v1.7.0-alpha.0` tag was made from (ie branch [`1.7.0`](https://github.com/dojoengine/katana/tree/1.7.0)). So, the next version ie `1.7.0-alpha.1` will be coming from main. Hence, why this changes are needed. None of the options provided by the `release-dispatch.yml` workflow will be able to advance the current version (1.6.3) of the main branch to the desired version (ie `1.7.0-alpha.1`). 