### PR TITLE
feat(rpc): use stable version of RPC 0.9

### DIFF
--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -32,7 +32,7 @@ use starknet::core::types::{
 };
 
 /// The currently supported version of the Starknet JSON-RPC specification.
-pub const RPC_SPEC_VERSION: &str = "0.9.0-rc.2";
+pub const RPC_SPEC_VERSION: &str = "0.9.0";
 
 /// Read API.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "starknet"))]


### PR DESCRIPTION
The stable version of the RPC 0.9 has been [released](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.9.0). Katana doesn't actually support all the features in RPC 0.9.0 (especially the WebSocket API) but we still need to make the bump mostly to ensure compatibility with the ecosystem.