### PR TITLE
fix(rpc): invalid spec version

### DIFF
--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -32,7 +32,7 @@ use starknet::core::types::{
 };
 
 /// The currently supported version of the Starknet JSON-RPC specification.
-pub const RPC_SPEC_VERSION: &str = "0.9.0.rc-2";
+pub const RPC_SPEC_VERSION: &str = "0.9.0-rc.2";
 
 /// Read API.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "starknet"))]


### PR DESCRIPTION
The valid semver compatible version format is '0.9.0-rc.2'.