### PR TITLE
test(reverse-proxy): run Katana and Caddy as separate processes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,7 +267,9 @@ jobs:
           name: binary
 
       - name: Run Katana
-        run: ./katana --http.port 6060 --explorer > katana.log 2>&1 &
+        run: |
+          chmod +x ./katana
+          ./katana --http.port 6060 --explorer > katana.log 2>&1 &
 
       - name: Run Reverse Proxy (Caddy)
         run: caddy run --config ./tests/fixtures/Caddyfile > caddy.log 2>&1 &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,28 +266,12 @@ jobs:
         with:
           name: binary
 
-      - name: Run Katana
+      - name: Setup Katana binary
+        run: chmod +x ./katana
+
+      - name: Run reverse proxy test
         run: |
-          chmod +x ./katana
-          ./katana --http.port 6060 --explorer > katana.log 2>&1 &
-
-      - name: Run Reverse Proxy (Caddy)
-        run: caddy run --config ./tests/fixtures/Caddyfile > caddy.log 2>&1 &
-
-      - uses: browser-actions/setup-chrome@v1
-      - run: cargo run -p reverse-proxy-test
-
-      - name: Output Katana logs on failure
-        if: failure()
-        run: |
-          echo "=== Last 50 lines of Katana logs ==="
-          tail -n 50 katana.log
-
-      - name: Output Caddy logs on failure
-        if: failure()
-        run: |
-          echo "=== Last 50 lines of Caddy logs ==="
-          tail -n 50 caddy.log
+          KATANA_BIN=./katana ./scripts/reverse-proxy-test.sh
 
   dojo-integration-test:
     needs: [fmt, clippy]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,7 +267,7 @@ jobs:
           name: binary
 
       - name: Run Katana
-        run: katana --http.port 6060 --explorer > katana.log 2>&1 &
+        run: ./katana --http.port 6060 --explorer > katana.log 2>&1 &
 
       - name: Run Reverse Proxy (Caddy)
         run: caddy run --config ./tests/fixtures/Caddyfile > caddy.log 2>&1 &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,7 +245,7 @@ jobs:
           cargo run -p snos-integration-test
 
   explorer-reverse-proxy:
-    needs: [fmt, clippy]
+    needs: [fmt, clippy, build-katana-binary]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
@@ -261,10 +261,16 @@ jobs:
           key: ci-${{ github.job }}
           shared-key: katana-ci-cache
 
-      - name: Download test artifacts
+      - name: Download Katana binary
         uses: actions/download-artifact@v5
         with:
-          name: test-artifacts
+          name: binary
+
+      - name: Run Katana
+        run: katana --http.port 6060 --explorer > katana.log 2>&1 &
+
+      - name: Run Reverse Proxy (Caddy)
+        run: caddy run --config ./tests/fixtures/Caddyfile > caddy.log 2>&1 &
 
       - uses: browser-actions/setup-chrome@v1
       - run: cargo run -p reverse-proxy-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,6 +275,18 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
       - run: cargo run -p reverse-proxy-test
 
+      - name: Output Katana logs on failure
+        if: failure()
+        run: |
+          echo "=== Last 50 lines of Katana logs ==="
+          tail -n 50 katana.log
+
+      - name: Output Caddy logs on failure
+        if: failure()
+        run: |
+          echo "=== Last 50 lines of Caddy logs ==="
+          tail -n 50 caddy.log
+
   dojo-integration-test:
     needs: [fmt, clippy]
     runs-on: ubuntu-latest-32-cores

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,6 +269,9 @@ jobs:
       - name: Setup Katana binary
         run: chmod +x ./katana
 
+      # chrome executable required by puppeteer
+      - uses: browser-actions/setup-chrome@v1
+
       - name: Run reverse proxy test
         run: |
           KATANA_BIN=./katana ./scripts/reverse-proxy-test.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9028,7 +9028,6 @@ version = "1.7.0-alpha.2"
 dependencies = [
  "anyhow",
  "headless_chrome",
- "katana-utils",
  "nix 0.30.1",
  "reqwest 0.12.22",
  "tokio",

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -15,7 +15,6 @@ http.workspace = true
 http-body.workspace = true
 hyper.workspace = true
 jsonrpsee = { workspace = true, features = [ "server-core" ], optional = true }
-rust-embed = "6.8.1"
 tiny_http = "0.12"
 tokio = { workspace = true, features = [ "full" ] }
 tower.workspace = true
@@ -23,6 +22,11 @@ tower-http = { workspace = true, features = [ "cors" ] }
 tracing.workspace = true
 url.workspace = true
 urlencoding = "2.1.2"
+
+# If the `debug-embed` is not enabled, the assets are not embedded in the binary when the crate is
+# build in debug mode. We want to make sure the assets are embedded in both debug and release mode
+# to ensure consistent behaviour.
+rust-embed = { version = "6.8.1", features = [ "debug-embed" ] }
 
 [dev-dependencies]
 katana-runner.workspace = true

--- a/scripts/reverse-proxy-test.sh
+++ b/scripts/reverse-proxy-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# This script is for running a test to make sure the `/explorer` endpoint can still be accessible
+# as normal when Katana is put behind a reverse proxy.
+#
+# This script is meant to be run at the repo's root directory
+
+set -e
+
+# Use environment variables for binary paths, or default to bare commands
+
+KATANA_BIN="${KATANA_BIN:-katana}"
+CADDY_BIN="${CADDY_BIN:-caddy}"
+
+# Cleanup background processes
+cleanup() {
+	echo "Cleaning up processes..."
+	if [ ! -z "$KATANA_PID" ]; then
+		kill $KATANA_PID 2>/dev/null || true
+	fi
+	if [ ! -z "$CADDY_PID" ]; then
+		kill $CADDY_PID 2>/dev/null || true
+	fi
+}
+
+# Wait for a service to be ready
+#
+# Arguments:
+#   $1 - service_name: The name of the service to wait for
+#   $2 - url: The health check URL of the service to check for service availability
+wait_for_service() {
+	local service_name=$1
+	local url=$2
+
+	for i in {1..30}; do
+		if curl -s -o /dev/null -w "%{http_code}" "$url" | grep -q "200"; then
+			echo "${service_name} is running at ${url}"
+			return 0
+		fi
+
+		if [ $i -eq 30 ]; then
+			echo "Failed to start ${service_name}"
+			exit 1
+		fi
+
+		sleep 1
+	done
+}
+
+# Perofrm background processes cleanup on exit
+trap cleanup EXIT
+
+${KATANA_BIN} --http.port 6060 --explorer > katana.log 2>&1 &
+KATANA_PID=$!
+echo "Katana starting at port 6060..."
+wait_for_service "Katana" "http://localhost:6060/"
+
+${CADDY_BIN} run --config ./tests/fixtures/Caddyfile > caddy.log 2>&1 &
+CADDY_PID=$!
+echo "Caddy starting at port 9090..."
+wait_for_service "Caddy" "https://localhost:9090/health-check"
+
+if ! cargo run -p reverse-proxy-test; then
+	echo
+	echo -e "\033[31mtest failed\033[0m"
+	echo
+	echo "=== Last 50 lines of katana.log ==="
+	echo
+	tail -n 50 katana.log
+	echo
+	echo "=== Last 50 lines of caddy.log ==="
+	echo
+	tail -n 50 caddy.log
+	exit 1
+fi

--- a/tests/reverse-proxy/Cargo.toml
+++ b/tests/reverse-proxy/Cargo.toml
@@ -6,8 +6,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-katana-utils.workspace = true
-
 anyhow.workspace = true
 headless_chrome = { version = "1.0.17", features = [ "fetch", "rustls" ] }
 nix = { version = "0.30.0", features = [ "user" ] }


### PR DESCRIPTION
The reverse-proxy test doesn't run Katana in a way that is only possible programmatically. We can use the binary created in the test workflow (#229) for running Katana instead of using the programmatic API. This will speed up the compilation process as we don't need to compile any of the Katana crates. The Caddy process has also been separated to allow `reverse-proxy-test` crate to focus solely on the testing logic.

We may need to write a script that encapsulates everything so as to avoid needing to run Katana and Caddy manually.