### PR TITLE
feat(primitives): macro for creating eth addresss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6418,6 +6418,7 @@ dependencies = [
  "criterion",
  "derive_more 0.99.20",
  "heapless",
+ "hex",
  "lazy_static",
  "num-bigint",
  "num-traits",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true }
 base64.workspace = true
+hex.workspace = true
 blockifier = { workspace = true, features = [ "testing" ] } # some Clone derives are gated behind 'testing' feature
 cainome-cairo-serde.workspace = true
 cairo-lang-starknet-classes.workspace = true

--- a/crates/primitives/src/eth.rs
+++ b/crates/primitives/src/eth.rs
@@ -1,1 +1,1 @@
-pub use alloy_primitives::{Address, ChainId};
+pub use alloy_primitives::{address, Address, ChainId};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use hex as _;
+
 pub mod block;
 pub mod cairo;
 pub mod chain;
@@ -20,8 +22,14 @@ pub mod version;
 pub mod state;
 pub mod utils;
 
-pub use alloy_primitives::U256;
+mod macros;
+
+pub use alloy_primitives::{B256, U256};
 pub use contract::ContractAddress;
 pub use starknet::macros::felt;
 pub use starknet_types_core::felt::{Felt, FromStrError};
 pub use starknet_types_core::hash;
+
+pub mod _private {
+    pub use ::alloy_primitives;
+}

--- a/crates/primitives/src/macros.rs
+++ b/crates/primitives/src/macros.rs
@@ -1,0 +1,60 @@
+/// Creates an [Ethereum Address][crate::eth::Address] from a literal hex string.
+///
+/// This macro supports both short and full-length (20-bytes) hex strings, and automatically pads
+/// the hex string to 40 characters with leading zeros.
+///
+/// # Examples
+/// ```
+/// use katana_primitives::eth_address;
+///
+/// let addr1 = eth_address!("0x1337"); // Pads to 20 bytes
+/// let addr2 = eth_address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045"); // Full 20 bytes
+/// let addr3 = eth_address!("1337"); // Also works without 0x prefix
+/// ```
+#[macro_export]
+macro_rules! eth_address {
+    ($hex:literal) => {{
+        // Runtime execution
+        let hex_str = $hex;
+        let hex_str = if hex_str.starts_with("0x") || hex_str.starts_with("0X") {
+            &hex_str[2..]
+        } else {
+            hex_str
+        };
+
+        // Pad to 40 characters (20 bytes) with leading zeros
+        let padded_hex =
+            if hex_str.len() < 40 { format!("{:0>40}", hex_str) } else { hex_str.to_string() };
+
+        $crate::_private::alloy_primitives::Address::from_str(&padded_hex).unwrap()
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy_primitives::Address;
+
+    #[test]
+    fn test_eth_address_macro() {
+        // Test with short hex
+        let addr1 = eth_address!("0x1337");
+        let expected1 = Address::from_str("0x0000000000000000000000000000000000001337").unwrap();
+        assert_eq!(addr1, expected1);
+
+        // Test without 0x prefix
+        let addr2 = eth_address!("1337");
+        assert_eq!(addr2, expected1);
+
+        // Test with full 20 bytes
+        let addr3 = eth_address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+        let expected3 = Address::from_str("0xd8da6bf26964af9d7eed9e03e53415d37aa96045").unwrap();
+        assert_eq!(addr3, expected3);
+
+        // Test single digit
+        let addr4 = eth_address!("0x1");
+        let expected4 = Address::from_str("0x0000000000000000000000000000000000000001").unwrap();
+        assert_eq!(addr4, expected4);
+    }
+}


### PR DESCRIPTION
`alloy-primitives` already have a [macro](https://docs.rs/alloy-primitives/latest/alloy_primitives/macro.address.html) for creating an eth [`Address`](https://docs.rs/alloy-primitives/latest/alloy_primitives/struct.Address.html) but you are required to specify all 40 hex literal characters to satisfy the 20-bytes of an Address. 

This new macro implementation is a bit less performant and can't be used in a const expression, but supports short (less than 40 characters) hex string. In most cases (usually in tests), I rarely need to specify the full length address.