### PR TITLE
feat(explorer): builder pattern for creating `ExplorerLayer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,12 +1433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "ascii-canvas"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,11 +1603,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "tokio",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -3180,12 +3170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,15 +3579,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -4339,18 +4314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4429,15 +4392,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "funty"
@@ -5568,26 +5522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,28 +6185,20 @@ dependencies = [
 name = "katana-explorer"
 version = "1.7.0-alpha.3"
 dependencies = [
- "anyhow",
- "axum 0.6.20",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 0.14.32",
  "jsonrpsee",
  "katana-runner",
- "katana-tasks",
- "notify",
  "reqwest 0.12.22",
  "rust-embed",
  "serde",
  "serde_json",
  "tempfile",
- "tiny_http",
- "tokio",
+ "thiserror 1.0.69",
  "tower 0.5.2",
- "tower-http",
  "tracing",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -6816,26 +6742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6945,7 +6851,6 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -7446,25 +7351,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.9.1",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10024,16 +9910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11250,18 +11126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,6 +3598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,6 +4339,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4408,6 +4429,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -5538,6 +5568,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6210,8 +6260,12 @@ dependencies = [
  "jsonrpsee",
  "katana-runner",
  "katana-tasks",
+ "notify",
  "reqwest 0.12.22",
  "rust-embed",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tiny_http",
  "tokio",
  "tower 0.5.2",
@@ -6762,6 +6816,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6871,6 +6945,7 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -7371,6 +7446,25 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -1,33 +1,23 @@
 [package]
 edition.workspace = true
-license-file.workspace = true
+license.workspace = true
 name = "katana-explorer"
 repository.workspace = true
 version.workspace = true
 
-[features]
 [dependencies]
-katana-tasks.workspace = true
-
-anyhow.workspace = true
-axum = "0.6.20"
 bytes.workspace = true
 http.workspace = true
 http-body.workspace = true
-hyper.workspace = true
 jsonrpsee = { workspace = true, features = [ "server-core" ], optional = true }
-notify = "6.1.1"
 serde = { workspace = true, features = [ "derive" ] }
 serde_json.workspace = true
-tiny_http = "0.12"
-tokio = { workspace = true, features = [ "full" ] }
+thiserror.workspace = true
 tower.workspace = true
-tower-http = { workspace = true, features = [ "cors" ] }
 tracing.workspace = true
 url.workspace = true
-urlencoding = "2.1.2"
 
-rust-embed = { version = "6.8.1", features = [ "debug-embed" ] }
+rust-embed = { version = "6.8", features = [ "debug-embed" ] }
 
 [dev-dependencies]
 katana-runner.workspace = true

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -5,6 +5,10 @@ name = "katana-explorer"
 repository.workspace = true
 version.workspace = true
 
+[features]
+default = ["embedded-ui"]
+embedded-ui = ["rust-embed"]
+
 [dependencies]
 katana-tasks.workspace = true
 
@@ -15,6 +19,9 @@ http.workspace = true
 http-body.workspace = true
 hyper.workspace = true
 jsonrpsee = { workspace = true, features = [ "server-core" ], optional = true }
+notify = "6.1.1"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 tiny_http = "0.12"
 tokio = { workspace = true, features = [ "full" ] }
 tower.workspace = true
@@ -23,11 +30,10 @@ tracing.workspace = true
 url.workspace = true
 urlencoding = "2.1.2"
 
-# If the `debug-embed` is not enabled, the assets are not embedded in the binary when the crate is
-# build in debug mode. We want to make sure the assets are embedded in both debug and release mode
-# to ensure consistent behaviour.
-rust-embed = { version = "6.8.1", features = [ "debug-embed" ] }
+# Optional UI embedding - only when embedded-ui feature is enabled
+rust-embed = { version = "6.8.1", features = [ "debug-embed" ], optional = true }
 
 [dev-dependencies]
 katana-runner.workspace = true
 reqwest.workspace = true
+tempfile.workspace = true

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -6,9 +6,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["embedded-ui"]
-embedded-ui = ["rust-embed"]
-
 [dependencies]
 katana-tasks.workspace = true
 
@@ -20,7 +17,7 @@ http-body.workspace = true
 hyper.workspace = true
 jsonrpsee = { workspace = true, features = [ "server-core" ], optional = true }
 notify = "6.1.1"
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = [ "derive" ] }
 serde_json.workspace = true
 tiny_http = "0.12"
 tokio = { workspace = true, features = [ "full" ] }
@@ -30,8 +27,7 @@ tracing.workspace = true
 url.workspace = true
 urlencoding = "2.1.2"
 
-# Optional UI embedding - only when embedded-ui feature is enabled
-rust-embed = { version = "6.8.1", features = [ "debug-embed" ], optional = true }
+rust-embed = { version = "6.8.1", features = [ "debug-embed" ] }
 
 [dev-dependencies]
 katana-runner.workspace = true

--- a/crates/explorer/README.md
+++ b/crates/explorer/README.md
@@ -1,272 +1,47 @@
 # Katana Explorer
 
-The Katana Explorer provides a web interface for interacting with Katana blockchain instances. This crate implements a flexible Tower middleware for serving the Explorer UI with multiple deployment modes.
+This crate provides the Katana Explorer UI server functionality. The UI code is maintained in a separate repository and included here as a git submodule.
 
-## Features
+## Structure
 
-- 🔥 **Hot Reload**: Real-time UI updates during development
-- 📦 **Embedded Assets**: Production-ready embedded UI 
-- 🗂️ **Filesystem Serving**: Serve UI from any directory
-- 🔒 **Security Headers**: Configurable security headers for production
-- 🌐 **CORS Support**: Enable cross-origin requests for development
-- ⚡ **Caching**: Intelligent file caching with invalidation
-- 🎯 **SPA Support**: Single Page Application routing support
+The explorer UI code is located in the `ui` directory as a git submodule. The built files must be present in `ui/dist` directory for the explorer to work.
 
-## Deployment Modes
+## Building the Explorer
 
-### 1. Embedded Mode (Production)
+### In CI
 
-Serves pre-built UI assets embedded in the binary:
+The explorer UI is automatically built in CI before building Katana. This ensures that the explorer UI is always available when building official releases.
 
-```rust
-use katana_explorer::{ExplorerLayer, ExplorerMode, ExplorerConfig};
+### Building Locally
 
-// Simple embedded mode
-let layer = ExplorerLayer::embedded("KATANA".to_string())?;
+If you need to build the explorer UI locally:
 
-// Or with full config
-let config = ExplorerConfig {
-    mode: ExplorerMode::Embedded,
-    chain_id: "KATANA".to_string(),
-    security_headers: true,
-    ..Default::default()
-};
-let layer = ExplorerLayer::new(config)?;
-```
+1. Initialize the submodule:
 
-### 2. FileSystem Mode with Hot Reload (Development)
-
-Serves UI files from disk with automatic reload on changes:
-
-```rust
-use std::path::PathBuf;
-
-// Simple filesystem mode with hot reload
-let layer = ExplorerLayer::filesystem(
-    PathBuf::from("./ui/dist"),
-    "KATANA_DEV".to_string(),
-    true, // hot_reload enabled
-)?;
-
-// Or with full config
-let config = ExplorerConfig {
-    mode: ExplorerMode::FileSystem {
-        ui_path: PathBuf::from("./ui/dist"),
-        hot_reload: true,
-    },
-    chain_id: "KATANA_DEV".to_string(),
-    cors_enabled: true,
-    security_headers: false, // Disable for development
-    ..Default::default()
-};
-```
-
-### 3. Proxy Mode (Future)
-
-Proxy requests to an external development server (planned feature):
-
-```rust
-use url::Url;
-
-let layer = ExplorerLayer::proxy(
-    Url::parse("http://localhost:3000")?,
-    "KATANA".to_string(),
-)?;
-```
-
-## Configuration
-
-```rust
-use katana_explorer::{ExplorerConfig, ExplorerMode};
-use std::collections::HashMap;
-
-let config = ExplorerConfig {
-    // Serving mode
-    mode: ExplorerMode::FileSystem { 
-        ui_path: PathBuf::from("./ui/dist"),
-        hot_reload: true,
-    },
-    
-    // Chain configuration
-    chain_id: "KATANA".to_string(),
-    
-    // Server configuration  
-    path_prefix: "/explorer".to_string(), // URL prefix
-    cors_enabled: true,                   // Enable CORS
-    security_headers: true,               // Add security headers
-    compression: false,                   // Enable compression (future)
-    
-    // Custom headers
-    custom_headers: {
-        let mut headers = HashMap::new();
-        headers.insert("X-Custom-Header".to_string(), "value".to_string());
-        headers
-    },
-    
-    // UI environment variables
-    ui_env: {
-        let mut env = HashMap::new();
-        env.insert("DEBUG".to_string(), serde_json::Value::Bool(true));
-        env.insert("API_URL".to_string(), serde_json::Value::String("/api".to_string()));
-        env
-    },
-};
-```
-
-## Integration with Tower Services
-
-```rust
-use tower::ServiceBuilder;
-use tower_http::cors::CorsLayer;
-
-let service = ServiceBuilder::new()
-    .layer(CorsLayer::permissive())
-    .layer(explorer_layer)
-    .service_fn(your_main_service);
-```
-
-## Building the UI
-
-### With Embedded UI (Production)
-
-Enable the `embedded-ui` feature (enabled by default):
-
-```toml
-[dependencies]
-katana-explorer = { version = "1.0", features = ["embedded-ui"] }
-```
-
-The build script will automatically:
-1. Initialize the UI git submodule
-2. Install dependencies with Bun
-3. Build the UI assets
-4. Embed them in the binary
-
-### Without Embedded UI (Development/Custom)
-
-Disable the `embedded-ui` feature:
-
-```toml
-[dependencies]
-katana-explorer = { version = "1.0", default-features = false }
-```
-
-Then use `FileSystem` or `Proxy` mode to serve UI assets.
-
-## Development Workflow
-
-1. **Initial Setup**:
-   ```bash
-   git submodule update --init --recursive
-   cd ui && bun install
-   ```
-
-2. **Development Mode** (with hot reload):
-   ```rust
-   let layer = ExplorerLayer::filesystem(
-       PathBuf::from("./ui/dist"), 
-       "KATANA_DEV".to_string(),
-       true // Enable hot reload
-   )?;
-   ```
-
-3. **Build UI** (when needed):
-   ```bash
-   cd ui && bun run build
-   ```
-
-4. **Start Katana** with filesystem mode - UI changes will be picked up automatically!
-
-## Environment Variables
-
-The explorer automatically injects environment variables into the UI:
-
-### Default Variables
-- `CHAIN_ID`: The configured chain ID
-- `ENABLE_CONTROLLER`: Boolean flag for controller integration
-
-### Custom Variables
-Add custom variables through the `ui_env` config:
-
-```rust
-let mut env = HashMap::new();
-env.insert("DEBUG".to_string(), serde_json::Value::Bool(true));
-env.insert("API_ENDPOINT".to_string(), serde_json::Value::String("/api/v1".to_string()));
-
-let config = ExplorerConfig {
-    ui_env: env,
-    // ... other config
-};
-```
-
-These are accessible in the UI via `window.KATANA_CONFIG`:
-
-```javascript
-// In your UI code
-const config = window.KATANA_CONFIG;
-console.log('Chain ID:', config.CHAIN_ID);
-console.log('Debug mode:', config.DEBUG);
-```
-
-## File Structure
-
-```
-crates/explorer/
-├── src/lib.rs              # Main implementation
-├── build.rs                # UI build script (feature-gated)
-├── examples/
-│   └── hot_reload_example.rs # Usage examples
-├── ui/                      # UI submodule (git submodule)
-│   ├── src/                 # UI source code
-│   ├── dist/                # Built assets (generated)
-│   └── package.json         # UI dependencies
-└── README.md               # This file
-```
-
-## Performance & Caching
-
-- **Embedded Mode**: Assets served directly from memory
-- **FileSystem Mode**: Files cached in memory with mtime-based invalidation
-- **Hot Reload**: Cache automatically cleared on file system changes
-- **HTTP Headers**: Appropriate cache-control headers for different asset types
-
-## Security
-
-- **Content Security Policy**: Configurable CSP headers
-- **CORS**: Optional CORS support for development
-- **X-Frame-Options**: Prevents embedding in frames
-- **Content-Type Sniffing**: Disabled for security
-
-## Error Handling
-
-- **Missing Assets**: Graceful fallback to embedded assets (if available)
-- **File Errors**: Detailed logging and fallback behavior
-- **Build Failures**: Non-fatal warnings when UI build fails
-
-## Examples
-
-See the `examples/` directory for complete usage examples:
-
-- `hot_reload_example.rs`: Development workflow with hot reload
-
-Run examples with:
 ```bash
-cargo run --example hot_reload_example
+git submodule update --init --recursive
 ```
 
-## Troubleshooting
+2. Build the UI:
 
-### UI Assets Not Found
-- Ensure `ui/dist` directory exists and contains built files
-- Check that git submodules are initialized
-- Verify Bun is installed for building UI
+```bash
+cd ui
+bun install
+bun run build
+```
 
-### Hot Reload Not Working
-- Ensure `hot_reload: true` in FileSystem mode
-- Check file system permissions
-- Verify the UI path exists and is readable
+The build output will be placed in `ui/dist`. This directory must exist and contain the built files for the explorer to work.
 
-### Build Errors
-- Install Bun: https://bun.sh
-- Initialize submodules: `git submodule update --init --recursive`
-- Build manually: `cd ui && bun run build`
+## Runtime Behavior
+
+The explorer will fail to start if the UI build files are not found. This is intentional to prevent running with missing or outdated UI files.
+
+## Development
+
+For local development of the UI:
+
+1. Initialize the submodule as described above
+2. Navigate to the UI directory: `cd ui`
+3. Start the development server: `bun run dev`
+
+Note: The `ui/dist` directory is gitignored to prevent committing built files.

--- a/crates/explorer/README.md
+++ b/crates/explorer/README.md
@@ -1,53 +1,272 @@
 # Katana Explorer
 
-This crate provides the Katana Explorer UI server functionality. The UI code is maintained in a separate repository and included here as a git submodule.
+The Katana Explorer provides a web interface for interacting with Katana blockchain instances. This crate implements a flexible Tower middleware for serving the Explorer UI with multiple deployment modes.
 
-## Structure
+## Features
 
-The explorer UI code is located in the `ui` directory as a git submodule. The built files must be present in `ui/dist` directory for the explorer to work.
+- 🔥 **Hot Reload**: Real-time UI updates during development
+- 📦 **Embedded Assets**: Production-ready embedded UI 
+- 🗂️ **Filesystem Serving**: Serve UI from any directory
+- 🔒 **Security Headers**: Configurable security headers for production
+- 🌐 **CORS Support**: Enable cross-origin requests for development
+- ⚡ **Caching**: Intelligent file caching with invalidation
+- 🎯 **SPA Support**: Single Page Application routing support
 
-## Building the Explorer
+## Deployment Modes
 
-### In CI
+### 1. Embedded Mode (Production)
 
-The explorer UI is automatically built in CI before building Katana. This ensures that the explorer UI is always available when building official releases.
+Serves pre-built UI assets embedded in the binary:
 
-### Building Locally
+```rust
+use katana_explorer::{ExplorerLayer, ExplorerMode, ExplorerConfig};
 
-If you need to build the explorer UI locally:
+// Simple embedded mode
+let layer = ExplorerLayer::embedded("KATANA".to_string())?;
 
-1. Initialize the submodule:
-
-```bash
-git submodule update --init --recursive
+// Or with full config
+let config = ExplorerConfig {
+    mode: ExplorerMode::Embedded,
+    chain_id: "KATANA".to_string(),
+    security_headers: true,
+    ..Default::default()
+};
+let layer = ExplorerLayer::new(config)?;
 ```
 
-2. Build the UI:
+### 2. FileSystem Mode with Hot Reload (Development)
 
-```bash
-cd ui
-bun install
-bun run build
+Serves UI files from disk with automatic reload on changes:
+
+```rust
+use std::path::PathBuf;
+
+// Simple filesystem mode with hot reload
+let layer = ExplorerLayer::filesystem(
+    PathBuf::from("./ui/dist"),
+    "KATANA_DEV".to_string(),
+    true, // hot_reload enabled
+)?;
+
+// Or with full config
+let config = ExplorerConfig {
+    mode: ExplorerMode::FileSystem {
+        ui_path: PathBuf::from("./ui/dist"),
+        hot_reload: true,
+    },
+    chain_id: "KATANA_DEV".to_string(),
+    cors_enabled: true,
+    security_headers: false, // Disable for development
+    ..Default::default()
+};
 ```
 
-The build output will be placed in `ui/dist`. This directory must exist and contain the built files for the explorer to work.
+### 3. Proxy Mode (Future)
 
-## Runtime Behavior
+Proxy requests to an external development server (planned feature):
 
-The explorer will fail to start if the UI build files are not found. This is intentional to prevent running with missing or outdated UI files.
+```rust
+use url::Url;
 
-## Development
+let layer = ExplorerLayer::proxy(
+    Url::parse("http://localhost:3000")?,
+    "KATANA".to_string(),
+)?;
+```
 
-For local development of the UI:
+## Configuration
 
-1. Initialize the submodule as described above
-2. Navigate to the UI directory: `cd ui`
-3. Start the development server: `bun run dev`
+```rust
+use katana_explorer::{ExplorerConfig, ExplorerMode};
+use std::collections::HashMap;
 
-Note: The `ui/dist` directory is gitignored to prevent committing built files.
+let config = ExplorerConfig {
+    // Serving mode
+    mode: ExplorerMode::FileSystem { 
+        ui_path: PathBuf::from("./ui/dist"),
+        hot_reload: true,
+    },
+    
+    // Chain configuration
+    chain_id: "KATANA".to_string(),
+    
+    // Server configuration  
+    path_prefix: "/explorer".to_string(), // URL prefix
+    cors_enabled: true,                   // Enable CORS
+    security_headers: true,               // Add security headers
+    compression: false,                   // Enable compression (future)
+    
+    // Custom headers
+    custom_headers: {
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom-Header".to_string(), "value".to_string());
+        headers
+    },
+    
+    // UI environment variables
+    ui_env: {
+        let mut env = HashMap::new();
+        env.insert("DEBUG".to_string(), serde_json::Value::Bool(true));
+        env.insert("API_URL".to_string(), serde_json::Value::String("/api".to_string()));
+        env
+    },
+};
+```
 
-## Utilities
+## Integration with Tower Services
 
-This crate also provides some utility functions for working with the embedded files:
+```rust
+use tower::ServiceBuilder;
+use tower_http::cors::CorsLayer;
 
-- `inject_rpc_url`: Injects the RPC URL into an HTML file
+let service = ServiceBuilder::new()
+    .layer(CorsLayer::permissive())
+    .layer(explorer_layer)
+    .service_fn(your_main_service);
+```
+
+## Building the UI
+
+### With Embedded UI (Production)
+
+Enable the `embedded-ui` feature (enabled by default):
+
+```toml
+[dependencies]
+katana-explorer = { version = "1.0", features = ["embedded-ui"] }
+```
+
+The build script will automatically:
+1. Initialize the UI git submodule
+2. Install dependencies with Bun
+3. Build the UI assets
+4. Embed them in the binary
+
+### Without Embedded UI (Development/Custom)
+
+Disable the `embedded-ui` feature:
+
+```toml
+[dependencies]
+katana-explorer = { version = "1.0", default-features = false }
+```
+
+Then use `FileSystem` or `Proxy` mode to serve UI assets.
+
+## Development Workflow
+
+1. **Initial Setup**:
+   ```bash
+   git submodule update --init --recursive
+   cd ui && bun install
+   ```
+
+2. **Development Mode** (with hot reload):
+   ```rust
+   let layer = ExplorerLayer::filesystem(
+       PathBuf::from("./ui/dist"), 
+       "KATANA_DEV".to_string(),
+       true // Enable hot reload
+   )?;
+   ```
+
+3. **Build UI** (when needed):
+   ```bash
+   cd ui && bun run build
+   ```
+
+4. **Start Katana** with filesystem mode - UI changes will be picked up automatically!
+
+## Environment Variables
+
+The explorer automatically injects environment variables into the UI:
+
+### Default Variables
+- `CHAIN_ID`: The configured chain ID
+- `ENABLE_CONTROLLER`: Boolean flag for controller integration
+
+### Custom Variables
+Add custom variables through the `ui_env` config:
+
+```rust
+let mut env = HashMap::new();
+env.insert("DEBUG".to_string(), serde_json::Value::Bool(true));
+env.insert("API_ENDPOINT".to_string(), serde_json::Value::String("/api/v1".to_string()));
+
+let config = ExplorerConfig {
+    ui_env: env,
+    // ... other config
+};
+```
+
+These are accessible in the UI via `window.KATANA_CONFIG`:
+
+```javascript
+// In your UI code
+const config = window.KATANA_CONFIG;
+console.log('Chain ID:', config.CHAIN_ID);
+console.log('Debug mode:', config.DEBUG);
+```
+
+## File Structure
+
+```
+crates/explorer/
+├── src/lib.rs              # Main implementation
+├── build.rs                # UI build script (feature-gated)
+├── examples/
+│   └── hot_reload_example.rs # Usage examples
+├── ui/                      # UI submodule (git submodule)
+│   ├── src/                 # UI source code
+│   ├── dist/                # Built assets (generated)
+│   └── package.json         # UI dependencies
+└── README.md               # This file
+```
+
+## Performance & Caching
+
+- **Embedded Mode**: Assets served directly from memory
+- **FileSystem Mode**: Files cached in memory with mtime-based invalidation
+- **Hot Reload**: Cache automatically cleared on file system changes
+- **HTTP Headers**: Appropriate cache-control headers for different asset types
+
+## Security
+
+- **Content Security Policy**: Configurable CSP headers
+- **CORS**: Optional CORS support for development
+- **X-Frame-Options**: Prevents embedding in frames
+- **Content-Type Sniffing**: Disabled for security
+
+## Error Handling
+
+- **Missing Assets**: Graceful fallback to embedded assets (if available)
+- **File Errors**: Detailed logging and fallback behavior
+- **Build Failures**: Non-fatal warnings when UI build fails
+
+## Examples
+
+See the `examples/` directory for complete usage examples:
+
+- `hot_reload_example.rs`: Development workflow with hot reload
+
+Run examples with:
+```bash
+cargo run --example hot_reload_example
+```
+
+## Troubleshooting
+
+### UI Assets Not Found
+- Ensure `ui/dist` directory exists and contains built files
+- Check that git submodules are initialized
+- Verify Bun is installed for building UI
+
+### Hot Reload Not Working
+- Ensure `hot_reload: true` in FileSystem mode
+- Check file system permissions
+- Verify the UI path exists and is readable
+
+### Build Errors
+- Install Bun: https://bun.sh
+- Initialize submodules: `git submodule update --init --recursive`
+- Build manually: `cd ui && bun run build`

--- a/crates/explorer/build.rs
+++ b/crates/explorer/build.rs
@@ -1,88 +1,130 @@
-use std::path::Path;
-use std::process::Command;
-
 fn main() {
-    println!("cargo:rerun-if-changed=ui/");
+    // Only build UI when embedded-ui feature is enabled
+    #[cfg(feature = "embedded-ui")]
+    {
+        println!("cargo:rerun-if-changed=ui/");
+        build_ui();
+    }
+
+    #[cfg(not(feature = "embedded-ui"))]
+    {
+        println!("cargo:warning=Embedded UI feature is disabled. UI assets will not be built.");
+        println!(
+            "cargo:warning=Use --features embedded-ui to enable embedded assets, or use \
+             FileSystem/Proxy mode."
+        );
+    }
+}
+
+#[cfg(feature = "embedded-ui")]
+fn build_ui() {
+    use std::path::Path;
 
     // Check if we're in a build script
     if std::env::var("CARGO_MANIFEST_DIR").is_ok() {
-        // $CARGO_MANIFEST_DIR/ui/
-        let ui_dir = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("ui");
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let ui_dir = Path::new(&manifest_dir).join("ui");
         println!("Explorer UI directory: {}", ui_dir.display());
 
-        // Check if ui/ doesn't exist or is empty. This determines whether we need to initialize the
-        // git submodule.
-        //
-        // The condition is true if:
-        // 1. The ui directory doesn't exist at all, OR
-        // 2. The ui directory exists but is empty (no entries when reading the directory)
+        // Check if ui/ doesn't exist or is empty
         let should_update_submodule = !ui_dir.exists()
             || (ui_dir.exists()
                 && ui_dir.read_dir().map(|mut d| d.next().is_none()).unwrap_or(true));
 
         if should_update_submodule {
-            // Check if we're in a git repository
-            let git_check = Command::new("git").arg("rev-parse").arg("--git-dir").output();
-            if git_check.is_ok() && git_check.unwrap().status.success() {
-                // Update git submodule
-                println!("UI directory is empty, updating git submodule...");
-
-                let status = Command::new("git")
-                    .arg("submodule")
-                    .arg("update")
-                    .arg("--init")
-                    .arg("--recursive")
-                    .arg("--force")
-                    .arg("ui")
-                    .status()
-                    .expect("Failed to update git submodule");
-
-                if !status.success() {
-                    panic!(
-                        "Failed to update git submodule for UI directory at {}",
-                        ui_dir.display()
-                    );
-                }
-            } else {
-                panic!(
-                    "UI directory doesn't exist at {} and couldn't fetch it through git submodule \
-                     (not in a git repository)",
-                    ui_dir.display()
-                );
-            }
+            initialize_submodule(&ui_dir);
         }
 
-        let bun_check = Command::new("bun").arg("--version").output();
-
-        if bun_check.is_err() || !bun_check.unwrap().status.success() {
-            panic!("Bun is not installed. Please install Bun at https://bun.sh .");
+        // Check if dist directory exists, if not, build
+        let dist_dir = ui_dir.join("dist");
+        if !dist_dir.exists() || is_dist_empty(&dist_dir) {
+            build_ui_assets(&ui_dir);
+        } else {
+            println!("UI assets already exist at {}", dist_dir.display());
         }
+    }
+}
 
-        // Install dependencies if node_modules doesn't exist
-        // $CARGO_MANIFEST_DIR/ui/node_modules
-        println!("Installing UI dependencies...");
+#[cfg(feature = "embedded-ui")]
+fn initialize_submodule(ui_dir: &std::path::Path) {
+    use std::process::Command;
 
-        let status = Command::new("bun")
-            .current_dir(&ui_dir)
-            .arg("install")
+    // Check if we're in a git repository
+    let git_check = Command::new("git").arg("rev-parse").arg("--git-dir").output();
+    if git_check.is_ok() && git_check.unwrap().status.success() {
+        println!("UI directory is empty, updating git submodule...");
+
+        let status = Command::new("git")
+            .arg("submodule")
+            .arg("update")
+            .arg("--init")
+            .arg("--recursive")
+            .arg("--force")
+            .arg("ui")
             .status()
-            .expect("Failed to install UI dependencies");
+            .expect("Failed to update git submodule");
 
         if !status.success() {
-            panic!("Failed to install UI dependencies in {}", ui_dir.display());
+            panic!("Failed to update git submodule for UI directory at {}", ui_dir.display());
         }
+    } else {
+        panic!(
+            "UI directory doesn't exist at {} and couldn't fetch it through git submodule (not in \
+             a git repository)",
+            ui_dir.display()
+        );
+    }
+}
 
-        println!("Building UI...");
-        let status = Command::new("bun")
-            .current_dir(&ui_dir)
-            .env("IS_EMBEDDED", "true")
-            .arg("run")
-            .arg("build")
-            .status()
-            .expect("Failed to build UI");
+#[cfg(feature = "embedded-ui")]
+fn is_dist_empty(dist_dir: &std::path::Path) -> bool {
+    dist_dir.read_dir().map(|mut entries| entries.next().is_none()).unwrap_or(true)
+}
 
-        if !status.success() {
-            panic!("Failed to build UI in {}", ui_dir.display());
+#[cfg(feature = "embedded-ui")]
+fn build_ui_assets(ui_dir: &std::path::Path) {
+    use std::process::Command;
+
+    // Check for Bun
+    let bun_check = Command::new("bun").arg("--version").output();
+    if bun_check.is_err() || !bun_check.unwrap().status.success() {
+        eprintln!("Warning: Bun is not installed. Attempting to skip UI build...");
+        eprintln!("If you need embedded UI assets, please install Bun at https://bun.sh");
+        return;
+    }
+
+    println!("Installing UI dependencies...");
+    let status = Command::new("bun").current_dir(ui_dir).arg("install").status();
+
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(_) => {
+            eprintln!("Warning: Failed to install UI dependencies in {}", ui_dir.display());
+            return;
+        }
+        Err(e) => {
+            eprintln!("Warning: Failed to run bun install: {}", e);
+            return;
+        }
+    }
+
+    println!("Building UI...");
+    let status = Command::new("bun")
+        .current_dir(ui_dir)
+        .env("IS_EMBEDDED", "true")
+        .arg("run")
+        .arg("build")
+        .status();
+
+    match status {
+        Ok(status) if status.success() => {
+            println!("UI build completed successfully");
+        }
+        Ok(_) => {
+            eprintln!("Warning: Failed to build UI in {}", ui_dir.display());
+        }
+        Err(e) => {
+            eprintln!("Warning: Failed to run bun build: {}", e);
         }
     }
 }

--- a/crates/explorer/build.rs
+++ b/crates/explorer/build.rs
@@ -1,28 +1,16 @@
-fn main() {
-    // Only build UI when embedded-ui feature is enabled
-    #[cfg(feature = "embedded-ui")]
-    {
-        println!("cargo:rerun-if-changed=ui/");
-        build_ui();
-    }
+use std::env::var;
+use std::path::Path;
+use std::process::Command;
 
-    #[cfg(not(feature = "embedded-ui"))]
-    {
-        println!("cargo:warning=Embedded UI feature is disabled. UI assets will not be built.");
-        println!(
-            "cargo:warning=Use --features embedded-ui to enable embedded assets, or use \
-             FileSystem/Proxy mode."
-        );
-    }
+fn main() {
+    println!("cargo:rerun-if-changed=ui/");
+    build_ui();
 }
 
-#[cfg(feature = "embedded-ui")]
 fn build_ui() {
-    use std::path::Path;
-
     // Check if we're in a build script
-    if std::env::var("CARGO_MANIFEST_DIR").is_ok() {
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    if var("CARGO_MANIFEST_DIR").is_ok() {
+        let manifest_dir = var("CARGO_MANIFEST_DIR").unwrap();
         let ui_dir = Path::new(&manifest_dir).join("ui");
         println!("Explorer UI directory: {}", ui_dir.display());
 
@@ -45,10 +33,7 @@ fn build_ui() {
     }
 }
 
-#[cfg(feature = "embedded-ui")]
-fn initialize_submodule(ui_dir: &std::path::Path) {
-    use std::process::Command;
-
+fn initialize_submodule(ui_dir: &Path) {
     // Check if we're in a git repository
     let git_check = Command::new("git").arg("rev-parse").arg("--git-dir").output();
     if git_check.is_ok() && git_check.unwrap().status.success() {
@@ -76,15 +61,11 @@ fn initialize_submodule(ui_dir: &std::path::Path) {
     }
 }
 
-#[cfg(feature = "embedded-ui")]
-fn is_dist_empty(dist_dir: &std::path::Path) -> bool {
+fn is_dist_empty(dist_dir: &Path) -> bool {
     dist_dir.read_dir().map(|mut entries| entries.next().is_none()).unwrap_or(true)
 }
 
-#[cfg(feature = "embedded-ui")]
-fn build_ui_assets(ui_dir: &std::path::Path) {
-    use std::process::Command;
-
+fn build_ui_assets(ui_dir: &Path) {
     // Check for Bun
     let bun_check = Command::new("bun").arg("--version").output();
     if bun_check.is_err() || !bun_check.unwrap().status.success() {

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -5,11 +5,48 @@ use std::task::{Context, Poll};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use http::header::HeaderValue;
-use http::StatusCode;
-use jsonrpsee::core::http_helpers::{Body, Request, Response};
-use jsonrpsee::core::BoxError;
+use http::{Request, Response, StatusCode};
 use rust_embed::RustEmbed;
 use tower::{Layer, Service};
+
+// Define Body type based on what's available
+#[cfg(feature = "jsonrpsee")]
+use jsonrpsee::core::{http_helpers::Body, BoxError};
+
+#[cfg(not(feature = "jsonrpsee"))]
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[cfg(not(feature = "jsonrpsee"))]
+#[derive(Debug)]
+pub enum Body {
+    Fixed(Bytes),
+}
+
+#[cfg(not(feature = "jsonrpsee"))]
+impl Body {
+    fn from<T: Into<Vec<u8>>>(data: T) -> Self {
+        Self::Fixed(Bytes::from(data.into()))
+    }
+}
+
+#[cfg(not(feature = "jsonrpsee"))]
+impl http_body::Body for Body {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        match self.get_mut() {
+            Body::Fixed(bytes) if !bytes.is_empty() => {
+                let frame = http_body::Frame::data(std::mem::take(bytes));
+                std::task::Poll::Ready(Some(Ok(frame)))
+            }
+            _ => std::task::Poll::Ready(None),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ExplorerLayer {
@@ -52,10 +89,10 @@ where
     B::Error: Into<BoxError>,
     S::Future: Send + 'static,
     S::Error: Into<BoxError> + 'static,
-    S: Service<Request<B>, Response = Response>,
+    S: Service<Request<B>, Response = Response<Body>>,
     B: http_body::Body<Data = Bytes> + Send + 'static,
 {
-    type Response = S::Response;
+    type Response = Response<Body>;
     type Error = S::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
@@ -181,4 +218,119 @@ fn is_static_asset_path(path: &str) -> bool {
             || path.ends_with(".woff2")
             || path.ends_with(".ttf")
             || path.ends_with(".eot"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_content_type() {
+        assert_eq!(get_content_type("index.html"), "text/html");
+        assert_eq!(get_content_type("app.js"), "application/javascript");
+        assert_eq!(get_content_type("styles.css"), "text/css");
+        assert_eq!(get_content_type("logo.png"), "image/png");
+        assert_eq!(get_content_type("icon.svg"), "image/svg+xml");
+        assert_eq!(get_content_type("data.json"), "application/json");
+        assert_eq!(get_content_type("favicon.ico"), "image/x-icon");
+        assert_eq!(get_content_type("font.woff"), "font/woff");
+        assert_eq!(get_content_type("font.woff2"), "font/woff2");
+        assert_eq!(get_content_type("font.ttf"), "font/ttf");
+        assert_eq!(get_content_type("font.eot"), "application/vnd.ms-fontobject");
+        assert_eq!(get_content_type("unknown.xyz"), "application/octet-stream");
+        assert_eq!(get_content_type("no_extension"), "application/octet-stream");
+    }
+
+    #[test]
+    fn test_is_static_asset_path() {
+        // Valid static assets
+        assert!(is_static_asset_path("app.js"));
+        assert!(is_static_asset_path("styles.css"));
+        assert!(is_static_asset_path("logo.png"));
+        assert!(is_static_asset_path("icon.svg"));
+        assert!(is_static_asset_path("data.json"));
+        assert!(is_static_asset_path("favicon.ico"));
+        assert!(is_static_asset_path("font.woff"));
+        assert!(is_static_asset_path("font.woff2"));
+        assert!(is_static_asset_path("font.ttf"));
+        assert!(is_static_asset_path("font.eot"));
+
+        // Nested paths
+        assert!(is_static_asset_path("assets/js/app.js"));
+        assert!(is_static_asset_path("css/main.css"));
+
+        // Invalid static assets
+        assert!(!is_static_asset_path(""));
+        assert!(!is_static_asset_path("index.html"));
+        assert!(!is_static_asset_path("page"));
+        assert!(!is_static_asset_path("unknown.txt"));
+        assert!(!is_static_asset_path("file.xml"));
+    }
+
+    #[test]
+    fn test_setup_env_basic_injection() {
+        let html = "<html><head></head><body></body></html>";
+        let chain_id = "KATANA";
+        let result = setup_env(html, chain_id);
+
+        assert!(result.contains("window.CHAIN_ID = \"KATANA\";"));
+        assert!(result.contains("window.ENABLE_CONTROLLER = false;"));
+        assert!(result.contains("<head><script>"));
+    }
+
+    #[test]
+    fn test_setup_env_escapes_chain_id() {
+        let html = "<html><head></head><body></body></html>";
+
+        // Test escaping quotes
+        let chain_id = "CHAIN\"WITH\"QUOTES";
+        let result = setup_env(html, chain_id);
+        assert!(result.contains("window.CHAIN_ID = \"CHAIN\\\"WITH\\\"QUOTES\";"));
+
+        // Test escaping HTML characters
+        let chain_id = "CHAIN<WITH>TAGS";
+        let result = setup_env(html, chain_id);
+        assert!(result.contains("window.CHAIN_ID = \"CHAIN&lt;WITH&gt;TAGS\";"));
+    }
+
+    #[test]
+    fn test_setup_env_no_head_tag() {
+        let html = "<html><body></body></html>";
+        let chain_id = "KATANA";
+        let result = setup_env(html, chain_id);
+
+        assert!(result.starts_with("<script>"));
+        assert!(result.contains("window.CHAIN_ID = \"KATANA\";"));
+    }
+
+    #[test]
+    fn test_setup_env_preserves_html_structure() {
+        let html = "<html><head><title>Test</title></head><body><h1>Hello</h1></body></html>";
+        let chain_id = "KATANA";
+        let result = setup_env(html, chain_id);
+
+        assert!(result.contains("<title>Test</title>"));
+        assert!(result.contains("<h1>Hello</h1>"));
+        assert!(result.contains("window.CHAIN_ID = \"KATANA\";"));
+    }
+
+    #[test]
+    fn test_explorer_layer_new_with_assets() {
+        // This test verifies that ExplorerLayer::new works when assets are available
+        // The build.rs script may have built assets, so this might succeed
+        let result = ExplorerLayer::new("test-chain".to_string());
+
+        // The test can succeed or fail depending on whether assets were built
+        // What matters is that we get the expected behavior in each case
+        match result {
+            Ok(layer) => {
+                // If assets are available, we should get a layer with the correct chain_id
+                assert_eq!(layer.chain_id, "test-chain");
+            }
+            Err(err) => {
+                // If assets are not available, we should get the expected error
+                assert!(err.to_string().contains("Explorer assets not found"));
+            }
+        }
+    }
 }

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -1,17 +1,24 @@
+use std::collections::HashMap;
 use std::future::Future;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::SystemTime;
 
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use http::header::HeaderValue;
-use http::{Request, Response, StatusCode};
-use rust_embed::RustEmbed;
-use tower::{Layer, Service};
-
+use http::{HeaderMap, Request, Response, StatusCode};
 // Define Body type based on what's available
 #[cfg(feature = "jsonrpsee")]
 use jsonrpsee::core::{http_helpers::Body, BoxError};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tower::{Layer, Service};
+use tracing::{debug, error, info, warn};
+use url::Url;
 
 #[cfg(not(feature = "jsonrpsee"))]
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -35,36 +42,140 @@ impl http_body::Body for Body {
     type Error = BoxError;
 
     fn poll_frame(
-        self: std::pin::Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
         match self.get_mut() {
             Body::Fixed(bytes) if !bytes.is_empty() => {
                 let frame = http_body::Frame::data(std::mem::take(bytes));
-                std::task::Poll::Ready(Some(Ok(frame)))
+                Poll::Ready(Some(Ok(frame)))
             }
-            _ => std::task::Poll::Ready(None),
+            _ => Poll::Ready(None),
         }
     }
 }
 
+/// Explorer serving mode configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExplorerMode {
+    /// Serve embedded assets (production mode)
+    Embedded,
+    /// Serve from filesystem with optional hot reload (development mode)
+    FileSystem { ui_path: PathBuf, hot_reload: bool },
+    /// Proxy to external development server
+    Proxy { upstream_url: Url, inject_env: bool },
+}
+
+/// Explorer configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExplorerConfig {
+    /// Serving mode
+    pub mode: ExplorerMode,
+    /// Chain ID to inject into the UI
+    pub chain_id: String,
+    /// URL path prefix (default: "/explorer")
+    pub path_prefix: String,
+    /// Enable CORS headers
+    pub cors_enabled: bool,
+    /// Enable security headers
+    pub security_headers: bool,
+    /// Enable compression
+    pub compression: bool,
+    /// Custom headers to add to responses
+    pub custom_headers: HashMap<String, String>,
+    /// Custom environment variables to inject into UI
+    pub ui_env: HashMap<String, serde_json::Value>,
+}
+
+impl Default for ExplorerConfig {
+    fn default() -> Self {
+        Self {
+            mode: ExplorerMode::Embedded,
+            chain_id: "KATANA".to_string(),
+            path_prefix: "/explorer".to_string(),
+            cors_enabled: false,
+            security_headers: true,
+            compression: false,
+            custom_headers: HashMap::new(),
+            ui_env: HashMap::new(),
+        }
+    }
+}
+
+/// File cache entry for hot reload functionality
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    content: Bytes,
+    content_type: String,
+    last_modified: SystemTime,
+}
+
+/// Explorer layer for Tower middleware
 #[derive(Debug, Clone)]
 pub struct ExplorerLayer {
-    /// The chain ID of the network
-    chain_id: String,
+    config: ExplorerConfig,
 }
 
 impl ExplorerLayer {
-    pub fn new(chain_id: String) -> Result<Self> {
-        // Validate that the embedded assets are available
-        if ExplorerAssets::get("index.html").is_none() {
-            return Err(anyhow!(
-                "Explorer assets not found. Make sure the explorer UI is built in CI and the \
-                 ui/dist directory is available."
-            ));
+    pub fn new(config: ExplorerConfig) -> Result<Self> {
+        // Validate configuration
+        match &config.mode {
+            ExplorerMode::Embedded => {
+                #[cfg(feature = "embedded-ui")]
+                {
+                    if EmbeddedAssets::get("index.html").is_none() {
+                        return Err(anyhow!(
+                            "Embedded mode selected but no UI assets found. Make sure the \
+                             explorer UI is built."
+                        ));
+                    }
+                }
+                #[cfg(not(feature = "embedded-ui"))]
+                {
+                    return Err(anyhow!(
+                        "Embedded mode selected but embedded-ui feature is disabled. Enable the \
+                         feature or use FileSystem/Proxy mode."
+                    ));
+                }
+            }
+            ExplorerMode::FileSystem { ui_path, .. } => {
+                if !ui_path.exists() {
+                    return Err(anyhow!("UI path does not exist: {}", ui_path.display()));
+                }
+                if !ui_path.join("index.html").exists() {
+                    warn!("index.html not found in UI path: {}", ui_path.display());
+                }
+            }
+            ExplorerMode::Proxy { upstream_url, .. } => {
+                debug!("Proxy mode configured to upstream: {}", upstream_url);
+            }
         }
 
-        Ok(Self { chain_id })
+        info!("Explorer configured with mode: {:?}", config.mode);
+        Ok(Self { config })
+    }
+
+    /// Create a new ExplorerLayer with embedded mode
+    pub fn embedded(chain_id: String) -> Result<Self> {
+        Self::new(ExplorerConfig { mode: ExplorerMode::Embedded, chain_id, ..Default::default() })
+    }
+
+    /// Create a new ExplorerLayer with filesystem mode
+    pub fn filesystem(ui_path: PathBuf, chain_id: String, hot_reload: bool) -> Result<Self> {
+        Self::new(ExplorerConfig {
+            mode: ExplorerMode::FileSystem { ui_path, hot_reload },
+            chain_id,
+            ..Default::default()
+        })
+    }
+
+    /// Create a new ExplorerLayer with proxy mode  
+    pub fn proxy(upstream_url: Url, chain_id: String) -> Result<Self> {
+        Self::new(ExplorerConfig {
+            mode: ExplorerMode::Proxy { upstream_url, inject_env: true },
+            chain_id,
+            ..Default::default()
+        })
     }
 }
 
@@ -72,14 +183,72 @@ impl<S> Layer<S> for ExplorerLayer {
     type Service = ExplorerService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        ExplorerService { inner, chain_id: self.chain_id.clone() }
+        ExplorerService::new(inner, self.config.clone())
     }
 }
 
-#[derive(Debug, Clone)]
+/// Explorer service implementation
+#[derive(Debug)]
 pub struct ExplorerService<S> {
     inner: S,
-    chain_id: String,
+    config: ExplorerConfig,
+    file_cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
+    _watcher: Option<RecommendedWatcher>,
+}
+
+impl<S> ExplorerService<S> {
+    pub fn new(inner: S, config: ExplorerConfig) -> Self {
+        let file_cache = Arc::new(RwLock::new(HashMap::new()));
+
+        // Set up file watcher for hot reload
+        let _watcher = if let ExplorerMode::FileSystem { ui_path, hot_reload } = &config.mode {
+            if *hot_reload {
+                Self::setup_file_watcher(ui_path.clone(), file_cache.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Self { inner, config, file_cache, _watcher }
+    }
+
+    fn setup_file_watcher(
+        ui_path: PathBuf,
+        cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
+    ) -> Option<RecommendedWatcher> {
+        match notify::recommended_watcher({
+            let cache = cache.clone();
+            move |result: Result<Event, notify::Error>| {
+                match result {
+                    Ok(event) => {
+                        debug!("File system event: {:?}", event);
+                        // Clear cache on any file change
+                        if let Ok(mut cache) = cache.try_write() {
+                            cache.clear();
+                            debug!("File cache cleared due to file system change");
+                        }
+                    }
+                    Err(e) => error!("File watcher error: {:?}", e),
+                }
+            }
+        }) {
+            Ok(mut watcher) => {
+                if let Err(e) = watcher.watch(&ui_path, RecursiveMode::Recursive) {
+                    error!("Failed to watch UI directory: {:?}", e);
+                    None
+                } else {
+                    info!("Hot reload enabled for UI directory: {}", ui_path.display());
+                    Some(watcher)
+                }
+            }
+            Err(e) => {
+                error!("Failed to create file watcher: {:?}", e);
+                None
+            }
+        }
+    }
 }
 
 impl<S, B> Service<Request<B>> for ExplorerService<S>
@@ -101,236 +270,463 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        // If the path does not start with the base path, pass the request to the inner service.
-        let Some(rel_path) = req.uri().path().strip_prefix("/explorer") else {
+        // Check if this is an explorer request
+        let uri_path = req.uri().path().to_string();
+        if !uri_path.starts_with(&self.config.path_prefix) {
             return Box::pin(self.inner.call(req));
-        };
+        }
 
-        // Check if the request is for a static asset that actually exists
-        let file_path = rel_path.trim_start_matches('/');
-        let is_static_asset = is_static_asset_path(file_path);
+        // Extract the file path after the prefix
+        let rel_path = uri_path
+            .strip_prefix(&self.config.path_prefix)
+            .unwrap_or("")
+            .trim_start_matches('/')
+            .to_string();
 
-        // If it's a static asset, try to find the exact file.
-        // Otherwise, serve `index.html` since it's a SPA route.
-        let asset_path = if is_static_asset && ExplorerAssets::get(file_path).is_some() {
-            file_path.to_string()
-        } else {
-            "index.html".to_string()
-        };
+        let config = self.config.clone();
+        let cache = self.file_cache.clone();
 
-        let response = if let Some(asset) = ExplorerAssets::get(&asset_path) {
-            let content_type = get_content_type(&format!("/{asset_path}"));
-            let content = asset.data;
-
-            let body = if content_type == "text/html" {
-                let html = String::from_utf8_lossy(&content).to_string();
-                let html = setup_env(&html, &self.chain_id);
-                Body::from(html)
-            } else {
-                Body::from(content.to_vec())
+        Box::pin(async move {
+            let response = match Self::serve_asset(&config, cache, &rel_path).await {
+                Some(response) => response,
+                None => Self::create_404_response(),
             };
-
-            let mut response = Response::builder().body(body).unwrap();
-
-            let mut headers = req.headers().clone();
-            let content_type = HeaderValue::from_str(content_type).unwrap();
-            headers.insert("Content-Type", content_type);
-            response.headers_mut().extend(headers);
-
-            response
-        } else {
-            Response::builder()
-                .status(StatusCode::NOT_FOUND)
-                .body(Body::from("Not found"))
-                .expect("good data; qed")
-        };
-
-        Box::pin(async { Ok(response) })
+            Ok(response)
+        })
     }
 }
 
-/// Embedded explorer UI files.
-#[derive(RustEmbed)]
-#[folder = "ui/dist"]
-struct ExplorerAssets;
+impl<S> ExplorerService<S> {
+    async fn serve_asset(
+        config: &ExplorerConfig,
+        cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
+        path: &str,
+    ) -> Option<Response<Body>> {
+        match &config.mode {
+            ExplorerMode::FileSystem { ui_path, hot_reload } => {
+                Self::serve_from_filesystem(config, cache, ui_path, path, *hot_reload).await
+            }
+            ExplorerMode::Embedded => Self::serve_embedded(config, path).await,
+            ExplorerMode::Proxy { .. } => {
+                // For now, we'll implement a simple fallback to embedded
+                // Full proxy implementation would require an HTTP client
+                warn!("Proxy mode not fully implemented, falling back to embedded");
+                Self::serve_embedded(config, path).await
+            }
+        }
+    }
 
-/// This function adds a script tag to the HTML that sets up environment variables
-/// for the explorer to use.
-fn setup_env(html: &str, chain_id: &str) -> String {
-    let escaped_chain_id = chain_id.replace("\"", "\\\"").replace("<", "&lt;").replace(">", "&gt;");
+    async fn serve_from_filesystem(
+        config: &ExplorerConfig,
+        cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
+        ui_path: &Path,
+        path: &str,
+        hot_reload: bool,
+    ) -> Option<Response<Body>> {
+        let file_path = if path.is_empty() || path == "/" {
+            ui_path.join("index.html")
+        } else if Self::is_static_asset_path(path) {
+            ui_path.join(path)
+        } else {
+            // SPA fallback - serve index.html for routes
+            ui_path.join("index.html")
+        };
 
-    // We inject the chain ID into the HTML for the controller to use.
-    // The chain id is a required param to initialize the controller <https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L32>.
-    // The parameters are consumed by the explorer here <https://github.com/cartridge-gg/explorer/blob/68ac4ea9500a90abc0d7c558440a99587cb77585/src/constants/rpc.ts#L14-L15>.
+        // Try cache first (if hot reload is disabled or for performance)
+        if hot_reload {
+            let cache_read = cache.read().await;
+            if let Some(entry) = cache_read.get(path) {
+                if let Ok(metadata) = std::fs::metadata(&file_path) {
+                    if let Ok(modified) = metadata.modified() {
+                        if modified <= entry.last_modified {
+                            debug!("Serving {} from cache", path);
+                            return Some(Self::create_response(
+                                config,
+                                &entry.content_type,
+                                entry.content.clone(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
 
-    // NOTE: ENABLE_CONTROLLER feature flag is a temporary solution to handle the controller.
-    // The controller expects to have a `defaultChainId` but we don't have a way
-    // to set it in the explorer yet in development mode (locally running katana instance).
-    // The temporary solution is to disable the controller by setting the ENABLE_CONTROLLER flag to
-    // false for these explorers. Once we have an updated controller JS SDK which can handle the
-    // chain ID of local katana instances then we can remove this flag value. (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L57)
-    // TODO: remove the ENABLE_CONTROLLER flag once we have a proper way to handle the chain ID for
-    // local katana instances.
-    let script = format!(
-        r#"<script>
+        // Read from filesystem
+        match tokio::fs::read(&file_path).await {
+            Ok(content) => {
+                let content_type = Self::get_content_type(&file_path.to_string_lossy());
+                let processed_content = if content_type == "text/html" {
+                    let html = String::from_utf8_lossy(&content);
+                    let injected = Self::inject_environment(&html, config);
+                    Bytes::from(injected)
+                } else {
+                    Bytes::from(content)
+                };
+
+                // Update cache if hot reload is enabled
+                if hot_reload {
+                    let mut cache_write = cache.write().await;
+                    cache_write.insert(
+                        path.to_string(),
+                        CacheEntry {
+                            content: processed_content.clone(),
+                            content_type: content_type.to_string(),
+                            last_modified: SystemTime::now(),
+                        },
+                    );
+                }
+
+                debug!("Serving {} from filesystem: {}", path, file_path.display());
+                Some(Self::create_response(config, content_type, processed_content))
+            }
+            Err(e) => {
+                debug!("Failed to read file {}: {}", file_path.display(), e);
+
+                // Fallback to embedded if filesystem fails
+                #[cfg(feature = "embedded-ui")]
+                {
+                    warn!("Falling back to embedded assets for: {}", path);
+                    Self::serve_embedded(config, path).await
+                }
+                #[cfg(not(feature = "embedded-ui"))]
+                None
+            }
+        }
+    }
+
+    async fn serve_embedded(config: &ExplorerConfig, path: &str) -> Option<Response<Body>> {
+        #[cfg(feature = "embedded-ui")]
+        {
+            let asset_path = if path.is_empty() || path == "/" {
+                "index.html"
+            } else if Self::is_static_asset_path(path) && EmbeddedAssets::get(path).is_some() {
+                path
+            } else {
+                "index.html" // SPA fallback
+            };
+
+            if let Some(asset) = EmbeddedAssets::get(asset_path) {
+                let content_type = Self::get_content_type(&format!("/{}", asset_path));
+                let content = if content_type == "text/html" {
+                    let html = String::from_utf8_lossy(&asset.data);
+                    let injected = Self::inject_environment(&html, config);
+                    Bytes::from(injected)
+                } else {
+                    Bytes::copy_from_slice(&asset.data)
+                };
+
+                debug!("Serving {} from embedded assets", asset_path);
+                return Some(Self::create_response(config, content_type, content));
+            }
+        }
+
+        #[cfg(not(feature = "embedded-ui"))]
+        {
+            let _ = (config, path); // Silence unused warnings
+        }
+
+        None
+    }
+
+    fn create_response(
+        config: &ExplorerConfig,
+        content_type: &str,
+        content: Bytes,
+    ) -> Response<Body> {
+        let mut response =
+            Response::builder().status(StatusCode::OK).header("Content-Type", content_type);
+
+        // Add caching headers
+        let cache_control = Self::get_cache_control(content_type);
+        response = response.header("Cache-Control", cache_control);
+
+        // Add security headers
+        if config.security_headers {
+            for (key, value) in Self::get_security_headers().iter() {
+                response = response.header(key, value);
+            }
+        }
+
+        // Add CORS headers
+        if config.cors_enabled {
+            response = response.header("Access-Control-Allow-Origin", "*");
+            response = response.header("Access-Control-Allow-Methods", "GET, OPTIONS");
+            response = response.header("Access-Control-Allow-Headers", "Content-Type");
+        }
+
+        // Add custom headers
+        for (key, value) in &config.custom_headers {
+            response = response.header(key, value);
+        }
+
+        response.body(Body::from(content.to_vec())).unwrap()
+    }
+
+    fn create_404_response() -> Response<Body> {
+        Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .header("Content-Type", "text/plain")
+            .body(Body::from("Explorer UI not found"))
+            .unwrap()
+    }
+
+    fn inject_environment(html: &str, config: &ExplorerConfig) -> String {
+        let mut env_vars = config.ui_env.clone();
+        env_vars.insert("CHAIN_ID".to_string(), serde_json::Value::String(config.chain_id.clone()));
+        env_vars.insert("ENABLE_CONTROLLER".to_string(), serde_json::Value::Bool(false));
+
+        let env_json = serde_json::to_string(&env_vars).unwrap_or_default();
+        let script = format!(
+            r#"<script>
+                window.KATANA_CONFIG = {};
+                // Backward compatibility
                 window.CHAIN_ID = "{}";
                 window.ENABLE_CONTROLLER = false;
             </script>"#,
-        escaped_chain_id,
-    );
+            env_json, config.chain_id
+        );
 
-    if let Some(head_pos) = html.find("<head>") {
-        let (start, end) = html.split_at(head_pos + 6);
-        format!("{}{}{}", start, script, end)
-    } else {
-        format!("{}\n{}", script, html)
+        if let Some(head_pos) = html.find("<head>") {
+            let (start, end) = html.split_at(head_pos + 6);
+            format!("{}{}{}", start, script, end)
+        } else {
+            format!("{}\n{}", script, html)
+        }
+    }
+
+    fn get_content_type(path: &str) -> &'static str {
+        match path.rsplit('.').next() {
+            Some("html") => "text/html; charset=utf-8",
+            Some("js") => "application/javascript; charset=utf-8",
+            Some("mjs") => "application/javascript; charset=utf-8",
+            Some("css") => "text/css; charset=utf-8",
+            Some("png") => "image/png",
+            Some("jpg") | Some("jpeg") => "image/jpeg",
+            Some("gif") => "image/gif",
+            Some("svg") => "image/svg+xml",
+            Some("json") => "application/json; charset=utf-8",
+            Some("ico") => "image/x-icon",
+            Some("woff") => "font/woff",
+            Some("woff2") => "font/woff2",
+            Some("ttf") => "font/ttf",
+            Some("eot") => "application/vnd.ms-fontobject",
+            Some("webp") => "image/webp",
+            Some("avif") => "image/avif",
+            _ => "application/octet-stream",
+        }
+    }
+
+    fn get_cache_control(content_type: &str) -> &'static str {
+        if content_type.starts_with("text/html") {
+            "no-cache, must-revalidate" // Always check HTML files
+        } else if content_type.starts_with("application/javascript")
+            || content_type.starts_with("text/css")
+        {
+            "public, max-age=31536000, immutable" // 1 year for JS/CSS (assuming they're hashed)
+        } else {
+            "public, max-age=3600" // 1 hour for other assets
+        }
+    }
+
+    fn get_security_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
+        headers.insert("X-Content-Type-Options", HeaderValue::from_static("nosniff"));
+        headers
+            .insert("Referrer-Policy", HeaderValue::from_static("strict-origin-when-cross-origin"));
+        headers.insert(
+            "Content-Security-Policy",
+            HeaderValue::from_static(
+                "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src \
+                 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:;",
+            ),
+        );
+        headers
+    }
+
+    fn is_static_asset_path(path: &str) -> bool {
+        !path.is_empty()
+            && (path.ends_with(".js")
+                || path.ends_with(".mjs")
+                || path.ends_with(".css")
+                || path.ends_with(".png")
+                || path.ends_with(".jpg")
+                || path.ends_with(".jpeg")
+                || path.ends_with(".gif")
+                || path.ends_with(".svg")
+                || path.ends_with(".json")
+                || path.ends_with(".ico")
+                || path.ends_with(".woff")
+                || path.ends_with(".woff2")
+                || path.ends_with(".ttf")
+                || path.ends_with(".eot")
+                || path.ends_with(".webp")
+                || path.ends_with(".avif"))
     }
 }
 
-/// Gets the content type for a file based on its extension.
-fn get_content_type(path: &str) -> &'static str {
-    match path.rsplit('.').next() {
-        Some("html") => "text/html",
-        Some("js") => "application/javascript",
-        Some("css") => "text/css",
-        Some("png") => "image/png",
-        Some("svg") => "image/svg+xml",
-        Some("json") => "application/json",
-        Some("ico") => "image/x-icon",
-        Some("woff") => "font/woff",
-        Some("woff2") => "font/woff2",
-        Some("ttf") => "font/ttf",
-        Some("eot") => "application/vnd.ms-fontobject",
-        _ => "application/octet-stream",
+/// Embedded explorer UI files (only available with embedded-ui feature)
+#[cfg(feature = "embedded-ui")]
+#[derive(rust_embed::RustEmbed)]
+#[folder = "ui/dist"]
+struct EmbeddedAssets;
+
+/// Stub for when embedded-ui feature is disabled
+#[cfg(not(feature = "embedded-ui"))]
+struct EmbeddedAssets;
+
+#[cfg(not(feature = "embedded-ui"))]
+impl EmbeddedAssets {
+    fn get(_path: &str) -> Option<EmbeddedFile> {
+        None
     }
 }
 
-/// Checks if the given path is a path to a static asset.
-fn is_static_asset_path(path: &str) -> bool {
-    !path.is_empty()
-        && (path.ends_with(".js")
-            || path.ends_with(".css")
-            || path.ends_with(".png")
-            || path.ends_with(".svg")
-            || path.ends_with(".json")
-            || path.ends_with(".ico")
-            || path.ends_with(".woff")
-            || path.ends_with(".woff2")
-            || path.ends_with(".ttf")
-            || path.ends_with(".eot"))
+#[cfg(not(feature = "embedded-ui"))]
+struct EmbeddedFile;
+
+#[cfg(not(feature = "embedded-ui"))]
+impl EmbeddedFile {
+    pub fn data(&self) -> &[u8] {
+        &[]
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use tempfile::TempDir;
+    use tokio::fs;
+
     use super::*;
 
     #[test]
     fn test_get_content_type() {
-        assert_eq!(get_content_type("index.html"), "text/html");
-        assert_eq!(get_content_type("app.js"), "application/javascript");
-        assert_eq!(get_content_type("styles.css"), "text/css");
-        assert_eq!(get_content_type("logo.png"), "image/png");
-        assert_eq!(get_content_type("icon.svg"), "image/svg+xml");
-        assert_eq!(get_content_type("data.json"), "application/json");
-        assert_eq!(get_content_type("favicon.ico"), "image/x-icon");
-        assert_eq!(get_content_type("font.woff"), "font/woff");
-        assert_eq!(get_content_type("font.woff2"), "font/woff2");
-        assert_eq!(get_content_type("font.ttf"), "font/ttf");
-        assert_eq!(get_content_type("font.eot"), "application/vnd.ms-fontobject");
-        assert_eq!(get_content_type("unknown.xyz"), "application/octet-stream");
-        assert_eq!(get_content_type("no_extension"), "application/octet-stream");
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("index.html"),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("app.js"),
+            "application/javascript; charset=utf-8"
+        );
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("app.mjs"),
+            "application/javascript; charset=utf-8"
+        );
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("styles.css"),
+            "text/css; charset=utf-8"
+        );
+        assert_eq!(ExplorerService::<()>::get_content_type("logo.png"), "image/png");
+        assert_eq!(ExplorerService::<()>::get_content_type("photo.jpg"), "image/jpeg");
+        assert_eq!(ExplorerService::<()>::get_content_type("icon.svg"), "image/svg+xml");
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("data.json"),
+            "application/json; charset=utf-8"
+        );
+        assert_eq!(ExplorerService::<()>::get_content_type("favicon.ico"), "image/x-icon");
+        assert_eq!(ExplorerService::<()>::get_content_type("font.woff"), "font/woff");
+        assert_eq!(ExplorerService::<()>::get_content_type("font.woff2"), "font/woff2");
+        assert_eq!(ExplorerService::<()>::get_content_type("font.ttf"), "font/ttf");
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("font.eot"),
+            "application/vnd.ms-fontobject"
+        );
+        assert_eq!(ExplorerService::<()>::get_content_type("image.webp"), "image/webp");
+        assert_eq!(ExplorerService::<()>::get_content_type("image.avif"), "image/avif");
+        assert_eq!(
+            ExplorerService::<()>::get_content_type("unknown.xyz"),
+            "application/octet-stream"
+        );
     }
 
     #[test]
     fn test_is_static_asset_path() {
-        // Valid static assets
-        assert!(is_static_asset_path("app.js"));
-        assert!(is_static_asset_path("styles.css"));
-        assert!(is_static_asset_path("logo.png"));
-        assert!(is_static_asset_path("icon.svg"));
-        assert!(is_static_asset_path("data.json"));
-        assert!(is_static_asset_path("favicon.ico"));
-        assert!(is_static_asset_path("font.woff"));
-        assert!(is_static_asset_path("font.woff2"));
-        assert!(is_static_asset_path("font.ttf"));
-        assert!(is_static_asset_path("font.eot"));
+        assert!(ExplorerService::<()>::is_static_asset_path("app.js"));
+        assert!(ExplorerService::<()>::is_static_asset_path("app.mjs"));
+        assert!(ExplorerService::<()>::is_static_asset_path("styles.css"));
+        assert!(ExplorerService::<()>::is_static_asset_path("logo.png"));
+        assert!(ExplorerService::<()>::is_static_asset_path("icon.svg"));
+        assert!(ExplorerService::<()>::is_static_asset_path("data.json"));
+        assert!(ExplorerService::<()>::is_static_asset_path("assets/js/app.js"));
 
-        // Nested paths
-        assert!(is_static_asset_path("assets/js/app.js"));
-        assert!(is_static_asset_path("css/main.css"));
-
-        // Invalid static assets
-        assert!(!is_static_asset_path(""));
-        assert!(!is_static_asset_path("index.html"));
-        assert!(!is_static_asset_path("page"));
-        assert!(!is_static_asset_path("unknown.txt"));
-        assert!(!is_static_asset_path("file.xml"));
+        assert!(!ExplorerService::<()>::is_static_asset_path(""));
+        assert!(!ExplorerService::<()>::is_static_asset_path("index.html"));
+        assert!(!ExplorerService::<()>::is_static_asset_path("page"));
+        assert!(!ExplorerService::<()>::is_static_asset_path("unknown.txt"));
     }
 
     #[test]
-    fn test_setup_env_basic_injection() {
+    fn test_inject_environment() {
         let html = "<html><head></head><body></body></html>";
-        let chain_id = "KATANA";
-        let result = setup_env(html, chain_id);
+        let config = ExplorerConfig {
+            chain_id: "TEST_CHAIN".to_string(),
+            ui_env: {
+                let mut env = HashMap::new();
+                env.insert("DEBUG".to_string(), serde_json::Value::Bool(true));
+                env
+            },
+            ..Default::default()
+        };
 
-        assert!(result.contains("window.CHAIN_ID = \"KATANA\";"));
-        assert!(result.contains("window.ENABLE_CONTROLLER = false;"));
-        assert!(result.contains("<head><script>"));
+        let result = ExplorerService::<()>::inject_environment(html, &config);
+
+        assert!(result.contains("window.KATANA_CONFIG"));
+        assert!(result.contains("\"CHAIN_ID\":\"TEST_CHAIN\""));
+        assert!(result.contains("\"DEBUG\":true"));
+        assert!(result.contains("window.CHAIN_ID = \"TEST_CHAIN\""));
     }
 
     #[test]
-    fn test_setup_env_escapes_chain_id() {
-        let html = "<html><head></head><body></body></html>";
+    fn test_explorer_config_default() {
+        let config = ExplorerConfig::default();
+        assert_eq!(config.chain_id, "KATANA");
+        assert_eq!(config.path_prefix, "/explorer");
+        assert!(!config.cors_enabled);
+        assert!(config.security_headers);
+    }
 
-        // Test escaping quotes
-        let chain_id = "CHAIN\"WITH\"QUOTES";
-        let result = setup_env(html, chain_id);
-        assert!(result.contains("window.CHAIN_ID = \"CHAIN\\\"WITH\\\"QUOTES\";"));
+    #[tokio::test]
+    async fn test_filesystem_mode_with_temp_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let ui_path = temp_dir.path().to_path_buf();
 
-        // Test escaping HTML characters
-        let chain_id = "CHAIN<WITH>TAGS";
-        let result = setup_env(html, chain_id);
-        assert!(result.contains("window.CHAIN_ID = \"CHAIN&lt;WITH&gt;TAGS\";"));
+        // Create a simple index.html
+        let index_content = r#"<html><head></head><body><h1>Test UI</h1></body></html>"#;
+        fs::write(ui_path.join("index.html"), index_content).await.unwrap();
+
+        // Create config
+        let config = ExplorerConfig {
+            mode: ExplorerMode::FileSystem { ui_path: ui_path.clone(), hot_reload: false },
+            chain_id: "TEST".to_string(),
+            ..Default::default()
+        };
+
+        // Test layer creation
+        let layer = ExplorerLayer::new(config).unwrap();
+        assert!(matches!(layer.config.mode, ExplorerMode::FileSystem { .. }));
     }
 
     #[test]
-    fn test_setup_env_no_head_tag() {
-        let html = "<html><body></body></html>";
-        let chain_id = "KATANA";
-        let result = setup_env(html, chain_id);
+    fn test_explorer_layer_embedded_without_assets() {
+        // This should fail if embedded-ui feature is disabled and no assets
+        let result = ExplorerLayer::embedded("TEST".to_string());
 
-        assert!(result.starts_with("<script>"));
-        assert!(result.contains("window.CHAIN_ID = \"KATANA\";"));
-    }
+        #[cfg(feature = "embedded-ui")]
+        {
+            // With embedded-ui feature, this might pass or fail depending on whether assets exist
+            // We just test that it doesn't panic
+            let _ = result;
+        }
 
-    #[test]
-    fn test_setup_env_preserves_html_structure() {
-        let html = "<html><head><title>Test</title></head><body><h1>Hello</h1></body></html>";
-        let chain_id = "KATANA";
-        let result = setup_env(html, chain_id);
-
-        assert!(result.contains("<title>Test</title>"));
-        assert!(result.contains("<h1>Hello</h1>"));
-        assert!(result.contains("window.CHAIN_ID = \"KATANA\";"));
-    }
-
-    #[test]
-    fn test_explorer_layer_new_with_assets() {
-        // This test verifies that ExplorerLayer::new works when assets are available
-        // The build.rs script may have built assets, so this might succeed
-        let result = ExplorerLayer::new("test-chain".to_string());
-
-        // The test can succeed or fail depending on whether assets were built
-        // What matters is that we get the expected behavior in each case
-        match result {
-            Ok(layer) => {
-                // If assets are available, we should get a layer with the correct chain_id
-                assert_eq!(layer.chain_id, "test-chain");
-            }
-            Err(err) => {
-                // If assets are not available, we should get the expected error
-                assert!(err.to_string().contains("Explorer assets not found"));
-            }
+        #[cfg(not(feature = "embedded-ui"))]
+        {
+            assert!(result.is_err());
         }
     }
+
+    // Mock service tests would go here - similar to the previous implementation
+    // but adapted for the new architecture
 }

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -1,3 +1,45 @@
+//! # Katana Explorer
+//!
+//! A flexible Tower middleware for serving the Katana blockchain explorer UI with multiple
+//! deployment modes including hot reload for development and embedded assets for production.
+//!
+//! ## Features
+//!
+//! - **Hot Reload**: Real-time UI updates during development
+//! - **Multiple Serving Modes**: Embedded, FileSystem, and Proxy
+//! - **Security Headers**: Production-ready security configuration
+//! - **Caching**: Intelligent file caching with invalidation
+//! - **SPA Support**: Single Page Application routing
+//! - **Builder Pattern**: Ergonomic configuration API
+//!
+//! ## Quick Start
+//!
+//! ```rust,no_run
+//! use katana_explorer::ExplorerLayer;
+//!
+//! // Development mode with hot reload
+//! let dev_layer = ExplorerLayer::builder().development().chain_id("KATANA_DEV").build()?;
+//!
+//! // Production mode with embedded assets
+//! let prod_layer = ExplorerLayer::builder().production().chain_id("KATANA_PROD").build()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! ## Serving Modes
+//!
+//! - [`ExplorerMode::Embedded`]: Serves pre-built UI assets embedded in the binary
+//! - [`ExplorerMode::FileSystem`]: Serves UI files from disk with optional hot reload
+//! - [`ExplorerMode::Proxy`]: Proxies requests to an external development server (planned)
+//!
+//! ## Integration with Tower
+//!
+//! ```rust,no_run
+//! use katana_explorer::ExplorerLayer;
+//! use tower::ServiceBuilder;
+//!
+//! let service = ServiceBuilder::new().layer(explorer_layer).service_fn(your_main_service);
+//! ```
+
 use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -55,35 +97,149 @@ impl http_body::Body for Body {
     }
 }
 
-/// Explorer serving mode configuration
+/// Explorer serving mode configuration.
+///
+/// Determines how the Explorer UI assets are served to clients. Each mode has different
+/// performance characteristics and is suited for different deployment scenarios.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExplorerMode {
-    /// Serve embedded assets (production mode)
+    /// Serve pre-built UI assets embedded in the binary.
+    ///
+    /// **Best for**: Production deployments where assets don't change.
+    ///
+    /// **Requires**: The `embedded-ui` feature must be enabled and UI assets must be
+    /// built during compilation via the build script.
+    ///
+    /// **Performance**: Fastest serving as assets are loaded from memory.
     Embedded,
-    /// Serve from filesystem with optional hot reload (development mode)
-    FileSystem { ui_path: PathBuf, hot_reload: bool },
-    /// Proxy to external development server
-    Proxy { upstream_url: Url, inject_env: bool },
+
+    /// Serve UI files from the filesystem with optional hot reload.
+    ///
+    /// **Best for**: Development and scenarios where UI can be updated without recompilation.
+    ///
+    /// **Requires**: The specified `ui_path` must exist and contain built UI assets.
+    /// When `hot_reload` is enabled, file system watching is used to detect changes.
+    ///
+    /// **Performance**: Slightly slower than embedded mode due to file I/O, but supports
+    /// intelligent caching and hot reload for development efficiency.
+    FileSystem {
+        /// Path to the directory containing built UI assets (must contain index.html).
+        ui_path: PathBuf,
+        /// Enable real-time file watching and cache invalidation for development.
+        hot_reload: bool,
+    },
+
+    /// Proxy requests to an external development server.
+    ///
+    /// **Best for**: Development with separate UI development server (e.g., Vite dev server).
+    ///
+    /// **Status**: Planned feature - currently falls back to embedded mode.
+    ///
+    /// **Future**: Will support proxying to upstream servers like `http://localhost:3000`.
+    Proxy {
+        /// URL of the upstream development server.
+        upstream_url: Url,
+        /// Whether to inject environment variables into HTML responses.
+        inject_env: bool,
+    },
 }
 
-/// Explorer configuration
+/// Comprehensive configuration for the Explorer UI server.
+///
+/// This struct contains all settings needed to configure how the Explorer UI is served,
+/// including the serving mode, security settings, and custom environment variables.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use std::collections::HashMap;
+/// use std::path::PathBuf;
+///
+/// use katana_explorer::{ExplorerConfig, ExplorerMode};
+///
+/// // Development configuration
+/// let dev_config = ExplorerConfig {
+///     mode: ExplorerMode::FileSystem { ui_path: PathBuf::from("./ui/dist"), hot_reload: true },
+///     chain_id: "KATANA_DEV".to_string(),
+///     cors_enabled: true,
+///     security_headers: false,
+///     ..Default::default()
+/// };
+///
+/// // Production configuration
+/// let prod_config = ExplorerConfig {
+///     mode: ExplorerMode::Embedded,
+///     chain_id: "KATANA_PROD".to_string(),
+///     security_headers: true,
+///     ..Default::default()
+/// };
+/// ```
+///
+/// ## Recommendations
+///
+/// - Use [`ExplorerLayer::builder()`] for a more ergonomic configuration experience
+/// - Enable `hot_reload` only in development environments
+/// - Always enable `security_headers` in production
+/// - Use `cors_enabled` carefully - only enable when necessary for development
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExplorerConfig {
-    /// Serving mode
+    /// The serving mode determining how UI assets are provided to clients.
     pub mode: ExplorerMode,
-    /// Chain ID to inject into the UI
+
+    /// Blockchain chain ID to inject into the UI environment.
+    ///
+    /// This value is made available to the UI via `window.CHAIN_ID` and
+    /// `window.KATANA_CONFIG.CHAIN_ID` for blockchain connections.
     pub chain_id: String,
-    /// URL path prefix (default: "/explorer")
+
+    /// URL path prefix for all Explorer routes.
+    ///
+    /// **Default**: `"/explorer"`
+    ///
+    /// All Explorer requests must start with this prefix. For example, with the default
+    /// prefix, the Explorer UI is available at `/explorer` and static assets at
+    /// `/explorer/assets/*`.
     pub path_prefix: String,
-    /// Enable CORS headers
+
+    /// Enable Cross-Origin Resource Sharing (CORS) headers.
+    ///
+    /// **Security Note**: Only enable in development or when explicitly needed.
+    /// Enabling CORS allows requests from any origin.
+    ///
+    /// **Default**: `false`
     pub cors_enabled: bool,
-    /// Enable security headers
+
+    /// Enable production security headers.
+    ///
+    /// When enabled, adds headers like `X-Frame-Options`, `X-Content-Type-Options`,
+    /// `Content-Security-Policy`, etc.
+    ///
+    /// **Recommendation**: Always enable in production, disable in development for easier
+    /// debugging.
+    ///
+    /// **Default**: `true`
     pub security_headers: bool,
-    /// Enable compression
+
+    /// Enable asset compression (future feature).
+    ///
+    /// **Status**: Not yet implemented.
+    ///
+    /// **Default**: `false`
     pub compression: bool,
-    /// Custom headers to add to responses
+
+    /// Custom HTTP headers to add to all responses.
+    ///
+    /// Useful for adding environment-specific headers like `X-Environment: staging`
+    /// or API versioning headers.
     pub custom_headers: HashMap<String, String>,
-    /// Custom environment variables to inject into UI
+
+    /// Custom environment variables to inject into the UI.
+    ///
+    /// These variables are made available to the UI via `window.KATANA_CONFIG`.
+    /// Common use cases include API endpoints, feature flags, and theme settings.
+    ///
+    /// **Note**: The `CHAIN_ID` and `ENABLE_CONTROLLER` variables are automatically
+    /// injected and don't need to be specified here.
     pub ui_env: HashMap<String, serde_json::Value>,
 }
 
@@ -102,21 +258,92 @@ impl Default for ExplorerConfig {
     }
 }
 
-/// File cache entry for hot reload functionality
+/// File cache entry for hot reload functionality.
+///
+/// Stores cached file content along with metadata for efficient serving
+/// and change detection in FileSystem mode with hot reload enabled.
 #[derive(Debug, Clone)]
 struct CacheEntry {
+    /// The cached file content.
     content: Bytes,
+    /// The MIME content type for HTTP response headers.
     content_type: String,
+    /// Last modification time for cache invalidation.
     last_modified: SystemTime,
 }
 
-/// Explorer layer for Tower middleware
+/// Tower layer for serving the Katana Explorer UI.
+///
+/// This layer intercepts HTTP requests matching the configured path prefix and serves
+/// the Explorer UI assets, while passing through all other requests to the inner service.
+///
+/// ## Usage
+///
+/// ```rust,no_run
+/// use katana_explorer::ExplorerLayer;
+/// use tower::ServiceBuilder;
+///
+/// // Using builder pattern (recommended)
+/// let layer = ExplorerLayer::builder()
+///     .development()           // or .production()
+///     .chain_id("KATANA")
+///     .build()?;
+///
+/// // Integrate with Tower service stack
+/// let service = ServiceBuilder::new().layer(layer).service_fn(your_main_service);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// ## Path Handling
+///
+/// - Requests to `{path_prefix}/*` are handled by the Explorer
+/// - All other requests pass through to the inner service
+/// - Static assets are served directly, SPA routes serve `index.html`
+///
+/// ## Error Conditions
+///
+/// Layer creation fails if:
+/// - Embedded mode is selected but no assets are available
+/// - FileSystem mode is selected but the UI path doesn't exist
+/// - Invalid configuration is provided
 #[derive(Debug, Clone)]
 pub struct ExplorerLayer {
     config: ExplorerConfig,
 }
 
 impl ExplorerLayer {
+    /// Create a new ExplorerLayer with the given configuration.
+    ///
+    /// ## Validation
+    ///
+    /// This method validates the provided configuration:
+    /// - For `Embedded` mode: Checks that UI assets are available
+    /// - For `FileSystem` mode: Verifies the UI path exists
+    /// - For `Proxy` mode: Logs the upstream configuration
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use std::path::PathBuf;
+    ///
+    /// use katana_explorer::{ExplorerConfig, ExplorerLayer, ExplorerMode};
+    ///
+    /// let config = ExplorerConfig {
+    ///     mode: ExplorerMode::FileSystem { ui_path: PathBuf::from("./ui/dist"), hot_reload: true },
+    ///     chain_id: "KATANA".to_string(),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let layer = ExplorerLayer::new(config)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if:
+    /// - Embedded mode is selected but `embedded-ui` feature is disabled or no assets exist
+    /// - FileSystem mode is selected but the specified path doesn't exist
+    /// - Invalid URLs are provided in proxy mode
     pub fn new(config: ExplorerConfig) -> Result<Self> {
         // Validate configuration
         match &config.mode {
@@ -155,17 +382,99 @@ impl ExplorerLayer {
         Ok(Self { config })
     }
 
-    /// Create a builder for more ergonomic configuration
+    /// Create a builder for ergonomic layer configuration.
+    ///
+    /// The builder pattern provides a fluent API with sensible defaults and preset methods
+    /// for common use cases. This is the recommended way to create an `ExplorerLayer`.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Development mode with hot reload
+    /// let dev_layer = ExplorerLayer::builder().development().chain_id("KATANA_DEV").build()?;
+    ///
+    /// // Custom configuration
+    /// let custom_layer = ExplorerLayer::builder()
+    ///     .chain_id("KATANA")
+    ///     .filesystem_with_hot_reload("./ui/dist")
+    ///     .with_cors()
+    ///     .debug()
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// See [`ExplorerLayerBuilder`] for all available configuration methods.
     pub fn builder() -> ExplorerLayerBuilder {
         ExplorerLayerBuilder::new()
     }
 
-    /// Create a new ExplorerLayer with embedded mode
+    /// Create an ExplorerLayer with embedded assets mode.
+    ///
+    /// This is a convenience method for production deployments where UI assets
+    /// are embedded in the binary.
+    ///
+    /// ## Requirements
+    ///
+    /// - The `embedded-ui` feature must be enabled (default)
+    /// - UI assets must be available (built during compilation)
+    ///
+    /// ## Equivalent to
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // These are equivalent:
+    /// let layer1 = ExplorerLayer::embedded("KATANA".to_string())?;
+    /// let layer2 = ExplorerLayer::builder().production().chain_id("KATANA").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if embedded assets are not available.
     pub fn embedded(chain_id: String) -> Result<Self> {
         Self::new(ExplorerConfig { mode: ExplorerMode::Embedded, chain_id, ..Default::default() })
     }
 
-    /// Create a new ExplorerLayer with filesystem mode
+    /// Create an ExplorerLayer with filesystem mode.
+    ///
+    /// This convenience method configures the layer to serve UI files from the specified
+    /// directory with optional hot reload for development.
+    ///
+    /// ## Parameters
+    ///
+    /// - `ui_path`: Directory containing built UI assets (must contain `index.html`)
+    /// - `chain_id`: Blockchain chain ID to inject into the UI
+    /// - `hot_reload`: Enable file watching and automatic cache invalidation
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use std::path::PathBuf;
+    ///
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Development with hot reload
+    /// let dev_layer = ExplorerLayer::filesystem(
+    ///     PathBuf::from("./ui/dist"),
+    ///     "KATANA_DEV".to_string(),
+    ///     true, // hot_reload
+    /// )?;
+    ///
+    /// // Static filesystem serving
+    /// let static_layer = ExplorerLayer::filesystem(
+    ///     PathBuf::from("/var/www/explorer"),
+    ///     "KATANA_PROD".to_string(),
+    ///     false, // no hot reload
+    /// )?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the specified UI path doesn't exist.
     pub fn filesystem(ui_path: PathBuf, chain_id: String, hot_reload: bool) -> Result<Self> {
         Self::new(ExplorerConfig {
             mode: ExplorerMode::FileSystem { ui_path, hot_reload },
@@ -174,7 +483,31 @@ impl ExplorerLayer {
         })
     }
 
-    /// Create a new ExplorerLayer with proxy mode  
+    /// Create an ExplorerLayer with proxy mode.
+    ///
+    /// This convenience method configures the layer to proxy requests to an external
+    /// development server (e.g., Vite dev server).
+    ///
+    /// ## Status
+    ///
+    /// **Note**: Proxy mode is not fully implemented yet and currently falls back
+    /// to embedded mode. This method is provided for future compatibility.
+    ///
+    /// ## Parameters
+    ///
+    /// - `upstream_url`: URL of the development server to proxy to
+    /// - `chain_id`: Blockchain chain ID to inject into proxied HTML responses
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    /// use url::Url;
+    ///
+    /// let proxy_layer =
+    ///     ExplorerLayer::proxy(Url::parse("http://localhost:3000")?, "KATANA_DEV".to_string())?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn proxy(upstream_url: Url, chain_id: String) -> Result<Self> {
         Self::new(ExplorerConfig {
             mode: ExplorerMode::Proxy { upstream_url, inject_env: true },
@@ -184,30 +517,149 @@ impl ExplorerLayer {
     }
 }
 
-/// Builder for creating ExplorerLayer with a fluent API
+/// Fluent builder for creating [`ExplorerLayer`] with ergonomic configuration.
+///
+/// The builder provides a convenient API with method chaining, sensible defaults,
+/// and preset configurations for common use cases. This is the recommended way
+/// to configure the Explorer layer.
+///
+/// ## Design Philosophy
+///
+/// - **Preset Methods**: `.development()` and `.production()` provide opinionated defaults
+/// - **Fluent API**: All methods return `Self` for easy chaining
+/// - **Type Safety**: Invalid configurations are caught at compile time
+/// - **Discoverability**: Method names clearly indicate their purpose
+///
+/// ## Basic Usage
+///
+/// ```rust,no_run
+/// use katana_explorer::ExplorerLayer;
+///
+/// // Start with a preset and customize as needed
+/// let layer = ExplorerLayer::builder()
+///     .development()           // Apply development defaults
+///     .chain_id("KATANA_DEV")  // Set required chain ID
+///     .ui_path("./my-ui")      // Override UI path if needed
+///     .build()?; // Create the layer
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// ## Advanced Usage
+///
+/// ```rust,no_run
+/// use katana_explorer::ExplorerLayer;
+///
+/// let layer = ExplorerLayer::builder()
+///     .chain_id("KATANA")
+///     .filesystem_with_hot_reload("./ui/dist")
+///     .cors(true)
+///     .security_headers(false)
+///     .ui_env("DEBUG", true)
+///     .ui_env("API_ENDPOINT", "/api/v2")
+///     .header("X-Environment", "development")
+///     .path_prefix("/blockchain-explorer")
+///     .build()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 #[derive(Debug, Clone)]
 pub struct ExplorerLayerBuilder {
     config: ExplorerConfig,
 }
 
 impl ExplorerLayerBuilder {
-    /// Create a new builder with default configuration
+    /// Create a new builder with default configuration.
+    ///
+    /// Initializes the builder with [`ExplorerConfig::default()`] values.
+    /// Use preset methods like [`development()`](Self::development) or
+    /// [`production()`](Self::production) for common configurations.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining (fluent API pattern).
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let builder = ExplorerLayer::builder(); // Same as ExplorerLayerBuilder::new()
+    /// ```
     pub fn new() -> Self {
         Self { config: ExplorerConfig::default() }
     }
 
-    /// Build the ExplorerLayer with current configuration
+    /// Build the ExplorerLayer with the current configuration.
+    ///
+    /// This method validates the configuration and creates the final [`ExplorerLayer`].
+    /// Configuration validation includes checking that UI paths exist and assets are
+    /// available for the selected mode.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Result<ExplorerLayer, anyhow::Error>` where errors indicate
+    /// configuration validation failures.
+    ///
+    /// ## Errors
+    ///
+    /// - **Embedded mode**: Returns error if `embedded-ui` feature is disabled or no assets exist
+    /// - **FileSystem mode**: Returns error if the specified UI path doesn't exist
+    /// - **Proxy mode**: Returns error if the upstream URL is invalid
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().development().chain_id("KATANA_DEV").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn build(self) -> Result<ExplorerLayer> {
         ExplorerLayer::new(self.config)
     }
 
     // === Preset Methods ===
 
-    /// Configure for development with sensible defaults
-    /// - FileSystem mode with hot reload enabled
-    /// - CORS enabled for development
-    /// - Security headers disabled for easier development
-    /// - UI path defaults to "./ui/dist"
+    /// Configure for development with sensible defaults.
+    ///
+    /// This preset is optimized for local development and debugging:
+    /// - **FileSystem mode** with hot reload enabled (path: `"./ui/dist"`)
+    /// - **CORS enabled** for cross-origin requests during development
+    /// - **Security headers disabled** for easier debugging
+    /// - **Compression disabled** for faster builds
+    ///
+    /// ## When to use
+    ///
+    /// Use this preset when developing locally and you need real-time UI updates.
+    /// The hot reload feature watches for file changes and automatically serves
+    /// updated assets.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let dev_layer = ExplorerLayer::builder().development().chain_id("KATANA_DEV").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Post-configuration
+    ///
+    /// You can further customize after calling this preset:
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let custom_dev = ExplorerLayer::builder()
+    ///     .development()
+    ///     .ui_path("./my-ui/build")  // Override default path
+    ///     .api_endpoint("/api/v2")   // Add custom API endpoint
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn development(mut self) -> Self {
         self.config.mode =
             ExplorerMode::FileSystem { ui_path: PathBuf::from("./ui/dist"), hot_reload: true };
@@ -217,11 +669,51 @@ impl ExplorerLayerBuilder {
         self
     }
 
-    /// Configure for production with sensible defaults
-    /// - Embedded mode for optimal performance
-    /// - Security headers enabled
-    /// - CORS disabled for security
-    /// - Compression enabled (future)
+    /// Configure for production with sensible defaults.
+    ///
+    /// This preset is optimized for production deployments:
+    /// - **Embedded mode** for optimal performance and self-contained deployment
+    /// - **Security headers enabled** for production security
+    /// - **CORS disabled** for security (only enable if needed)
+    /// - **Compression enabled** for reduced bundle sizes (future feature)
+    ///
+    /// ## When to use
+    ///
+    /// Use this preset for production deployments where performance and security
+    /// are priorities. The embedded mode serves assets from memory with no filesystem I/O.
+    ///
+    /// ## Requirements
+    ///
+    /// - The `embedded-ui` feature must be enabled (default)
+    /// - UI assets must be built and embedded during compilation
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let prod_layer = ExplorerLayer::builder().production().chain_id("KATANA_MAINNET").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Post-configuration
+    ///
+    /// You can customize security settings after calling this preset:
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let custom_prod = ExplorerLayer::builder()
+    ///     .production()
+    ///     .with_cors()  // Enable CORS if needed for production
+    ///     .header("X-Environment", "staging")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn production(mut self) -> Self {
         self.config.mode = ExplorerMode::Embedded;
         self.config.cors_enabled = false;
@@ -232,13 +724,61 @@ impl ExplorerLayerBuilder {
 
     // === Core Configuration ===
 
-    /// Set the chain ID (required)
+    /// Set the blockchain chain ID.
+    ///
+    /// The chain ID is injected into the UI environment as both `window.CHAIN_ID`
+    /// and `window.KATANA_CONFIG.CHAIN_ID` for the frontend to use when connecting
+    /// to the blockchain.
+    ///
+    /// ## Parameters
+    ///
+    /// - `chain_id`: The chain identifier (e.g., "KATANA", "KATANA_DEV", "SN_MAIN")
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().chain_id("KATANA_TESTNET").development().build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn chain_id<S: Into<String>>(mut self, chain_id: S) -> Self {
         self.config.chain_id = chain_id.into();
         self
     }
 
-    /// Set the URL path prefix (default: "/explorer")
+    /// Set the URL path prefix for all Explorer routes.
+    ///
+    /// All Explorer requests must start with this prefix. Static assets and UI routes
+    /// will be served under this path. The default prefix is `"/explorer"`.
+    ///
+    /// ## Parameters
+    ///
+    /// - `prefix`: URL path prefix (should start with `/`)
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // UI will be available at /ui/* instead of /explorer/*
+    /// let layer = ExplorerLayer::builder().path_prefix("/ui").development().build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Important Notes
+    ///
+    /// - The prefix should not end with `/` (e.g., use `/ui` not `/ui/`)
+    /// - Changing the prefix affects all Explorer routes including assets
+    /// - Make sure your frontend routing is configured for the new prefix
     pub fn path_prefix<S: Into<String>>(mut self, prefix: S) -> Self {
         self.config.path_prefix = prefix.into();
         self
@@ -246,35 +786,228 @@ impl ExplorerLayerBuilder {
 
     // === Serving Mode Configuration ===
 
-    /// Use embedded assets mode
+    /// Use embedded assets mode.
+    ///
+    /// In this mode, pre-built UI assets are served from memory. The assets must
+    /// be embedded during compilation via the build script and the `embedded-ui`
+    /// feature must be enabled.
+    ///
+    /// ## When to use
+    ///
+    /// - Production deployments for optimal performance
+    /// - Self-contained binaries where UI won't change
+    /// - When filesystem access is limited or not desired
+    ///
+    /// ## Requirements
+    ///
+    /// - `embedded-ui` feature enabled (default)
+    /// - UI assets must be built before compilation
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().embedded_mode().chain_id("KATANA").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Performance
+    ///
+    /// Embedded mode offers the best performance since assets are served directly
+    /// from memory with no filesystem I/O overhead.
     pub fn embedded_mode(mut self) -> Self {
         self.config.mode = ExplorerMode::Embedded;
         self
     }
 
-    /// Use filesystem mode with specified path and hot reload setting
+    /// Use filesystem mode with specified path and hot reload setting.
+    ///
+    /// In this mode, UI assets are served from the filesystem. The UI path must
+    /// exist and contain a built UI (including `index.html`).
+    ///
+    /// ## Parameters
+    ///
+    /// - `ui_path`: Path to directory containing built UI assets
+    /// - `hot_reload`: Whether to watch for file changes and invalidate cache
+    ///
+    /// ## When to use
+    ///
+    /// - Development when you need file watching (`hot_reload = true`)
+    /// - Production when UI assets are deployed separately (`hot_reload = false`)
+    /// - When you want to update UI without recompiling the binary
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use std::path::PathBuf;
+    ///
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Development with hot reload
+    /// let dev_layer =
+    ///     ExplorerLayer::builder().filesystem_mode("./ui/dist", true).chain_id("DEV").build()?;
+    ///
+    /// // Production from filesystem (no hot reload)
+    /// let prod_layer = ExplorerLayer::builder()
+    ///     .filesystem_mode("/var/www/explorer", false)
+    ///     .chain_id("PROD")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn filesystem_mode<P: Into<PathBuf>>(mut self, ui_path: P, hot_reload: bool) -> Self {
         self.config.mode = ExplorerMode::FileSystem { ui_path: ui_path.into(), hot_reload };
         self
     }
 
-    /// Use filesystem mode with hot reload enabled (common development case)
+    /// Use filesystem mode with hot reload enabled.
+    ///
+    /// This is a convenience method for the common development use case where you
+    /// want to serve from filesystem with automatic cache invalidation when files change.
+    ///
+    /// ## Parameters
+    ///
+    /// - `ui_path`: Path to directory containing built UI assets
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .filesystem_with_hot_reload("./ui/build")
+    ///     .chain_id("DEV")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Equivalent to
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .filesystem_mode("./ui/build", true)  // hot_reload = true
+    ///     .chain_id("DEV")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn filesystem_with_hot_reload<P: Into<PathBuf>>(self, ui_path: P) -> Self {
         self.filesystem_mode(ui_path, true)
     }
 
-    /// Use filesystem mode with hot reload disabled
+    /// Use filesystem mode with hot reload disabled.
+    ///
+    /// This is useful for production deployments where UI assets are served from
+    /// the filesystem but you don't want the overhead of file watching.
+    ///
+    /// ## Parameters
+    ///
+    /// - `ui_path`: Path to directory containing built UI assets
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .filesystem_static("/var/www/katana-ui")
+    ///     .chain_id("PROD")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Use cases
+    ///
+    /// - Production with UI assets deployed via CD pipeline
+    /// - Docker containers with UI assets in separate volume
+    /// - When you want filesystem serving without file watching overhead
     pub fn filesystem_static<P: Into<PathBuf>>(self, ui_path: P) -> Self {
         self.filesystem_mode(ui_path, false)
     }
 
-    /// Use proxy mode
+    /// Use proxy mode with full control over settings.
+    ///
+    /// In proxy mode, requests are forwarded to an upstream development server
+    /// (e.g., Vite dev server). This is useful during development when running
+    /// the UI with its own development server.
+    ///
+    /// ## Parameters
+    ///
+    /// - `upstream_url`: URL of the upstream development server
+    /// - `inject_env`: Whether to inject environment variables into HTML responses
+    ///
+    /// ## Status
+    ///
+    /// **Currently planned but not implemented** - will fall back to embedded mode.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Future Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    /// use url::Url;
+    ///
+    /// let upstream = Url::parse("http://localhost:3000")?;
+    /// let layer = ExplorerLayer::builder()
+    ///     .proxy_mode(upstream, true)  // inject_env = true
+    ///     .chain_id("DEV")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn proxy_mode(mut self, upstream_url: Url, inject_env: bool) -> Self {
         self.config.mode = ExplorerMode::Proxy { upstream_url, inject_env };
         self
     }
 
-    /// Use proxy mode with environment injection enabled (default)
+    /// Use proxy mode with environment injection enabled.
+    ///
+    /// This convenience method configures proxy mode with environment variable
+    /// injection enabled, which is the common use case for development.
+    ///
+    /// ## Parameters
+    ///
+    /// - `upstream_url`: URL string of the upstream development server
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Result<Self, anyhow::Error>` where errors indicate invalid URLs.
+    ///
+    /// ## Errors
+    ///
+    /// Returns error if the upstream URL cannot be parsed.
+    ///
+    /// ## Status
+    ///
+    /// **Currently planned but not implemented** - will fall back to embedded mode.
+    ///
+    /// ## Future Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().proxy("http://localhost:3000")?.chain_id("DEV").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn proxy<S: AsRef<str>>(self, upstream_url: S) -> Result<Self> {
         let url = Url::parse(upstream_url.as_ref())
             .map_err(|e| anyhow!("Invalid upstream URL: {}", e))?;
@@ -283,7 +1016,42 @@ impl ExplorerLayerBuilder {
 
     // === Convenience Methods for UI Path ===
 
-    /// Set UI path (only relevant for filesystem mode)
+    /// Set or change the UI path for filesystem mode.
+    ///
+    /// This method automatically switches to filesystem mode if not already in that mode.
+    /// If already in filesystem mode, it updates the path while preserving the hot reload setting.
+    ///
+    /// ## Parameters
+    ///
+    /// - `path`: Path to directory containing built UI assets
+    ///
+    /// ## Behavior
+    ///
+    /// - **If in FileSystem mode**: Updates the UI path, preserves hot reload setting
+    /// - **If in other modes**: Switches to FileSystem mode with hot reload enabled
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Starting with embedded mode, switches to filesystem
+    /// let layer = ExplorerLayer::builder()
+    ///     .embedded_mode()
+    ///     .ui_path("./ui/dist")  // Now in filesystem mode with hot reload
+    ///     .build()?;
+    ///
+    /// // Already in filesystem mode, just updates path
+    /// let layer2 = ExplorerLayer::builder()
+    ///     .filesystem_static("./old-path")
+    ///     .ui_path("./new-path")  // Updates path, preserves hot_reload=false
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn ui_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
         match &mut self.config.mode {
             ExplorerMode::FileSystem { ui_path, .. } => {
@@ -298,7 +1066,46 @@ impl ExplorerLayerBuilder {
         self
     }
 
-    /// Enable hot reload (only relevant for filesystem mode)
+    /// Enable or disable hot reload for filesystem mode.
+    ///
+    /// Hot reload watches the UI directory for file changes and automatically
+    /// invalidates the file cache, ensuring the latest files are served.
+    ///
+    /// ## Parameters
+    ///
+    /// - `enabled`: Whether to enable file watching and cache invalidation
+    ///
+    /// ## Behavior
+    ///
+    /// - **If in FileSystem mode**: Updates the hot reload setting
+    /// - **If in other modes**: Logs a debug message and ignores the setting
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Enable hot reload for development
+    /// let dev_layer = ExplorerLayer::builder()
+    ///     .filesystem_static("./ui/dist")
+    ///     .hot_reload(true)  // Now has hot reload enabled
+    ///     .build()?;
+    ///
+    /// // Disable for production
+    /// let prod_layer = ExplorerLayer::builder()
+    ///     .filesystem_with_hot_reload("./ui/dist")
+    ///     .hot_reload(false)  // Disables hot reload
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Performance Note
+    ///
+    /// Hot reload adds file watching overhead. Disable in production for better performance.
     pub fn hot_reload(mut self, enabled: bool) -> Self {
         match &mut self.config.mode {
             ExplorerMode::FileSystem { hot_reload, .. } => {
@@ -314,24 +1121,160 @@ impl ExplorerLayerBuilder {
 
     // === Security and Headers ===
 
-    /// Enable or disable CORS
+    /// Enable or disable Cross-Origin Resource Sharing (CORS).
+    ///
+    /// When enabled, adds CORS headers that allow requests from any origin (`*`).
+    /// This is useful for development but should be used carefully in production.
+    ///
+    /// ## Parameters
+    ///
+    /// - `enabled`: Whether to add CORS headers to responses
+    ///
+    /// ## Security Implications
+    ///
+    /// - **Development**: Generally safe to enable for local development
+    /// - **Production**: Only enable if you need cross-origin access and understand the risks
+    /// - **CORS headers added**: `Access-Control-Allow-Origin: *`
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Enable CORS for development
+    /// let dev_layer = ExplorerLayer::builder().development().cors(true).build()?;
+    ///
+    /// // Disable CORS for security
+    /// let secure_layer = ExplorerLayer::builder().production().cors(false).build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn cors(mut self, enabled: bool) -> Self {
         self.config.cors_enabled = enabled;
         self
     }
 
-    /// Enable CORS (convenience method)
+    /// Enable CORS (convenience method).
+    ///
+    /// This is a convenience method equivalent to `.cors(true)` for better readability
+    /// in builder chains.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .development()
+    ///     .with_cors()  // More readable than .cors(true)
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Equivalent to
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().development().cors(true).build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn with_cors(self) -> Self {
         self.cors(true)
     }
 
-    /// Enable or disable security headers
+    /// Enable or disable production security headers.
+    ///
+    /// When enabled, adds various security headers to protect against common web
+    /// vulnerabilities. These headers are recommended for production but can
+    /// interfere with development debugging.
+    ///
+    /// ## Headers Added
+    ///
+    /// - `X-Frame-Options: DENY` - Prevents clickjacking
+    /// - `X-Content-Type-Options: nosniff` - Prevents MIME sniffing
+    /// - `Referrer-Policy: strict-origin-when-cross-origin` - Controls referrer info
+    /// - `Content-Security-Policy: ...` - Restricts resource loading
+    ///
+    /// ## Parameters
+    ///
+    /// - `enabled`: Whether to add security headers to responses
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Production with security headers
+    /// let prod_layer = ExplorerLayer::builder()
+    ///     .production()
+    ///     .security_headers(true)  // Already enabled by production()
+    ///     .build()?;
+    ///
+    /// // Development without security headers for easier debugging
+    /// let dev_layer = ExplorerLayer::builder()
+    ///     .development()
+    ///     .security_headers(false)  // Already disabled by development()
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Recommendations
+    ///
+    /// - **Production**: Always enable for security
+    /// - **Development**: Disable to avoid CSP and other restrictions
+    /// - **Staging**: Enable to test security headers before production
     pub fn security_headers(mut self, enabled: bool) -> Self {
         self.config.security_headers = enabled;
         self
     }
 
-    /// Add a custom header
+    /// Add a custom HTTP header to all responses.
+    ///
+    /// Custom headers are added to every response served by the Explorer layer.
+    /// This is useful for adding environment-specific headers, API versioning,
+    /// or custom application headers.
+    ///
+    /// ## Parameters
+    ///
+    /// - `key`: Header name (e.g., "X-Environment", "X-API-Version")
+    /// - `value`: Header value (e.g., "staging", "v1.0")
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .production()
+    ///     .header("X-Environment", "production")
+    ///     .header("X-API-Version", "v2.0")
+    ///     .header("X-Build-Time", "2024-01-15")
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Common Use Cases
+    ///
+    /// - Environment identification: `X-Environment: staging`
+    /// - API versioning: `X-API-Version: v1.0`
+    /// - Build information: `X-Build-Hash: abc123`
+    /// - Custom application headers: `X-Feature-Flags: feature1,feature2`
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         K: Into<String>,
@@ -341,7 +1284,38 @@ impl ExplorerLayerBuilder {
         self
     }
 
-    /// Add multiple custom headers
+    /// Add multiple custom HTTP headers to all responses.
+    ///
+    /// This is a convenience method for adding multiple headers at once rather
+    /// than chaining multiple `.header()` calls.
+    ///
+    /// ## Parameters
+    ///
+    /// - `headers`: An iterator of (key, value) pairs where both implement `Into<String>`
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use std::collections::HashMap;
+    ///
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let mut header_map = HashMap::new();
+    /// header_map.insert("X-Environment", "staging");
+    /// header_map.insert("X-API-Version", "v1.0");
+    ///
+    /// let layer = ExplorerLayer::builder().production().headers(header_map).build()?;
+    ///
+    /// // Or with a Vec of tuples
+    /// let headers = vec![("X-Service", "katana-explorer"), ("X-Version", "1.0.0")];
+    ///
+    /// let layer2 = ExplorerLayer::builder().production().headers(headers).build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn headers<I, K, V>(mut self, headers: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -356,7 +1330,51 @@ impl ExplorerLayerBuilder {
 
     // === UI Environment Variables ===
 
-    /// Add a UI environment variable
+    /// Add a UI environment variable.
+    ///
+    /// UI environment variables are injected into the HTML page and made available
+    /// to the frontend JavaScript via `window.KATANA_CONFIG`. This allows passing
+    /// configuration and runtime information to the UI.
+    ///
+    /// ## Parameters
+    ///
+    /// - `key`: Variable name (will be available as `window.KATANA_CONFIG.{key}`)
+    /// - `value`: Variable value (supports strings, numbers, booleans, and JSON values)
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .development()
+    ///     .ui_env("DEBUG", true)
+    ///     .ui_env("API_URL", "http://localhost:8080")
+    ///     .ui_env("MAX_RETRIES", 3)
+    ///     .ui_env("FEATURES", vec!["feature1", "feature2"])
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Frontend Access
+    ///
+    /// Variables are accessible in the browser as:
+    ///
+    /// ```javascript
+    /// console.log(window.KATANA_CONFIG.DEBUG);      // true
+    /// console.log(window.KATANA_CONFIG.API_URL);    // "http://localhost:8080"
+    /// console.log(window.KATANA_CONFIG.MAX_RETRIES); // 3
+    /// ```
+    ///
+    /// ## Automatic Variables
+    ///
+    /// These variables are automatically added and don't need to be set manually:
+    /// - `CHAIN_ID`: Set via the `chain_id()` method
+    /// - `ENABLE_CONTROLLER`: Always set to `false`
     pub fn ui_env<K, V>(mut self, key: K, value: V) -> Self
     where
         K: Into<String>,
@@ -366,7 +1384,39 @@ impl ExplorerLayerBuilder {
         self
     }
 
-    /// Add multiple UI environment variables
+    /// Add multiple UI environment variables.
+    ///
+    /// This is a convenience method for adding multiple UI environment variables
+    /// at once rather than chaining multiple `.ui_env()` calls.
+    ///
+    /// ## Parameters
+    ///
+    /// - `envs`: An iterator of (key, value) pairs to add to the UI environment
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use std::collections::HashMap;
+    ///
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let mut env_vars = HashMap::new();
+    /// env_vars.insert("DEBUG", true);
+    /// env_vars.insert("API_TIMEOUT", 5000);
+    /// env_vars.insert("ENVIRONMENT", "staging");
+    ///
+    /// let layer = ExplorerLayer::builder().development().ui_envs(env_vars).build()?;
+    ///
+    /// // Or with a Vec of tuples
+    /// let envs = vec![("FEATURE_A", true), ("FEATURE_B", false), ("POLL_INTERVAL", 1000)];
+    ///
+    /// let layer2 = ExplorerLayer::builder().development().ui_envs(envs).build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn ui_envs<I, K, V>(mut self, envs: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -379,19 +1429,138 @@ impl ExplorerLayerBuilder {
         self
     }
 
-    /// Enable debug mode (adds DEBUG=true to UI environment)
+    /// Enable debug mode by adding `DEBUG=true` to the UI environment.
+    ///
+    /// This convenience method adds `DEBUG: true` to the UI environment variables,
+    /// making it available to the frontend for enabling debug features, logging,
+    /// and development tools.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder()
+    ///     .development()
+    ///     .debug()  // Adds DEBUG: true to UI environment
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Frontend Access
+    ///
+    /// The debug flag is accessible in the browser as:
+    ///
+    /// ```javascript
+    /// if (window.KATANA_CONFIG.DEBUG) {
+    ///     console.log("Debug mode enabled");
+    ///     // Enable debug features
+    /// }
+    /// ```
+    ///
+    /// ## Equivalent to
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().development().ui_env("DEBUG", true).build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn debug(self) -> Self {
         self.ui_env("DEBUG", true)
     }
 
-    /// Set API endpoint URL for the UI
+    /// Set the API endpoint URL for the UI.
+    ///
+    /// This convenience method adds an `API_ENDPOINT` variable to the UI environment,
+    /// making it available to the frontend for API communication. This is useful
+    /// when the API endpoint differs from the default or when using a different port.
+    ///
+    /// ## Parameters
+    ///
+    /// - `endpoint`: The API endpoint URL (e.g., "/api/v1", "http://localhost:8080/api")
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // Relative endpoint
+    /// let layer = ExplorerLayer::builder().development().api_endpoint("/api/v2").build()?;
+    ///
+    /// // Absolute endpoint for different service
+    /// let layer2 =
+    ///     ExplorerLayer::builder().production().api_endpoint("https://api.katana.com/v1").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Frontend Access
+    ///
+    /// The API endpoint is accessible in the browser as:
+    ///
+    /// ```javascript
+    /// const apiUrl = window.KATANA_CONFIG.API_ENDPOINT;
+    /// fetch(`${apiUrl}/transactions`);
+    /// ```
+    ///
+    /// ## Equivalent to
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// let layer = ExplorerLayer::builder().development().ui_env("API_ENDPOINT", "/api/v2").build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn api_endpoint<S: Into<String>>(self, endpoint: S) -> Self {
         self.ui_env("API_ENDPOINT", endpoint.into())
     }
 
     // === Performance ===
 
-    /// Enable or disable compression (future feature)
+    /// Enable or disable asset compression.
+    ///
+    /// When enabled, static assets will be compressed before serving to reduce
+    /// bandwidth usage and improve loading times. This feature is planned for
+    /// future implementation.
+    ///
+    /// ## Parameters
+    ///
+    /// - `enabled`: Whether to enable asset compression
+    ///
+    /// ## Status
+    ///
+    /// **Currently not implemented** - this setting is reserved for future use.
+    /// Setting this value will not have any effect on current behavior.
+    ///
+    /// ## Returns
+    ///
+    /// Returns `Self` for method chaining.
+    ///
+    /// ## Future Examples
+    ///
+    /// ```rust,no_run
+    /// use katana_explorer::ExplorerLayer;
+    ///
+    /// // When implemented, this will enable gzip/brotli compression
+    /// let layer = ExplorerLayer::builder().production().compression(true).build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Implementation Notes
+    ///
+    /// When implemented, this will likely support:
+    /// - Gzip compression for text assets (HTML, CSS, JS)
+    /// - Brotli compression for better compression ratios
+    /// - Automatic content-encoding headers
+    /// - Pre-compression for embedded assets
     pub fn compression(mut self, enabled: bool) -> Self {
         self.config.compression = enabled;
         self
@@ -419,6 +1588,20 @@ pub struct ExplorerService<S> {
     config: ExplorerConfig,
     file_cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
     _watcher: Option<RecommendedWatcher>,
+}
+
+impl<S: Clone> Clone for ExplorerService<S> {
+    fn clone(&self) -> Self {
+        // Note: We don't clone the watcher, as having multiple watchers for the same path
+        // would be redundant and potentially problematic. The cache is shared via Arc,
+        // so hot reload functionality is maintained.
+        Self {
+            inner: self.inner.clone(),
+            config: self.config.clone(),
+            file_cache: self.file_cache.clone(),
+            _watcher: None,
+        }
+    }
 }
 
 impl<S> ExplorerService<S> {

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -198,11 +198,7 @@ impl RpcServer {
 
         #[cfg(feature = "explorer")]
         let explorer_layer = if self.explorer {
-            let layer = katana_explorer::ExplorerLayer::builder()
-                .embedded_mode()
-                .chain_id("KATANA")
-                .build()
-                .unwrap();
+            let layer = katana_explorer::ExplorerLayer::builder().embedded().build().unwrap();
             Some(layer)
         } else {
             None

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -198,7 +198,11 @@ impl RpcServer {
 
         #[cfg(feature = "explorer")]
         let explorer_layer = if self.explorer {
-            let layer = katana_explorer::ExplorerLayer::new(String::new()).unwrap();
+            let layer = katana_explorer::ExplorerLayer::builder()
+                .embedded_mode()
+                .chain_id("KATANA")
+                .build()
+                .unwrap();
             Some(layer)
         } else {
             None


### PR DESCRIPTION
This is a general refactor for making the `katana-explorer` crate more robust. It introduces a builder struct for creating `ExplorerLayer`. This PR also introduces a new mode for serving the UI which will only be implemented in future PR.