### PR TITLE
refactor(contracts): run build script on empty dir

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -36,8 +36,22 @@ fn main() {
         .expect("Failed to execute scarb build");
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        panic!("Contract compilation failed:\n{}", stderr);
+        let logs = String::from_utf8_lossy(&output.stdout);
+        let last_n_lines = logs
+            .split('\n')
+            .rev()
+            .take(50)
+            .collect::<Vec<&str>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<&str>>()
+            .join("\n");
+
+        panic!(
+            "Contract compilation build script failed. Below are the last 50 lines of `scarb \
+             build` output:\n\n{}",
+            last_n_lines
+        );
     }
 
     // Create build directory if it doesn't exist


### PR DESCRIPTION
Switch the contracts build target from depending on a directory node to depending on the full set of files under `$(CONTRACTS_DIR)`. This fixes missed rebuilds caused by directory `mtimes` not reflecting changes in nested files.

GNU Make decides whether to run a rule by comparing the target’s `mtime` with its prerequisites. The previous rule:

```Makefile
$(CONTRACTS_BUILD_DIR): $(CONTRACTS_DIR)
```

used the **directory mtime** as a proxy for changes. Directory `mtimes` often don’t update when you edit files deeper in the tree, so Make could skip necessary rebuilds.

By having `$(shell find $(CONTRACTS_DIR) -type f)` as the prerequisite, we capture all files at any depth and the target now rebuilds when any of the captured files is added/removed/modified.
