### PR TITLE
feat(dockerfile): remove Katana binary from CI runner image

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -110,17 +110,3 @@ RUN chown -R root:root /usr/local/cargo && chmod -R 700 /usr/local/cargo
 ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
 ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
 ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
-
-# ===== Dependency Builder Stage =====
-# This stage builds only Rust dependencies, separate from source code
-FROM external-tools as builder
-
-WORKDIR /katana
-COPY . .
-
-# Build katana
-RUN cargo install --path bin/katana --features native --locked
-# Verify the binary works
-RUN katana --version
-
-CMD ["katana"]

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -12,9 +12,6 @@ on:
       - main
     paths:
       - ".github/Dockerfile"
-  # run when a stable or pre-releases publish: <https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release>
-  release:
-    types: [published]
 
 env:
   RUST_VERSION: 1.86.0
@@ -27,7 +24,6 @@ jobs:
   # | Trigger            | Docker Tag                |
   # |--------------------|---------------------------|
   # | push               | Short SHA (first 7 chars) |
-  # | release            | GitHub release tag        |
   # | workflow_dispatch  | User-provided input       |
   # |--------------------|---------------------------|
   #
@@ -48,8 +44,6 @@ jobs:
           if [ "${{ github.event_name }}" == "push" ]; then
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c 1-7)
             echo "tag_name=$SHORT_SHA" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "release" ]; then
-            echo "tag_name=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "tag_name=${{ inputs.docker_tag }}" >> $GITHUB_OUTPUT
           fi
@@ -78,7 +72,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch' }}
+          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
           file: .github/Dockerfile
           tags: ghcr.io/${{ github.repository }}-dev:${{ needs.setup.outputs.tag_name }}-amd64,ghcr.io/${{ github.repository }}-dev:latest-amd64
           build-args: |
@@ -111,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch' }}
+          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
           file: .github/Dockerfile
           tags: ghcr.io/${{ github.repository }}-dev:${{ needs.setup.outputs.tag_name }}-arm64,ghcr.io/${{ github.repository }}-dev:latest-arm64
           build-args: |


### PR DESCRIPTION
Related #229 and will invalidate the recently merged #230. 

Since #229, now we are building the Katana binary as part of the [`test.yml`](https://github.com/dojoengine/katana/blob/8b3189b30884b528467c18cebcb4f43522fd6f80/.github/workflows/test.yml#L83) workflow. This ensures that we always have the latest version of the Katana binary that reflect the latest changes made when running tests.

The consequence of #229 is that is makes the binary in the `katana-dev` image redundant as it is no longer used anywhere in the CI. So, we can safely remove it to prevent possible conflict.

