### PR TITLE
feat(tracing): format timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6672,6 +6672,7 @@ version = "1.7.0-alpha.2"
 dependencies = [
  "anyhow",
  "bytes",
+ "chrono",
  "clap",
  "http 1.3.1",
  "http-body-util",
@@ -11628,6 +11629,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term 0.46.0",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,9 @@ syn = { version = "2.0", default-features = false }
 log = "0.4.21"
 tracing = { version = "0.1.38", features = [ "log" ], default-features = false }
 tracing-log = "0.1.3"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "json", "tracing-log" ] }
+tracing-opentelemetry = "0.31.0"
+tracing-subscriber = "0.3.16"
+
 # opentelemetry
 opentelemetry = { version = "0.30.0", features = [ "trace" ] }
 opentelemetry-gcloud-trace = "0.20"

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -11,8 +11,7 @@ serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-log.workspace = true
-tracing-opentelemetry = "0.31.0"
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = [ "chrono", "env-filter", "json", "time", "tracing-log" ] }
 
 # OpenTelemetry dependencies for trace context propagation
 anyhow.workspace = true
@@ -25,6 +24,8 @@ opentelemetry-stackdriver.workspace = true
 opentelemetry_sdk = "0.30.0"
 rustls.workspace = true
 tower-http = { workspace = true, features = [ "trace" ] }
+tracing-opentelemetry.workspace = true
 
 bytes.workspace = true
+chrono.workspace = true
 http-body-util = "0.1.3"

--- a/crates/tracing/src/fmt.rs
+++ b/crates/tracing/src/fmt.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time::{self};
 
 /// Format for logging output.
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize, Default)]
@@ -31,5 +33,36 @@ impl clap::ValueEnum for LogFormat {
             Self::Json => Some(clap::builder::PossibleValue::new("json")),
             Self::Full => Some(clap::builder::PossibleValue::new("full")),
         }
+    }
+}
+
+const DEFAULT_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f %Z";
+
+/// Default formatter for span and event timestamps.
+///
+/// Formats timestamps in local time with the following format:
+///
+/// ```console
+/// %Y-%m-%d %H:%M:%S%.3f %Z
+/// ```
+///
+/// Example output
+///
+/// ```console
+/// 2025-08-24 20:49:32.487 -04:00
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct LocalTime;
+
+impl LocalTime {
+    pub fn new() -> Self {
+        LocalTime
+    }
+}
+
+impl time::FormatTime for LocalTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        let time = chrono::Local::now();
+        write!(w, "{}", time.format(DEFAULT_TIMESTAMP_FORMAT))
     }
 }

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -11,6 +11,8 @@ pub mod otlp;
 
 pub use fmt::LogFormat;
 
+use crate::fmt::LocalTime;
+
 #[derive(Debug, Clone)]
 pub enum TracerConfig {
     Otlp(otlp::OtlpConfig),
@@ -65,15 +67,23 @@ pub async fn init(format: LogFormat, telemetry_config: Option<TracerConfig>) -> 
         };
 
         let fmt = match format {
-            LogFormat::Full => tracing_subscriber::fmt::layer().boxed(),
-            LogFormat::Json => tracing_subscriber::fmt::layer().json().boxed(),
+            LogFormat::Full => {
+                tracing_subscriber::fmt::layer().with_timer(LocalTime::new()).boxed()
+            }
+            LogFormat::Json => {
+                tracing_subscriber::fmt::layer().json().with_timer(LocalTime::new()).boxed()
+            }
         };
 
         tracing_subscriber::registry().with(filter).with(telemetry).with(fmt).init();
     } else {
         let fmt = match format {
-            LogFormat::Full => tracing_subscriber::fmt::layer().boxed(),
-            LogFormat::Json => tracing_subscriber::fmt::layer().json().boxed(),
+            LogFormat::Full => {
+                tracing_subscriber::fmt::layer().with_timer(LocalTime::new()).boxed()
+            }
+            LogFormat::Json => {
+                tracing_subscriber::fmt::layer().json().with_timer(LocalTime::new()).boxed()
+            }
         };
 
         tracing_subscriber::registry().with(filter).with(fmt).init();


### PR DESCRIPTION
Update the log timestamp format to be more readable. The new format is applied to both Full and JSON log formatting. 

This is what the new format looks like:

```
2025-08-24 21:11:48.403 -04:00  INFO rpc: RPC server started. addr=127.0.0.1:5050
```

And this is the before:

```
2025-08-25T00:12:12.654937Z  INFO rpc: RPC server started. addr=127.0.0.1:5050
```

