### PR TITLE
fix(ci): parse negative diff as actual number

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "0 9 * * 1" # Run every Monday at 9:00 AM UTC
   workflow_dispatch: # Allow manual triggering
+  pull_request:
+    paths:
+      [
+        ".github/workflows/weekly-report.yml",
+        "scripts/generate-binary-size-report.sh",
+      ]
 
 jobs:
   current-main-size:

--- a/scripts/generate-binary-size-report.sh
+++ b/scripts/generate-binary-size-report.sh
@@ -47,6 +47,16 @@ fi
 # Generate the report date
 REPORT_DATE=$(date -u +"%Y-%m-%d")
 
+# Convert absolute diff to human-readable (handle negative values)
+if [ "$DIFF_BYTES" -lt 0 ]; then
+  DIFF_BYTES_ABS=$(( -DIFF_BYTES ))
+  DIFF_HUMAN="-$(numfmt --to=iec-i --suffix=B --format="%.2f" "$DIFF_BYTES_ABS")"
+elif [ "$DIFF_BYTES" -gt 0 ]; then
+  DIFF_HUMAN="+$(numfmt --to=iec-i --suffix=B --format="%.2f" "$DIFF_BYTES")"
+else
+  DIFF_HUMAN="0B"
+fi
+
 # Output the markdown report
 cat << EOF
 # 📊 Weekly Binary Size Report - $REPORT_DATE
@@ -62,11 +72,11 @@ The Katana binary size has **$TREND_DESC** by **$DIFF_PERCENT%** since the last 
 | Main [(\`main\`)](https://github.com/dojoengine/katana/commit/$MAIN_COMMIT) | $MAIN_SIZE_HUMAN | $CHANGE_TEXT |
 
 ## Details
-- **Absolute Change:** $(if [ "$DIFF_BYTES" -gt 0 ]; then echo "+"; fi)$(numfmt --to=iec-i --suffix=B --format="%.2f" "$DIFF_BYTES")
+- **Absolute Change:** $DIFF_HUMAN
 - **Relative Change:** $DIFF_PERCENT%
 
 $WARNING
 
 ---
-*This report is automatically generated weekly to track binary size changes over time.*
+*This is an automated report.*
 EOF

--- a/scripts/generate-binary-size-report.sh
+++ b/scripts/generate-binary-size-report.sh
@@ -62,14 +62,14 @@ cat << EOF
 # 📊 Weekly Binary Size Report - $REPORT_DATE
 
 ## Summary
-The Katana binary size has **$TREND_DESC** by **$DIFF_PERCENT%** since the last release (\`$RELEASE_TAG\`).
+The Katana binary size has **$TREND_DESC** by **$DIFF_PERCENT%** since the last release ($RELEASE_TAG).
 
 ## Binary Size Comparison
 
 | Version | Size | Change |
 |---------|------|--------|
-| Release [(\`$RELEASE_TAG\`)](https://github.com/dojoengine/katana/releases/tag/$RELEASE_TAG) | $RELEASE_SIZE_HUMAN | - |
-| Main [(\`main\`)](https://github.com/dojoengine/katana/commit/$MAIN_COMMIT) | $MAIN_SIZE_HUMAN | $CHANGE_TEXT |
+| Release [($RELEASE_TAG)](https://github.com/dojoengine/katana/releases/tag/$RELEASE_TAG) | $RELEASE_SIZE_HUMAN | - |
+| Main [(main)](https://github.com/dojoengine/katana/commit/$MAIN_COMMIT) | $MAIN_SIZE_HUMAN | $CHANGE_TEXT |
 
 ## Details
 - **Absolute Change:** $DIFF_HUMAN


### PR DESCRIPTION
The recent [run](https://github.com/dojoengine/katana/actions/runs/17036058223/job/48290410996#step:6:) of the workflow has been failing at the report generation step with this error `numfmt: invalid option -- '4'` which originated from the `generate-binary-size-report.sh` script itself. The invalid option is caused by the command mistakenly parsing a number with the negative sign (-) as a CLI option. This PR fixes that by handling negative numbers appropriately.