### PR TITLE
feat: use the actual class info

### DIFF
--- a/crates/executor/src/implementation/blockifier/cache.rs
+++ b/crates/executor/src/implementation/blockifier/cache.rs
@@ -1,10 +1,8 @@
-use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 
 use blockifier::execution::contract_class::{CompiledClassV1, RunnableCompiledClass};
 use katana_primitives::class::{ClassHash, CompiledClass, ContractClass};
 use quick_cache::sync::Cache;
-use starknet_api::contract_class::SierraVersion;
 
 use super::utils::to_class;
 
@@ -256,11 +254,12 @@ impl ClassCache {
                 #[cfg(feature = "native")]
                 let entry_points = sierra.entry_points_by_type.clone();
 
+                let version = class.sierra_version();
+
                 let CompiledClass::Class(casm) = class.compile().unwrap() else {
                     unreachable!("cant be legacy")
                 };
 
-                let version = SierraVersion::from_str(&casm.compiler_version).unwrap();
                 let compiled = CompiledClassV1::try_from((casm, version.clone())).unwrap();
 
                 #[cfg(feature = "native")]

--- a/crates/rpc/rpc/src/starknet/config.rs
+++ b/crates/rpc/rpc/src/starknet/config.rs
@@ -10,6 +10,18 @@ pub struct StarknetApiConfig {
     /// If `None`, the maximum keys size is bounded by [`u64::MAX`].
     pub max_proof_keys: Option<u64>,
 
+    /// Maximum Sierra gas for contract calls.
+    ///
+    /// The maximum amount of execution resources allocated for a contract call via `starknet_call`
+    /// method. If `None,` defaults to `1,000,000,000`.
+    ///
+    /// ## Implementation Details
+    ///
+    /// If the contract call execution is tracked using Cairo steps (eg., the class is using an old
+    /// sierra compiler version), this Sierra gas value must be converted to Cairo steps. Check out
+    /// the [`call`] module for more information.
+    ///
+    /// [`call`]: katana_executor::implementation::blockifier::call
     pub max_call_gas: Option<u64>,
 
     /// The maximum number of concurrent `estimate_fee` requests allowed.


### PR DESCRIPTION
Currently when creating the `ClassInfo` struct from Blockifier, the values used aren't accurate. 

First, the sierra version is actually the CASM compiler version. The sierra version is encoded into the `sierra_program` field of a Starknet contract class artifact. The `sierra_program` is a list of field elements and the first six elements are reserved for the compilers - first 3 for sierra compiler version and last 3 for casm compiler version. Fyi, Blockifier performs a sierra version check when executing a contract execution to determine what resource to [track].

Second, we are using mock values for both sierra program length and abi length. I'm not exactly sure what's the specification of the ABI length, but I've referenced with the official StarkWare's [implementation] and it seems to be the length of the ABI in its RPC format i.e., a string of JSON.

The implementation for getting the ABI length is not optimized and would require to be computed every time the class is fetched from database -> class cache.

These values are important for ensuring deterministic executions as they affect transaction execution as well as fees.

[track]: https://github.com/dojoengine/sequencer/blob/3c206344dc64b5a0f150ea94cd2623b2a9a7da63/crates/blockifier/src/execution/contract_class.rs#L258
[implementation]: https://github.com/dojoengine/sequencer/blob/3c206344dc64b5a0f150ea94cd2623b2a9a7da63/crates/apollo_rpc/src/v0_8/api/mod.rs#L453-L477