### PR TITLE
fix(rpc): return the expected error types 

### DIFF
--- a/crates/executor/src/implementation/blockifier/cache.rs
+++ b/crates/executor/src/implementation/blockifier/cache.rs
@@ -216,8 +216,8 @@ impl ClassCache {
     ///
     /// This method will return an error if the global cache has not been initialized via
     /// [`ClassCacheBuilder::build_global`] first.
-    pub fn try_global() -> Result<&'static ClassCache, Error> {
-        COMPILED_CLASS_CACHE.get().ok_or(Error::NotInitialized)
+    pub fn try_global() -> Result<ClassCache, Error> {
+        COMPILED_CLASS_CACHE.get().cloned().ok_or(Error::NotInitialized)
     }
 
     /// Returns a reference to the global cache instance.
@@ -225,8 +225,8 @@ impl ClassCache {
     /// # Panics
     ///
     /// Panics if the global cache has not been initialized.
-    pub fn global() -> &'static ClassCache {
-        Self::try_global().expect("global class cache not initialized")
+    pub fn global() -> ClassCache {
+        Self::try_global().expect("global class cache not initialized").clone()
     }
 
     pub fn get(&self, hash: &ClassHash) -> Option<RunnableCompiledClass> {

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -141,12 +141,8 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
             let cfg_env = this.inner.backend.executor_factory.cfg().clone();
             let max_call_gas = this.inner.config.max_call_gas.unwrap_or(1_000_000_000);
 
-            match super::blockifier::call(state, env, cfg_env, request, max_call_gas) {
-                Ok(retdata) => Ok(retdata),
-                Err(err) => Err(ErrorObjectOwned::from(StarknetApiError::ContractError {
-                    revert_error: err.to_string(),
-                })),
-            }
+            let result = super::blockifier::call(state, env, cfg_env, request, max_call_gas)?;
+            Ok(result)
         })
         .await
     }


### PR DESCRIPTION
Currently, the request for contract call execution via the `starknet_call` RPC method is handled by the [`call`] utility function. The function returns a `Result` where the error type is [`ExecutionError`] which gets opaquely converted to `StarknetApiError::ContractError` on the RPC side:

https://github.com/dojoengine/katana/blob/1b50ea8078185ad456fba80678919dcbf7712e06/crates/rpc/rpc/src/starknet/read.rs#L144-L149 

Mapping the error entirely as a contract error is not the right behaviour and doesn't follow the expected error types for the `starknet_call` RPC method as defined by the [`spec`].

[`call`]: https://github.com/dojoengine/katana/blob/1b50ea8078185ad456fba80678919dcbf7712e06/crates/rpc/rpc/src/starknet/blockifier.rs#L98-L118
[`ExecutionError`]: https://github.com/dojoengine/katana/blob/1b50ea8078185ad456fba80678919dcbf7712e06/crates/executor/src/error.rs#L15-L18
[`spec`]: https://github.com/starkware-libs/starknet-specs/blob/c2e93098b9c2ca0423b7f4d15b201f52f22d8c36/api/starknet_api_openrpc.json#L605-L619