### PR TITLE
chore(cartridge): initialize git submodule in build script

### DIFF
--- a/crates/explorer/build.rs
+++ b/crates/explorer/build.rs
@@ -54,8 +54,8 @@ fn initialize_submodule(ui_dir: &Path) {
         }
     } else {
         panic!(
-            "UI directory doesn't exist at {} and couldn't fetch it through git submodule (not in \
-             a git repository)",
+            "/ui directory doesn't exist at {} and couldn't fetch it through git submodule (not \
+             in a git repository)",
             ui_dir.display()
         );
     }


### PR DESCRIPTION
The build script assumes that the `/controller` directory exist and silently fails if it doesn't. This is usually the case on a fresh git clone.