### PR TITLE
refactor(controller): remove dependency on `account_sdk`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "contracts/vrf"]
 	path = contracts/vrf
 	url = https://github.com/cartridge-gg/vrf
+[submodule "crates/cartridge/controller"]
+	path = crates/cartridge/controller
+	url = https://github.com/cartridge-gg/controller-rs.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,53 +3,6 @@
 version = 4
 
 [[package]]
-name = "account_sdk"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/controller-rs?rev=242e7bd#242e7bd5cc7835151c5bf6dd659c72048bb06467"
-dependencies = [
- "alloy-primitives 0.8.25",
- "alloy-signer 0.12.6",
- "anyhow",
- "async-trait",
- "auto_impl",
- "cainome",
- "cainome-cairo-serde",
- "chrono",
- "ecdsa",
- "futures",
- "graphql_client",
- "hex",
- "indexmap 2.10.0",
- "js-sys",
- "k256",
- "lazy_static",
- "nom",
- "num-traits",
- "once_cell",
- "primitive-types",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "serde_with",
- "starknet",
- "starknet-crypto 0.7.4",
- "starknet-types-core",
- "thiserror 1.0.69",
- "tokio",
- "toml",
- "tsify-next",
- "u256-literal",
- "url",
- "urlencoding",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test",
- "web-sys",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +88,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4195a29a4b87137b2bb02105e746102873bc03561805cf45c0e510c961f160e6"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "num_enum",
  "strum 0.27.2",
 ]
@@ -147,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda689f7287f15bd3582daba6be8d1545bad3740fd1fb778f629a1fe866bb43b"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -173,7 +126,7 @@ checksum = "2b5659581e41e8fe350ecc3593cb5c9dcffddfd550896390f2b78a07af67b0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -190,7 +143,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -208,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e8a436f0aad7df8bb47f144095fba61202265d9f5f09a70b0e3227881a668e"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "itoa",
@@ -223,7 +176,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "crc",
  "serde",
@@ -236,7 +189,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "serde",
 ]
@@ -247,7 +200,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "serde",
  "thiserror 2.0.12",
@@ -262,7 +215,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
@@ -280,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d4009efea6f403b3a80531f9c6f70fc242399498ff71196a1688cc1c901f44"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
  "serde",
@@ -294,7 +247,7 @@ checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "auto_impl",
  "dyn-clone",
 ]
@@ -305,7 +258,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -317,7 +270,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "883dee3b4020fcb5667ee627b4f401e899dad82bf37b246620339dd980720ed9"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-sol-types",
  "http 1.3.1",
  "serde",
@@ -337,11 +290,11 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "alloy-signer 1.0.24",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -360,7 +313,7 @@ checksum = "80d7980333dd9391719756ac28bc2afa9baa705fc70ffd11dc86ab078dd64477"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-serde",
  "serde",
 ]
@@ -374,8 +327,8 @@ dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-network",
- "alloy-primitives 1.3.0",
- "alloy-signer 1.0.24",
+ "alloy-primitives",
+ "alloy-signer",
  "alloy-signer-local",
  "k256",
  "rand 0.8.5",
@@ -384,33 +337,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 2.0.1",
- "foldhash",
- "hashbrown 0.15.4",
- "indexmap 2.10.0",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.8.5",
- "ruint",
- "rustc-hash 2.1.1",
- "serde",
- "sha3",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -456,11 +382,11 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-node-bindings",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
- "alloy-signer 1.0.24",
+ "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -514,7 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f060e3bb9f319eb01867a2d6d1ff9e0114e8877f5ca8f5db447724136106cae"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-transport",
  "alloy-transport-http",
  "futures",
@@ -536,7 +462,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10493fa300a2757d8134f584800fef545c15905c95122bed1f6dde0b0d9dae27"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -563,7 +489,7 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -580,24 +506,9 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8d2c52adebf3e6494976c8542fbdf12f10123b26e11ad56f77274c16a2a039"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96fbde54bee943cd94ebacc8a62c50b38c7dfd2552dcd79ff61aea778b1bfcc"
-dependencies = [
- "alloy-primitives 0.8.25",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -606,7 +517,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c0494d1e0f802716480aabbe25549c7f6bc2a25ff33b08fd332bbb4b7d06894"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "async-trait",
  "auto_impl",
  "either",
@@ -623,8 +534,8 @@ checksum = "59c2435eb8979a020763ced3fb478932071c56e5f75ea86db41f320915d325ba"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 1.3.0",
- "alloy-signer 1.0.24",
+ "alloy-primitives",
+ "alloy-signer",
  "async-trait",
  "k256",
  "rand 0.8.5",
@@ -699,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-sol-macro",
  "serde",
 ]
@@ -711,7 +622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89bec2f59a41c0e259b6fe92f78dfc49862c17d10f938db9c33150d5a7f42b6"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -748,7 +659,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -764,7 +675,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6acb36318dfa50817154064fea7932adf2eec3f51c86680e2b37d7e8906c66bb"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "darling 0.20.11",
  "proc-macro2",
  "quote",
@@ -3087,7 +2998,9 @@ dependencies = [
  "anyhow",
  "ark-ec 0.4.2",
  "cainome",
+ "katana-contracts",
  "katana-primitives",
+ "lazy_static",
  "num-bigint",
  "parking_lot",
  "reqwest 0.12.22",
@@ -3447,34 +3360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
-dependencies = [
- "cookie",
- "idna 0.3.0",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -4742,64 +4627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphql-introspection-query"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "graphql-parser"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
-dependencies = [
- "combine",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "graphql_client"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cdf7b487d864c2939b23902291a5041bc4a84418268f25fda1c8d4e15ad8fa"
-dependencies = [
- "graphql_query_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "graphql_client_codegen"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40f793251171991c4eb75bd84bc640afa8b68ff6907bc89d3b712a22f700506"
-dependencies = [
- "graphql-introspection-query",
- "graphql-parser",
- "heck 0.4.1",
- "lazy_static",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "graphql_query_derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bda454f3d313f909298f626115092d348bc231025699f557b27e248475f48c"
-dependencies = [
- "graphql_client_codegen",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5341,16 +5168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -5938,7 +5755,6 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -5988,7 +5804,7 @@ dependencies = [
 name = "katana-chain-spec"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "anyhow",
  "dirs",
  "katana-contracts",
@@ -6012,7 +5828,7 @@ dependencies = [
 name = "katana-cli"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "anyhow",
  "assert_matches",
  "clap",
@@ -6084,7 +5900,7 @@ dependencies = [
 name = "katana-core"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "anyhow",
  "arbitrary",
  "assert_matches",
@@ -6151,7 +5967,7 @@ dependencies = [
 name = "katana-executor"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "anyhow",
  "assert_matches",
  "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
@@ -6273,7 +6089,7 @@ version = "1.7.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-network",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -6406,7 +6222,7 @@ dependencies = [
 name = "katana-primitives"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "anyhow",
  "arbitrary",
  "assert_matches",
@@ -6443,7 +6259,7 @@ dependencies = [
 name = "katana-provider"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "anyhow",
  "auto_impl",
  "bitvec",
@@ -6476,7 +6292,7 @@ version = "1.7.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-node-bindings",
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "alloy-provider",
  "alloy-sol-types",
  "anyhow",
@@ -6546,7 +6362,7 @@ dependencies = [
 name = "katana-rpc-types"
 version = "1.7.0-alpha.3"
 dependencies = [
- "alloy-primitives 1.3.0",
+ "alloy-primitives",
  "assert_matches",
  "cainome",
  "cainome-cairo-serde",
@@ -6605,7 +6421,7 @@ dependencies = [
 name = "katana-slot-controller"
 version = "1.7.0-alpha.3"
 dependencies = [
- "account_sdk",
+ "cartridge",
  "katana-primitives",
 ]
 
@@ -7189,16 +7005,6 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "minicov"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
-dependencies = [
- "cc",
- "walkdir",
 ]
 
 [[package]]
@@ -8515,12 +8321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8538,16 +8338,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "publicsuffix"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
-dependencies = [
- "idna 1.0.3",
- "psl-types",
 ]
 
 [[package]]
@@ -8897,8 +8687,6 @@ checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "cookie",
- "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -9851,17 +9639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -11642,31 +11419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tsify-next"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde_json",
- "tsify-next-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-next-macros"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11697,16 +11449,6 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "u256-literal"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39a1ed842845c7cdbcf413a186dba1fb3cf8b13753c21e5572bf64aadec4778"
-dependencies = [
- "primitive-types",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "ucd-trie"
@@ -11891,12 +11633,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -12167,30 +11903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
-dependencies = [
- "js-sys",
- "minicov",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]

--- a/crates/cartridge/Cargo.toml
+++ b/crates/cartridge/Cargo.toml
@@ -4,13 +4,16 @@ license.workspace = true
 name = "cartridge"
 repository.workspace = true
 version.workspace = true
+build = "build.rs"
 
 [dependencies]
+katana-contracts.workspace = true
 katana-primitives.workspace = true
 
 anyhow.workspace = true
 ark-ec = "0.4"
 cainome.workspace = true
+lazy_static.workspace = true
 num-bigint.workspace = true
 parking_lot.workspace = true
 reqwest.workspace = true

--- a/crates/cartridge/build.rs
+++ b/crates/cartridge/build.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+use std::{env, fs};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let classes_dir = Path::new(&manifest_dir).join("controller/account_sdk/artifacts/classes");
+    let dest_path = Path::new(&manifest_dir).join("src/controller.rs");
+
+    let mut generated_code = String::new();
+
+    // Read all .json files from the classes directory
+    if let Ok(entries) = fs::read_dir(&classes_dir) {
+        let mut contracts = Vec::new();
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(extension) = path.extension() {
+                if extension == "json" {
+                    if let Some(file_name) = path.file_stem() {
+                        let file_name_str = file_name.to_string_lossy();
+                        // Only include controller.*.contract_class.json files, not compiled
+                        // ones
+                        if file_name_str.starts_with("controller.")
+                            && file_name_str.ends_with("contract_class")
+                            && !file_name_str.contains("compiled")
+                        {
+                            contracts.push(file_name_str.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Sort contracts for consistent ordering
+        contracts.sort();
+
+        for file_name in contracts {
+            // Convert filename to struct name (e.g., controller.latest.contract_class ->
+            // ControllerLatest)
+            let struct_name = filename_to_struct_name(&file_name);
+
+            generated_code.push_str(&format!(
+                "::katana_contracts::contract!(\n    {},\n    \
+                 \"{{CARGO_MANIFEST_DIR}}/controller/account_sdk/artifacts/classes/{}.json\"\n);
+                 ",
+                struct_name, file_name
+            ));
+        }
+    }
+
+    fs::write(dest_path, generated_code).unwrap();
+
+    // Tell Cargo to rerun this build script if the classes directory changes
+    println!("cargo:rerun-if-changed={}", classes_dir.display());
+}
+
+fn filename_to_struct_name(filename: &str) -> String {
+    // Split by dots and convert each part to PascalCase
+    let parts: Vec<&str> = filename.split('.').collect();
+    let mut struct_name = String::new();
+
+    for part in parts {
+        if part == "json" || part == "contract_class" || part == "compiled_contract_class" {
+            continue;
+        }
+
+        // Convert to PascalCase
+        let pascal_part = part
+            .split('_')
+            .map(|word| {
+                let mut chars = word.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(first) => first.to_uppercase().chain(chars).collect(),
+                }
+            })
+            .collect::<String>();
+
+        struct_name.push_str(&pascal_part);
+    }
+
+    struct_name
+}

--- a/crates/cartridge/src/controller.rs
+++ b/crates/cartridge/src/controller.rs
@@ -1,0 +1,35 @@
+::katana_contracts::contract!(
+    ControllerLatest,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.latest.\
+     contract_class.json"
+);
+::katana_contracts::contract!(
+    ControllerV104,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.v1.0.4.\
+     contract_class.json"
+);
+::katana_contracts::contract!(
+    ControllerV105,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.v1.0.5.\
+     contract_class.json"
+);
+::katana_contracts::contract!(
+    ControllerV106,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.v1.0.6.\
+     contract_class.json"
+);
+::katana_contracts::contract!(
+    ControllerV107,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.v1.0.7.\
+     contract_class.json"
+);
+::katana_contracts::contract!(
+    ControllerV108,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.v1.0.8.\
+     contract_class.json"
+);
+::katana_contracts::contract!(
+    ControllerV109,
+    "{CARGO_MANIFEST_DIR}/controller/account_sdk/artifacts/classes/controller.v1.0.9.\
+     contract_class.json"
+);

--- a/crates/cartridge/src/lib.rs
+++ b/crates/cartridge/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod controller;
 pub mod vrf;
 
 pub use client::Client;

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -770,9 +770,18 @@ chain_id.Named = "Mainnet"
         assert!(config.rpc.apis.contains(&RpcModuleKind::Starknet));
 
         // Verify that all the Controller classes are added to the genesis
-        for (_, class) in katana_slot_controller::CONTROLLERS.iter() {
-            assert!(config.chain.genesis().classes.get(&class.hash).is_some());
-        }
+        use katana_slot_controller::{
+            ControllerLatest, ControllerV104, ControllerV105, ControllerV106, ControllerV107,
+            ControllerV108, ControllerV109,
+        };
+
+        assert!(config.chain.genesis().classes.get(&ControllerV104::HASH).is_some());
+        assert!(config.chain.genesis().classes.get(&ControllerV105::HASH).is_some());
+        assert!(config.chain.genesis().classes.get(&ControllerV106::HASH).is_some());
+        assert!(config.chain.genesis().classes.get(&ControllerV107::HASH).is_some());
+        assert!(config.chain.genesis().classes.get(&ControllerV108::HASH).is_some());
+        assert!(config.chain.genesis().classes.get(&ControllerV109::HASH).is_some());
+        assert!(config.chain.genesis().classes.get(&ControllerLatest::HASH).is_some());
 
         // Test without paymaster enabled
         let args = NodeArgs::parse_from(["katana"]);
@@ -781,8 +790,12 @@ chain_id.Named = "Mainnet"
         // Verify cartridge module is not enabled by default
         assert!(!config.rpc.apis.contains(&RpcModuleKind::Cartridge));
 
-        for (_, class) in katana_slot_controller::CONTROLLERS.iter() {
-            assert!(config.chain.genesis().classes.get(&class.hash).is_none());
-        }
+        assert!(config.chain.genesis().classes.get(&ControllerV104::HASH).is_none());
+        assert!(config.chain.genesis().classes.get(&ControllerV105::HASH).is_none());
+        assert!(config.chain.genesis().classes.get(&ControllerV106::HASH).is_none());
+        assert!(config.chain.genesis().classes.get(&ControllerV107::HASH).is_none());
+        assert!(config.chain.genesis().classes.get(&ControllerV108::HASH).is_none());
+        assert!(config.chain.genesis().classes.get(&ControllerV109::HASH).is_none());
+        assert!(config.chain.genesis().classes.get(&ControllerLatest::HASH).is_none());
     }
 }

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -1,3 +1,5 @@
+pub use katana_contracts_macro::contract;
+
 pub mod contracts {
     use katana_contracts_macro::contract;
 

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -7,5 +7,5 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-account_sdk = { git = "https://github.com/cartridge-gg/controller-rs", rev = "242e7bd" }
+cartridge.workspace = true
 katana-primitives.workspace = true

--- a/crates/controller/src/lib.rs
+++ b/crates/controller/src/lib.rs
@@ -1,11 +1,15 @@
-pub use account_sdk::artifacts::CONTROLLERS;
+pub use cartridge::controller::*;
 use katana_primitives::genesis::Genesis;
 use katana_primitives::utils::class::parse_sierra_class;
 
 pub fn add_controller_classes(genesis: &mut Genesis) {
-    genesis.classes.extend(
-        CONTROLLERS.iter().map(|(_, v)| (v.hash, parse_sierra_class(v.content).unwrap().into())),
-    );
+    genesis.classes.insert(ControllerV104::HASH, ControllerV104::CLASS.clone().into());
+    genesis.classes.insert(ControllerV105::HASH, ControllerV105::CLASS.clone().into());
+    genesis.classes.insert(ControllerV106::HASH, ControllerV106::CLASS.clone().into());
+    genesis.classes.insert(ControllerV107::HASH, ControllerV107::CLASS.clone().into());
+    genesis.classes.insert(ControllerV108::HASH, ControllerV108::CLASS.clone().into());
+    genesis.classes.insert(ControllerV109::HASH, ControllerV109::CLASS.clone().into());
+    genesis.classes.insert(ControllerLatest::HASH, ControllerLatest::CLASS.clone().into());
 }
 
 pub fn add_vrf_provider_class(genesis: &mut Genesis) {


### PR DESCRIPTION
The crate is removed because it has the `starknet` crate in its dependency tree. This is part of an iterative effort to reduce the impact of `starknet` crate in the project. 

The latest version of `starknet` crate (ie `0.17.0`) bundles 2 (3 if includes higher MSRV) breaking changes - RPC upgrade, and minor bump of `starknet-types-core` to `0.2.0`. The minor bump is the change that caused the most damage as it conflicts with other crates that has `starknet-types-core` in their dependency trees as they are still on the `0.1` minor version. Our reliance on `starknet` crate for the RPC types has initially forced us to use the `0.17.0` version to support the recent Starknet JSON-RPC 0.9.0 [upgrade]. But now with #256 we are moving away from relying on the crate which would prevent us from being too tightly coupled with a specific version of `starknet`, and to use a version of the crate that is compatible with the rest of the related crate ecosystem.

[upgrade]: https://github.com/xJonathanLEI/starknet-rs/pull/778