### PR TITLE
ci(test): Dojo integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,8 +246,7 @@ jobs:
 
       - name: Start Katana
         run: |
-          cargo run --bin katana
-          katana > katana.log 2>&1 &
+          cargo run --bin katana > katana.log 2>&1 &
 
       - name: Checkout Dojo repository
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,11 +239,10 @@ jobs:
           key: ci-${{ github.job }}
           shared-key: katana-ci-cache
 
-      - name: Restore test artifacts
-        uses: actions/cache@v3
+      - name: Download test artifacts
+        uses: actions/download-artifact@v5
         with:
-          path: ./crates/contracts/build
-          key: test-artifacts
+          name: test-artifacts
 
       - name: Start Katana
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,12 +221,7 @@ jobs:
     runs-on: ubuntu-latest-32-cores
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
-      image: ghcr.io/dojoengine/katana-dev:rpc090rc2
-    env:
-      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
-      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
-      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
-      NEXTEST_PROFILE: ci
+      image: ghcr.io/dojoengine/katana-dev:latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -239,14 +234,17 @@ jobs:
           key: ci-${{ github.job }}
           shared-key: katana-ci-cache
 
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "nightly-2025-05-08"
+
       - name: Download test artifacts
         uses: actions/download-artifact@v5
         with:
           name: test-artifacts
 
       - name: Start Katana
-        run: |
-          cargo run --bin katana > katana.log 2>&1 &
+        run: cargo run --bin katana > katana.log 2>&1 &
 
       - name: Checkout Dojo repository
         uses: actions/checkout@v3
@@ -255,11 +253,7 @@ jobs:
           ref: v1.7.0-alpha.0
           path: dojo
 
-      - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "nightly-2025-05-08"
-
-      - name: Build and migrate `spawn-and=move` project
+      - name: Build and migrate `spawn-and-move` project
         run: |
           cd dojo
           cargo install --path bin/sozo --locked --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,6 +255,10 @@ jobs:
           ref: v1.7.0-alpha.0
           path: dojo
 
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.11.4"
+
       - name: Build and migrate `spawn-and=move` project
         run: |
           cd dojo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,7 @@ jobs:
           cd dojo
           cargo install --path bin/sozo --locked --force
 
-          cd dojo/examples/spawn-and-move
+          cd examples/spawn-and-move
           sozo build && sozo migrate
 
       - name: Output Katana logs on failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,7 +257,7 @@ jobs:
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.11.4"
+          scarb-version: "nightly-2025-05-08"
 
       - name: Build and migrate `spawn-and=move` project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,10 +234,6 @@ jobs:
           key: ci-${{ github.job }}
           shared-key: katana-ci-cache
 
-      - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "nightly-2025-05-08"
-
       - name: Download test artifacts
         uses: actions/download-artifact@v5
         with:
@@ -252,6 +248,10 @@ jobs:
           repository: dojoengine/dojo
           ref: v1.7.0-alpha.1
           path: dojo
+
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "nightly-2025-05-08"
 
       - name: Build and migrate `spawn-and-move` project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dojoengine/dojo
-          ref: v1.7.0-alpha.0
+          ref: v1.7.0-alpha.1
           path: dojo
 
       - name: Build and migrate `spawn-and-move` project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,6 +216,56 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
       - run: cargo run -p reverse-proxy-test
 
+  dojo-integration-test:
+    needs: [fmt, clippy]
+    runs-on: ubuntu-latest-32-cores
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    container:
+      image: ghcr.io/dojoengine/katana-dev:rpc090rc2
+    env:
+      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
+      NEXTEST_PROFILE: ci
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      # Workaround for https://github.com/actions/runner-images/issues/6775
+      - run: git config --global --add safe.directory "*"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-${{ github.job }}
+          shared-key: katana-ci-cache
+
+      - name: Restore test artifacts
+        uses: actions/cache@v3
+        with:
+          path: ./crates/contracts/build
+          key: test-artifacts
+
+      - name: Start Katana
+        run: cargo run --bin katana > katana.log 2>&1 &
+
+      - name: Checkout Dojo repository
+        uses: actions/checkout@v3
+        with:
+          repository: dojoengine/dojo
+          ref: v1.7.0-alpha.0
+          path: dojo
+
+      - name: Build and migrate `spawn-and=move` project
+        run: |
+          cd examples/spawn-and-move
+          sozo build && sozo migrate
+
+      - name: Output Katana logs on failure
+        if: failure()
+        run: |
+          echo "=== Last 50 lines of Katana logs ==="
+          tail -n 50 katana.log
+
   # db-compatibility-check:
   #   needs: [fmt, clippy]
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,7 +246,9 @@ jobs:
           key: test-artifacts
 
       - name: Start Katana
-        run: cargo run --bin katana > katana.log 2>&1 &
+        run: |
+          cargo run --bin katana
+          katana > katana.log 2>&1 &
 
       - name: Checkout Dojo repository
         uses: actions/checkout@v3
@@ -257,7 +259,10 @@ jobs:
 
       - name: Build and migrate `spawn-and=move` project
         run: |
-          cd examples/spawn-and-move
+          cd dojo
+          cargo install --path bin/sozo --locked --force
+
+          cd dojo/examples/spawn-and-move
           sozo build && sozo migrate
 
       - name: Output Katana logs on failure


### PR DESCRIPTION
Add Dojo integration in the CI. As Katana now supports only RPC 0.9.0, we're running the migration against Dojo tag `v1.7.0-alpha.0` as this is the first Dojo version that support RPC 0.9.0.