### PR TITLE
feat(init): upgrade Cartridge provider to v0.9

### DIFF
--- a/bin/katana/src/cli/init/settlement.rs
+++ b/bin/katana/src/cli/init/settlement.rs
@@ -20,8 +20,8 @@ const ATLANTIC_FACT_REGISTRY_MAINNET: Felt =
 const ATLANTIC_FACT_REGISTRY_SEPOLIA: Felt =
     felt!("0x4ce7851f00b6c3289674841fd7a1b96b6fd41ed1edc248faccd672c26371b8c");
 
-const CARTRIDGE_SN_MAINNET_PROVIDER: &str = "https://api.cartridge.gg/x/starknet/mainnet";
-const CARTRIDGE_SN_SEPOLIA_PROVIDER: &str = "https://api.cartridge.gg/x/starknet/sepolia";
+const CARTRIDGE_SN_MAINNET_PROVIDER: &str = "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9";
+const CARTRIDGE_SN_SEPOLIA_PROVIDER: &str = "https://api.cartridge.gg/x/starknet/sepolia/rpc/v0_9";
 
 #[derive(Debug, Clone)]
 pub struct SettlementChainProvider {


### PR DESCRIPTION
related #210 

We have to include the `rpc/v0_9` suffix on the RPC URL because the default RPC version exposed by Cartrigde-hosted nodes are still on 0.8. As of the time of writing, mainnet is still on RPC 0.8 hence whey Cartridge provider is still on that version. 