### PR TITLE
feat: bump `blockifier` to `0.15.0-rc.3`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,42 +207,42 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
 
-  snos-integration-test:
-    needs: [fmt, clippy]
-    runs-on: ubuntu-latest-32-cores
-    timeout-minutes: 30
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-    container:
-      image: ghcr.io/dojoengine/katana-dev:latest
-    env:
-      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
-      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
-      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      # Workaround for https://github.com/actions/runner-images/issues/6775
-      - run: git config --global --add safe.directory "*"
+  # snos-integration-test:
+  #   needs: [fmt, clippy]
+  #   runs-on: ubuntu-latest-32-cores
+  #   timeout-minutes: 30
+  #   if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+  #   container:
+  #     image: ghcr.io/dojoengine/katana-dev:latest
+  #   env:
+  #     MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+  #     LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+  #     TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #     # Workaround for https://github.com/actions/runner-images/issues/6775
+  #     - run: git config --global --add safe.directory "*"
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ci-${{ github.job }}
-          shared-key: katana-ci-cache
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         key: ci-${{ github.job }}
+  #         shared-key: katana-ci-cache
 
-      - name: Download test artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: test-artifacts
+  #     - name: Download test artifacts
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         name: test-artifacts
 
-      - name: Prepare SNOS test environment
-        run: |
-          if [ ! -d "./tests/snos/snos/build" ]; then
-            make snos-artifacts
-          fi
+  #     - name: Prepare SNOS test environment
+  #       run: |
+  #         if [ ! -d "./tests/snos/snos/build" ]; then
+  #           make snos-artifacts
+  #         fi
 
-      - run: |
-          cargo run -p snos-integration-test
+  #     - run: |
+  #         cargo run -p snos-integration-test
 
   explorer-reverse-proxy:
     needs: [fmt, clippy, build-katana-binary]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,167 +849,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "apollo_config"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+name = "apollo_compilation_utils"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "clap",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_config"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "clap",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_metrics 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "async-trait",
- "hyper 0.14.32",
- "rstest 0.17.0",
- "serde",
- "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "tracing-subscriber",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_metrics 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "async-trait",
- "hyper 0.14.32",
- "rstest 0.17.0",
- "serde",
- "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "tracing-subscriber",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "assert-json-diff",
- "cached",
- "colored 3.0.0",
- "serde",
- "serde_json",
- "socket2 0.5.10",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "apollo_infra_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "assert-json-diff",
- "cached",
- "colored 3.0.0",
- "serde",
- "serde_json",
- "socket2 0.5.10",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "apollo_metrics"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "indexmap 2.10.0",
- "metrics 0.24.2",
- "num-traits",
- "paste",
- "regex",
-]
-
-[[package]]
-name = "apollo_metrics"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "indexmap 2.10.0",
- "metrics 0.24.2",
- "num-traits",
- "paste",
- "regex",
-]
-
-[[package]]
-name = "apollo_proc_macros"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "apollo_proc_macros"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "apollo_sierra_multicompile"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_sierra_multicompile_types 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "async-trait",
+ "apollo_infra_utils",
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
@@ -1017,64 +861,91 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "starknet_api",
  "tempfile",
  "thiserror 1.0.69",
- "tracing",
- "validator",
 ]
 
 [[package]]
-name = "apollo_sierra_multicompile"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
+name = "apollo_compile_to_native"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_sierra_multicompile_types 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "async-trait",
- "cairo-lang-sierra",
+ "apollo_compilation_utils",
+ "apollo_compile_to_native_types",
+ "apollo_infra_utils",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils",
  "cairo-native",
- "rlimit",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "tempfile",
- "thiserror 1.0.69",
- "tracing",
+]
+
+[[package]]
+name = "apollo_compile_to_native_types"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
+dependencies = [
+ "apollo_config",
+ "serde",
  "validator",
 ]
 
 [[package]]
-name = "apollo_sierra_multicompile_types"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+name = "apollo_config"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_proc_macros 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "async-trait",
+ "apollo_infra_utils",
+ "clap",
+ "const_format",
+ "itertools 0.12.1",
  "serde",
  "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "strum_macros 0.25.3",
  "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "validator",
 ]
 
 [[package]]
-name = "apollo_sierra_multicompile_types"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
+name = "apollo_infra_utils"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_proc_macros 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "async-trait",
+ "apollo_proc_macros",
+ "assert-json-diff",
+ "colored 3.0.0",
+ "num_enum",
  "serde",
  "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "socket2 0.5.10",
+ "tempfile",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "apollo_metrics"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
+dependencies = [
+ "indexmap 2.10.0",
+ "metrics 0.24.2",
+ "num-traits",
+ "paste",
+ "regex",
+]
+
+[[package]]
+name = "apollo_proc_macros"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1490,8 +1361,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.3",
- "zstd-safe 7.2.4",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1900,7 +1771,6 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
- "serde",
  "tap",
  "wyz",
 ]
@@ -1916,69 +1786,28 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
  "anyhow",
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_sierra_multicompile 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "apollo_compilation_utils",
+ "apollo_compile_to_native",
+ "apollo_compile_to_native_types",
+ "apollo_config",
+ "apollo_infra_utils",
+ "apollo_metrics",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-secp256k1 0.4.0",
  "ark-secp256r1 0.4.0",
- "blockifier_test_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cached",
- "cairo-lang-casm",
- "cairo-lang-runner",
- "cairo-lang-starknet-classes",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.99.20",
- "indexmap 2.10.0",
- "itertools 0.12.1",
- "keccak",
- "log",
- "mockall",
- "num-bigint",
- "num-integer",
- "num-rational",
- "num-traits",
- "paste",
- "phf",
- "rand 0.8.5",
- "rstest 0.17.0",
- "rstest_reuse 0.7.0",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "sha2",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "blockifier"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "anyhow",
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_sierra_multicompile 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-secp256k1 0.4.0",
- "ark-secp256r1 0.4.0",
- "blockifier_test_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "blockifier_test_utils",
  "cached",
  "cairo-lang-casm",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "cairo-native",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
+ "dashmap",
  "derive_more 0.99.20",
  "indexmap 2.10.0",
  "itertools 0.12.1",
@@ -1999,7 +1828,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -2007,38 +1836,16 @@ dependencies = [
 
 [[package]]
 name = "blockifier_test_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "apollo_infra_utils",
  "cairo-lang-starknet-classes",
- "itertools 0.12.1",
  "pretty_assertions",
  "rstest 0.17.0",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-test",
-]
-
-[[package]]
-name = "blockifier_test_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "cairo-lang-starknet-classes",
- "itertools 0.12.1",
- "pretty_assertions",
- "rstest 0.17.0",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tempfile",
@@ -2197,16 +2004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
 ]
 
 [[package]]
@@ -2379,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b3c953c0321df1d7ce9101c7a94e2d4007aa8c3362ee96be54bbe77916ef60"
+checksum = "88bf35a939eaed69b8a71405c5d56fa52c3b1c76701b8c1056fe22b3e2569c7d"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -2393,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cd5bec42d0c4e9f1ac6c373c177c98c73a760fabb4066757edd32ef9db467e"
+checksum = "c13c2341fb2272999f6152b0fc2238148fe93c745183a07acba031b27eeb0b66"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -2419,19 +2216,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea55d64b6e7aa9186bb65ca32f50f386d6518d467930e53fcf47658dec74a2e"
+checksum = "17cf782d64a29c4acb1eb2759c39783d5e92c397d5ae3775754edae5d2c665ee"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093146c748e95400230a40dc6171ac192399484addd96c6ac70ec36b0a2e45b0"
+checksum = "80a146574d443e7fba848c069d7d84879c4635df5811963a18bf042df3e34e61"
 dependencies = [
+ "bincode 1.3.3",
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -2440,14 +2238,16 @@ dependencies = [
  "cairo-lang-utils",
  "itertools 0.14.0",
  "rust-analyzer-salsa",
+ "serde",
  "smol_str",
+ "typetag",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c85890af7f0d0b6e0d15686e0a5169d3396e2861cb3adac3c594f82ae5ed42c"
+checksum = "cb704187b1543aa4a2e0030d13ae6e0ad63712e5362cac3ded3237623a2b1b32"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -2457,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a54937f1baca684547159af847ba5332ec8015de442878b8e4d6dbbaeec714c"
+checksum = "a5a2e6145241a4812820948278a86e11c25adc30e9a19b2e24b2517be19eedac"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -2467,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e07492644cfa43e50cfc334a80c12c9e4d8e2a4248b3d2240301c99a025010a"
+checksum = "3c903cdcae48aa02c0ed41e1fd54b3231da51f1edf9538327ed155463594b8be"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -2483,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26c988d6b522c45b5f70add3808fcae13c921822d1c48724c394b450adcf7f9"
+checksum = "a943f0818cfc091c3302acd92053ff2a642004d32757c3b4f94c5aa18e184ac0"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -2503,10 +2303,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90577e4dc391e2384041763120618ed2017a8f709f20dfcaa2c1246f908dd374"
+checksum = "7b86cd38af57c36b2a72a2483d04d8b17ea2f9a554fd45b9d83375773f948818"
 dependencies = [
+ "assert_matches",
  "bincode 1.3.3",
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -2525,14 +2326,13 @@ dependencies = [
  "num-traits",
  "rust-analyzer-salsa",
  "serde",
- "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b7985c0ee345ead0e0f713474ec6490e3fac80c3c3889ab9e67b1588d30337"
+checksum = "f64f0a5ca9ac54975cdec98fe8491d9b62922b7cb048e6ded00188383b841b25"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -2551,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697772ca0b096e36cb98cfc9b1231b115a15eebf8ac7295f7b50252f5a1e6aea"
+checksum = "6230c6d37e5e8361900709112e56b42e48478806b829a086727ef59b2f7f3310"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -2576,9 +2376,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a956924e4f53cb1b69a7cee4758f0bcf50e23bbb8769f632625956a574f736"
+checksum = "b1e4872352761cf6d7f47eeb1626e3b1d84a514017fb4251173148d8c04f36d5"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -2587,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088f29ca8d06722bd92001d098b619a25979dcbfa5face7a6de5d8c7232f0454"
+checksum = "2327b8c070f9e50ac85a410f03c6aaf6a0dffee5ba8299d6af4bf2344587ac42"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -2600,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b63a8fe2e8f2ae6280392bcc8ab98b981db75832b16c98974b81978d3d1b26"
+checksum = "775b064b0265e8408565b1ec9d360116015acf35753f02db255cbb13ad30670e"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -2611,16 +2411,16 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "itertools 0.14.0",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db16efd33b13cecb1ca5b843a65f1e8e3eab4e18abf0c39522b04d741e51e7"
+checksum = "e7166250692bda4b8b31f0480b8ba7fe75793b15bd4f0b6e5b5fe5d6dde01da8"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-secp256k1 0.5.0",
@@ -2633,7 +2433,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet",
  "cairo-lang-utils",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "itertools 0.14.0",
  "keccak",
  "num-bigint",
@@ -2648,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3d35463c096f1e3ab6830e28c762b22a7b5c3fbf0df5c2e9a265d290d22ee5"
+checksum = "f53a1ea47d1a0295179881d5578fc2b2c8cd5d2ac99bd81958c423d54960bb84"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -2675,14 +2475,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e02d4df410965f122b67967936b722352eddbfde550883b054e019dc54beeef"
+checksum = "a48fe249ba77fb39363b1b40c81556c8d272083508b4618fb65b964559aca0ee"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
  "const-fnv1a-hash",
- "convert_case 0.7.1",
+ "convert_case 0.8.0",
  "derivative",
  "itertools 0.14.0",
  "lalrpop",
@@ -2702,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0d3be06212edb4d79be1296cd999b246d22e1541b49432db74dca16fe0c523"
+checksum = "fad6cbf5cc904f4309179793fc3757c1db9615e71c1b78eff601d2e22206d1c6"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -2718,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7f246adb40ac69242231642cdf2571c83463068086a00b5ae9131f7dfc74b5"
+checksum = "704ec6a8cb1b38f78571d5561519e87672ed5008a018a422842fa2a122ca3c34"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -2734,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ca1fbf8d29528d5fdf6a7e3b2ccdd4f3e9b57066057c30f9bc2c3118867571"
+checksum = "2e011122028a59557ff075b22f550f7d0267b493f3db3dbefc281ff6795d108c"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -2758,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb42e872cff7d050d2348978e2f12a94b4b29aee6f5ba5a7eca76a5294c900"
+checksum = "6a43885fd8e806f5c50a80473798faad1a9a919f474e469d3027aece4f8b2002"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -2779,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8217d84f5434c36c68f54b5bbac9c91ff981a3738f2e6bc51b102f5beae3fd8"
+checksum = "860006ddce78cae65babf37ff279c31358336ae76717991837d7e0868561878c"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -2789,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70aca831fef1f41b29c5e62a464a8ddd7964ed2414d3dafb6e1530bff1ae3cbd"
+checksum = "4ba6eb0a421d3411f4948e002d3dd81ab134044465bda3131f2718f56afda409"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -2815,19 +2615,20 @@ dependencies = [
  "smol_str",
  "starknet-types-core",
  "thiserror 2.0.12",
+ "typetag",
 ]
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e9b59bb3d46e68730266b27e3f0ad524c076eebab1bcc9352256a8957d6b88"
+checksum = "2cf81db2c36c1e3fe3bbf64ebc5c237f748e9f41bdd42a6ed3e03e00086d768c"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-utils",
- "convert_case 0.7.1",
+ "convert_case 0.8.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-integer",
@@ -2842,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686aea0cd9730af809010a74c0a8583b3acb99a08e5f97a07ed205f37b9e75ae"
+checksum = "f36620fd45292fd0276bd581e774222fbd06e13aa8a4bf820a4be8ad3bcec100"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -2860,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.11.4"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c69eb6919b69a9a7bb92f79d73c568d09ef77efa0b5d265efb763234ec979d4"
+checksum = "f7c3560464f6e243259a20906b0e173c7600e59e459bbc3beb620cd656b037ae"
 dependencies = [
  "genco",
  "xshell",
@@ -2870,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a6f34df0f3929bf8166c5a6d143c22ad28fd73937cfb5d7a994d56ca4a86c4"
+checksum = "eb622d636da63a5cc8138dba941d9eb1918d06e297bdb5a76dc69fffdf3581d9"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -2897,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199eb0e7ac78ba7dfbf6551ab7eab14dd45fdcf21675fd5472ca695dc6da96f1"
+checksum = "4c65df2eee1678a29b4b9dcff5c10a70b44e38d445ba2522025b1b6b7177b61f"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -2910,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.11.2"
+version = "2.12.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e621368454b62603ae035d04864770a70952e6ca8341b78c1ac50a0088939e3f"
+checksum = "5f043065d60a8a2510bfacb6c91767298fed50ed9abbd69ff7698322b7cb1e65"
 dependencies = [
  "hashbrown 0.15.4",
  "indexmap 2.10.0",
@@ -2922,13 +2723,14 @@ dependencies = [
  "parity-scale-codec",
  "schemars 0.8.22",
  "serde",
+ "smol_str",
 ]
 
 [[package]]
 name = "cairo-native"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67542e31b00b8f015088c06b04095aaed96b3e35b50d396289390e9fb9c9a778"
+checksum = "4d714224a1280776d90422e631790c0138d138a80b8e16231829dacea13c8289"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2981,28 +2783,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cairo-type-derive"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "cairo-vm"
-version = "1.0.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa8b4b56ee66cebcade4d85128e55b2bfdf046502187aeaa8c2768a427684dc"
+checksum = "2afc2bb5cf948599994a1f1634edc81934c3952e2f32c8e49efbde63d767fa69"
 dependencies = [
  "anyhow",
  "arbitrary",
  "bincode 2.0.1",
  "bitvec",
  "generic-array",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
  "hex",
+ "indoc",
  "keccak",
  "lazy_static",
  "nom",
@@ -3016,45 +2809,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "starknet-crypto 0.6.2",
+ "starknet-crypto 0.7.4",
  "starknet-types-core",
- "thiserror-no-std",
- "zip 0.6.6",
-]
-
-[[package]]
-name = "cairo-vm"
-version = "1.0.2"
-source = "git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell#0881dafa5440b304fb000578b6f17c0a6e5f0595"
-dependencies = [
- "anyhow",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bincode 2.0.1",
- "bitvec",
- "cairo-lang-casm",
- "cairo-lang-starknet",
- "cairo-lang-starknet-classes",
- "generic-array",
- "hashbrown 0.14.5",
- "hex",
- "keccak",
- "lazy_static",
- "nom",
- "num-bigint",
- "num-integer",
- "num-prime",
- "num-traits",
- "rand 0.8.5",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha2",
- "sha3",
- "starknet-crypto 0.6.2",
- "starknet-types-core",
- "thiserror-no-std",
- "wasm-bindgen",
+ "thiserror 2.0.12",
  "zip 0.6.6",
 ]
 
@@ -3428,12 +3185,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -4026,18 +3777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "dummy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac124e13ae9aa56acc4241f8c8207501d93afdd8d8e62f0c1f2e12f6508c65"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,39 +3925,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -4277,18 +4003,6 @@ dependencies = [
  "impl-serde",
  "primitive-types",
  "uint",
-]
-
-[[package]]
-name = "fake"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
-dependencies = [
- "deunicode",
- "dummy",
- "rand 0.8.5",
- "serde_json",
 ]
 
 [[package]]
@@ -4372,7 +4086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -4910,7 +4623,6 @@ dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
  "rayon",
- "serde",
 ]
 
 [[package]]
@@ -5508,7 +5220,7 @@ checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
- "portable-atomic 1.11.1",
+ "portable-atomic",
  "unicode-width 0.2.1",
  "web-time",
 ]
@@ -5570,6 +5282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5687,30 +5408,6 @@ checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
  "libc",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic 1.11.1",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -5996,7 +5693,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "vergen 9.0.6",
+ "vergen",
  "vergen-gitcl",
 ]
 
@@ -6160,7 +5857,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -6170,9 +5867,9 @@ dependencies = [
  "alloy-primitives 1.3.0",
  "anyhow",
  "assert_matches",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "blockifier",
  "cairo-native",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "criterion",
  "katana-chain-spec",
  "katana-contracts",
@@ -6191,7 +5888,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "starknet",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6431,10 +6128,10 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "base64 0.21.7",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "blockifier",
  "cainome-cairo-serde",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "criterion",
  "derive_more 0.99.20",
  "heapless",
@@ -6453,7 +6150,7 @@ dependencies = [
  "starknet",
  "starknet-crypto 0.7.4",
  "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -6583,7 +6280,7 @@ dependencies = [
  "serde_with",
  "similar-asserts",
  "starknet",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "thiserror 1.0.69",
 ]
 
@@ -6874,17 +6571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7077,23 +6763,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
-dependencies = [
- "ahash 0.7.8",
- "metrics-macros",
- "portable-atomic 0.3.20",
-]
-
-[[package]]
-name = "metrics"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
 dependencies = [
  "ahash 0.8.12",
- "portable-atomic 1.11.1",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -7103,7 +6778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
 dependencies = [
  "ahash 0.8.12",
- "portable-atomic 1.11.1",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -7137,17 +6812,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7311,7 +6975,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
- "portable-atomic 1.11.1",
+ "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
 ]
@@ -7522,6 +7186,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -7819,17 +7484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7842,65 +7496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
-name = "pathfinder-common"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "anyhow",
- "bitvec",
- "fake",
- "metrics 0.20.1",
- "num-bigint",
- "paste",
- "pathfinder-crypto",
- "primitive-types",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "tagged",
- "tagged-debug-derive",
- "thiserror 1.0.69",
- "vergen 8.3.2",
-]
-
-[[package]]
-name = "pathfinder-crypto"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "bitvec",
- "fake",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "pathfinder-serde"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "anyhow",
- "num-bigint",
- "pathfinder-common",
- "pathfinder-crypto",
- "primitive-types",
- "serde",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -8121,15 +7722,6 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
-dependencies = [
- "portable-atomic 1.11.1",
-]
-
-[[package]]
-name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
@@ -8140,7 +7732,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
- "portable-atomic 1.11.1",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -8499,39 +8091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost 0.14.1",
-]
-
-[[package]]
-name = "prove_block"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "anyhow",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cairo-lang-starknet-classes",
- "cairo-lang-utils",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "clap",
- "env_logger",
- "futures-core",
- "log",
- "num-bigint",
- "pathfinder-common",
- "pathfinder-crypto",
- "pathfinder-serde",
- "reqwest 0.11.27",
- "rpc-client",
- "rpc-replay",
- "serde",
- "serde_json",
- "serde_with",
- "starknet",
- "starknet-os",
- "starknet-os-types",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
@@ -8961,11 +8520,9 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -8974,7 +8531,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
@@ -9133,39 +8689,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rpc-client"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "log",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "starknet",
- "starknet-crypto 0.7.4",
- "starknet-os",
- "starknet-types-core",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rpc-replay"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cairo-lang-starknet-classes",
- "rpc-client",
- "serde",
- "serde_json",
- "starknet",
- "starknet-os-types",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "rsb_derive"
@@ -9993,19 +9516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.10.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10233,30 +9743,12 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
+ "borsh",
  "serde",
-]
-
-[[package]]
-name = "snos-integration-test"
-version = "1.7.0-alpha.2"
-dependencies = [
- "anyhow",
- "c-kzg",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "either",
- "katana-chain-spec",
- "katana-messaging",
- "katana-node",
- "katana-primitives",
- "katana-provider",
- "prove_block",
- "starknet",
- "starknet-os",
- "tokio",
 ]
 
 [[package]]
@@ -10526,28 +10018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-gateway-types"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "anyhow",
- "fake",
- "pathfinder-common",
- "pathfinder-crypto",
- "pathfinder-serde",
- "primitive-types",
- "rand 0.8.5",
- "reqwest 0.12.22",
- "rstest 0.18.2",
- "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "starknet-macros"
 version = "0.2.5-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10555,79 +10025,6 @@ checksum = "ed7b5b575473d4734c3b736735a2099cc14f66be26c6f9895c1a345f436012ed"
 dependencies = [
  "starknet-core",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "starknet-os"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "anyhow",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-secp256k1 0.4.0",
- "ark-secp256r1 0.4.0",
- "base64 0.21.7",
- "bitvec",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "c-kzg",
- "cairo-lang-casm",
- "cairo-lang-starknet",
- "cairo-lang-starknet-classes",
- "cairo-type-derive",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "futures",
- "futures-util",
- "heck 0.4.1",
- "hex",
- "indexmap 2.10.0",
- "indoc",
- "keccak",
- "lazy_static",
- "log",
- "num-bigint",
- "num-integer",
- "num-traits",
- "pathfinder-common",
- "pathfinder-crypto",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml",
- "sha2",
- "starknet-crypto 0.7.4",
- "starknet-gateway-types",
- "starknet-os-types",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
- "uuid 1.17.0",
- "zip 0.6.6",
-]
-
-[[package]]
-name = "starknet-os-types"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cairo-lang-starknet-classes",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "flate2",
- "num-bigint",
- "once_cell",
- "serde",
- "serde_json",
- "serde_with",
- "starknet",
- "starknet-crypto 0.7.4",
- "starknet-gateway-types",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
@@ -10688,15 +10085,16 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/dojoengine/sequencer?branch=blockifier%2Fv0.15.0-rc.3#b62241574f059534cb4d52d3dd6218ec07f84e2b"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "apollo_infra_utils",
  "base64 0.13.1",
  "bitvec",
  "cached",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
+ "cairo-lang-utils",
  "derive_more 0.99.20",
  "flate2",
  "hex",
@@ -10717,39 +10115,7 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet_api"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "base64 0.13.1",
- "bitvec",
- "cached",
- "cairo-lang-runner",
- "cairo-lang-starknet-classes",
- "derive_more 0.99.20",
- "flate2",
- "hex",
- "indexmap 2.10.0",
- "itertools 0.12.1",
- "num-bigint",
- "num-traits",
- "pretty_assertions",
- "primitive-types",
- "rand 0.8.5",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "sha3",
- "size-of",
- "starknet-crypto 0.7.4",
- "starknet-types-core",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]
@@ -10975,24 +10341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tagged"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "fake",
-]
-
-[[package]]
-name = "tagged-debug-derive"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11076,26 +10424,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
 ]
 
 [[package]]
@@ -11735,10 +11063,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typetag"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f22b40dd7bfe8c14230cf9702081366421890435b2d625fa92b4acc4c3de6f"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "u256-literal"
@@ -11845,12 +11203,6 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -11982,7 +11334,6 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
- "serde",
  "wasm-bindgen",
 ]
 
@@ -12032,24 +11383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "8.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
-dependencies = [
- "anyhow",
- "cfg-if",
- "rustversion",
- "time",
-]
-
-[[package]]
 name = "vergen"
 version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12076,7 +11409,7 @@ dependencies = [
  "derive_builder",
  "rustversion",
  "time",
- "vergen 9.0.6",
+ "vergen",
  "vergen-lib",
 ]
 
@@ -13108,18 +12441,10 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2 0.4.4",
- "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -13130,8 +12455,8 @@ checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
  "arbitrary",
- "bzip2 0.5.2",
- "constant_time_eq 0.3.1",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
@@ -13149,7 +12474,7 @@ dependencies = [
  "xz2",
  "zeroize",
  "zopfli",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -13166,30 +12491,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 	"crates/chain-spec",
 	"crates/cli",
 	"crates/contracts",
+	"crates/contracts/macro",
 	"crates/controller",
 	"crates/core",
 	"crates/executor",
@@ -39,7 +40,7 @@ members = [
 	"crates/utils",
 	"tests/db-compat",
 	"tests/reverse-proxy",
-	"tests/snos",
+	# "tests/snos",
 ]
 
 [workspace.package]
@@ -95,13 +96,13 @@ katana-trie = { path = "crates/trie" }
 katana-utils = { path = "crates/utils" }
 
 # cairo-lang
-cairo-lang-casm = "2.11.2"
-cairo-lang-runner = "2.11.2"
-cairo-lang-sierra = "2.11.2"
-cairo-lang-sierra-to-casm = "2.11.2"
-cairo-lang-starknet = "2.11.2"
-cairo-lang-starknet-classes = "2.11.2"
-cairo-lang-utils = "2.11.2"
+cairo-lang-casm = "2.12.0-dev.1"
+cairo-lang-runner = "2.12.0-dev.1"
+cairo-lang-sierra = "2.12.0-dev.1"
+cairo-lang-sierra-to-casm = "2.12.0-dev.1"
+cairo-lang-starknet = "2.12.0-dev.1"
+cairo-lang-starknet-classes = "2.12.0-dev.1"
+cairo-lang-utils = "2.12.0-dev.1"
 
 anyhow = "1.0.89"
 arbitrary = { version = "1.3.2", features = [ "derive" ] }
@@ -210,10 +211,11 @@ starknet-crypto = "0.7.4"
 starknet-types-core = { version = "0.1.8", features = [ "arbitrary", "hash" ] }
 # Some types that we used from cairo-vm implements the `Arbitrary` trait,
 # only under the `test_utils` feature.
-cairo-vm = { version = "1.0.2", features = [ "test_utils" ] }
+cairo-vm = { version = "2.3.1", features = [ "test_utils" ] }
 
-blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "5d737b9c9", default-features = false }
-starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "5d737b9c9" }
+blockifier = { git = "https://github.com/dojoengine/sequencer", branch = "blockifier/v0.15.0-rc.3", default-features = false }
+cairo-native = "0.6"
+starknet_api = { git = "https://github.com/dojoengine/sequencer", branch = "blockifier/v0.15.0-rc.3" }
 
 cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1", features = [ "abigen-rs" ] }
 cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1" }

--- a/crates/contracts/macro/Cargo.toml
+++ b/crates/contracts/macro/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 syn = { version = "2.0", features = [ "extra-traits", "full" ] }
 
 # Dependencies for contract class parsing and hash computation
-cairo-lang-starknet-classes = "2.11.2"
-katana-primitives = { path = "../../primitives" }
-starknet-crypto = "0.7.4"
-starknet-types-core = "0.1.8"
+cairo-lang-starknet-classes.workspace = true
+katana-primitives.workspace = true
+starknet-crypto.workspace = true
+starknet-types-core.workspace = true

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -18,7 +18,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 # cairo-native
-cairo-native = { version = "0.4.1", optional = true }
+cairo-native = { workspace = true, optional = true }
 cairo-vm.workspace = true
 parking_lot.workspace = true
 rayon = { workspace = true, optional = true }

--- a/crates/executor/src/implementation/blockifier/cache.rs
+++ b/crates/executor/src/implementation/blockifier/cache.rs
@@ -273,7 +273,7 @@ impl ClassCache {
                         let _span = span.enter();
 
                         let executor =
-                            AotContractExecutor::new(&program, &entry_points, version.into(), OptLevel::Default)
+                            AotContractExecutor::new(&program, &entry_points, version.into(), OptLevel::Default, None)
                                 .inspect_err(|error| tracing::error!(target: "class_cache", %error, "Failed to compile native class"))
                                 .unwrap();
 

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 // Re-export the blockifier crate.
 pub use blockifier;
 use blockifier::blockifier_versioned_constants::VersionedConstants;
-use blockifier::bouncer::{n_steps_to_sierra_gas, Bouncer, BouncerConfig, BouncerWeights};
+use blockifier::bouncer::{n_steps_to_gas, Bouncer, BouncerConfig, BouncerWeights, BuiltinWeights};
 
 pub mod cache;
 pub mod call;
@@ -132,9 +132,12 @@ impl<'a> StarknetVMProcessor<'a> {
         //
         // To learn more about the L2 gas, refer to <https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257>.
         block_max_capacity.sierra_gas =
-            n_steps_to_sierra_gas(limits.cairo_steps as usize, block_context.versioned_constants());
+            n_steps_to_gas(limits.cairo_steps as usize, block_context.versioned_constants());
 
-        let bouncer = Bouncer::new(BouncerConfig { block_max_capacity });
+        let bouncer = Bouncer::new(BouncerConfig {
+            block_max_capacity,
+            builtin_weights: BuiltinWeights::default(),
+        });
 
         Self {
             cfg_env,

--- a/crates/executor/src/implementation/blockifier/utils.rs
+++ b/crates/executor/src/implementation/blockifier/utils.rs
@@ -136,6 +136,7 @@ pub fn transact<S: StateReader>(
                     &tx_state,
                     &tx_state_changes_keys,
                     &info.summarize(versioned_constants),
+                    &info.summarize_builtins(),
                     &info.receipt.resources,
                     versioned_constants,
                 )?;
@@ -200,7 +201,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     tx: ApiInvokeTransaction::V0(starknet_api::transaction::InvokeTransactionV0 {
                         entry_point_selector: EntryPointSelector(tx.entry_point_selector),
                         contract_address: to_blk_address(tx.contract_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         calldata: Calldata(Arc::new(calldata)),
                         max_fee: Fee(tx.max_fee),
                     }),
@@ -222,7 +223,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         max_fee: Fee(tx.max_fee),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         calldata: Calldata(Arc::new(calldata)),
                     }),
                     tx_hash: TransactionHash(hash),
@@ -248,7 +249,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         tip: Tip(tx.tip),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         calldata: Calldata(Arc::new(calldata)),
                         paymaster_data: PaymasterData(paymaster_data),
                         account_deployment_data: AccountDeploymentData(account_deploy_data),
@@ -278,7 +279,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     tx: ApiDeployAccountTransaction::V1(DeployAccountTransactionV1 {
                         max_fee: Fee(tx.max_fee),
                         nonce: Nonce(tx.nonce),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         constructor_calldata: Calldata(Arc::new(calldata)),
                         contract_address_salt: salt,
@@ -306,7 +307,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     tx: ApiDeployAccountTransaction::V3(DeployAccountTransactionV3 {
                         tip: Tip(tx.tip),
                         nonce: Nonce(tx.nonce),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         constructor_calldata: Calldata(Arc::new(calldata)),
                         contract_address_salt: salt,
@@ -333,7 +334,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     max_fee: Fee(tx.max_fee),
                     nonce: Nonce::default(),
                     sender_address: to_blk_address(tx.sender_address),
-                    signature: TransactionSignature(tx.signature),
+                    signature: TransactionSignature(tx.signature.into()),
                     class_hash: ClassHash(tx.class_hash),
                 }),
 
@@ -341,7 +342,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     max_fee: Fee(tx.max_fee),
                     nonce: Nonce(tx.nonce),
                     sender_address: to_blk_address(tx.sender_address),
-                    signature: TransactionSignature(tx.signature),
+                    signature: TransactionSignature(tx.signature.into()),
                     class_hash: ClassHash(tx.class_hash),
                 }),
 
@@ -352,7 +353,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         max_fee: Fee(tx.max_fee),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         compiled_class_hash: CompiledClassHash(tx.compiled_class_hash),
                     })
@@ -371,7 +372,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         tip: Tip(tx.tip),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         account_deployment_data: AccountDeploymentData(account_deploy_data),
                         compiled_class_hash: CompiledClassHash(tx.compiled_class_hash),

--- a/crates/executor/src/utils.rs
+++ b/crates/executor/src/utils.rs
@@ -13,15 +13,17 @@ pub(crate) const LOG_TARGET: &str = "executor";
 pub fn log_resources(resources: &TransactionResources) {
     let mut mapped_strings = Vec::new();
 
-    for (builtin, count) in &resources.computation.vm_resources.builtin_instance_counter {
+    for (builtin, count) in &resources.computation.tx_vm_resources.builtin_instance_counter {
         mapped_strings.push(format!("{builtin}: {count}"));
     }
 
     // Sort the strings alphabetically
     mapped_strings.sort();
-    mapped_strings.insert(0, format!("steps: {}", resources.computation.vm_resources.n_steps));
-    mapped_strings
-        .insert(1, format!("memory holes: {}", resources.computation.vm_resources.n_memory_holes));
+    mapped_strings.insert(0, format!("steps: {}", resources.computation.tx_vm_resources.n_steps));
+    mapped_strings.insert(
+        1,
+        format!("memory holes: {}", resources.computation.tx_vm_resources.n_memory_holes),
+    );
 
     trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Transaction resource usage.");
 }
@@ -74,7 +76,7 @@ pub(crate) fn build_receipt(
 }
 
 fn get_receipt_resources(receipt: &TransactionReceipt) -> receipt::ExecutionResources {
-    let computation_resources = receipt.resources.computation.vm_resources.clone();
+    let computation_resources = receipt.resources.computation.tx_vm_resources.clone();
 
     let gas = GasUsed {
         l2_gas: receipt.gas.l2_gas.0,


### PR DESCRIPTION
Related #247 

Bumps `blockifer` to the latest [upstream] tag `v0.15.0-rc.3`. We still rely on our fork, so the version that is used for this bump is a [patched version] of the upstream tag. The patched is basically the branch `blockifier/cairo-2.11` but rebased onto the upstream tag `v0.15.0-rc.3`.

The `snos-integration-test` will be removed temporarily until we have a version of SNOS using `cairo-lang-*@2.12.0-dev.1` as currently it's causing a version conflict issue with the cairo-lang deps. The test will most likely be added back once the new SNOS implementation is ready. The [current one] is pretty much deprecated and its development has stopped.

[upstream]: https://github.com/starkware-libs/sequencer/releases/tag/v0.15.0-rc.3
[patched version]: https://github.com/dojoengine/sequencer/tree/blockifier/v0.15.0-rc.3
[current one]: https://github.com/keep-starknet-strange/snos