### PR TITLE
fix(rpc): unfinished error conversion

### DIFF
--- a/crates/contracts/macro/Cargo.toml
+++ b/crates/contracts/macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition.workspace = true
 name = "katana-contracts-macro"
-version = "1.7.0-alpha.2"
-edition = "2021"
+version.workspace = true
 
 [lib]
 proc-macro = true
@@ -9,11 +9,11 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
 serde_json = "1.0"
+syn = { version = "2.0", features = [ "extra-traits", "full" ] }
 
 # Dependencies for contract class parsing and hash computation
-katana-primitives = { path = "../../primitives" }
 cairo-lang-starknet-classes = "2.11.2"
+katana-primitives = { path = "../../primitives" }
 starknet-crypto = "0.7.4"
 starknet-types-core = "0.1.8"

--- a/crates/rpc/rpc-api/src/error/starknet.rs
+++ b/crates/rpc/rpc-api/src/error/starknet.rs
@@ -234,13 +234,10 @@ impl From<Box<InvalidTransactionError>> for StarknetApiError {
 impl From<StarknetRsError> for StarknetApiError {
     fn from(value: StarknetRsError) -> Self {
         match value {
-            StarknetRsError::FeeBelowMinimum => {
-                unimplemented!("ReplacementTransactionUnderpriced")
-            }
+            StarknetRsError::FeeBelowMinimum => Self::FeeBelowMinimum,
             StarknetRsError::ReplacementTransactionUnderpriced => {
-                unimplemented!("ReplacementTransactionUnderpriced")
+                Self::ReplacementTransactionUnderpriced
             }
-
             StarknetRsError::FailedToReceiveTransaction => Self::FailedToReceiveTxn,
             StarknetRsError::NoBlocks => Self::NoBlocks,
             StarknetRsError::NonAccount => Self::NonAccount,

--- a/crates/rpc/rpc/src/starknet/blockifier.rs
+++ b/crates/rpc/rpc/src/starknet/blockifier.rs
@@ -71,13 +71,7 @@ pub fn estimate_fees(
                         let fee = receipt.fee();
                         let resources = receipt.resources_used();
 
-                        // let unit = match fee.unit {
-                        //     fee::PriceUnit::Wei => PriceUnit::Wei,
-                        //     fee::PriceUnit::Fri => PriceUnit::Fri,
-                        // };
-
                         results.push(Ok(FeeEstimate {
-                            // unit,
                             overall_fee: fee.overall_fee,
                             l2_gas_price: fee.l2_gas_price,
                             l1_gas_price: fee.l1_gas_price,


### PR DESCRIPTION
Related #210 

`ReplacementTransactionUnderpriced` and `FeeBelowMinimum` are two new errors that have been added as part of the RPC 0.9.0. PR #210 missed to add these new errors.

