### PR TITLE
feat(bin): restructure `init` command with explicit rollup/sovereign modes

### DIFF
--- a/bin/katana/src/cli/init/deployment.rs
+++ b/bin/katana/src/cli/init/deployment.rs
@@ -234,7 +234,7 @@ pub async fn deploy_settlement_contract(
         // FINAL CHECKS
         // -----------------------------------------------------------------------
 
-        check_program_info(chain_id, deployed_appchain_contract, account.provider()).await?;
+        check_program_info(chain_id, deployed_appchain_contract.into(), account.provider()).await?;
 
         Ok(DeploymentOutcome {
             block_number: deployment_block,
@@ -262,10 +262,10 @@ pub async fn deploy_settlement_contract(
 /// * Layout bridge program hash
 pub async fn check_program_info(
     chain_id: Felt,
-    appchain_address: Felt,
+    appchain_address: ContractAddress,
     provider: &SettlementChainProvider,
 ) -> Result<(), ContractInitError> {
-    let appchain = AppchainContractReader::new(appchain_address, provider);
+    let appchain = AppchainContractReader::new(appchain_address.into(), provider);
 
     // Compute the chain's config hash
     let config_hash = compute_config_hash(

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -638,8 +638,8 @@ mod tests {
 
         let result = Cli::parse_from([
             "init",
-            "--id",
             "rollup",
+            "--id",
             "wot",
             "--settlement-chain",
             "http://localhost:5050",

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -287,14 +287,14 @@ impl RollupArgs {
                 format!("Failed to get chain id for settlement layer: {settlement_chain}")
             }) {
                 Ok(id) => id,
-                error @ Err(..) => return Some(error),
+                Err(err) => return Some(Err(err)),
             };
 
             let chain_id = match cairo_short_string_to_felt(&id)
                 .with_context(|| format!("Invalid chain id: {id}"))
             {
                 Ok(id) => id,
-                error @ Err(..) => return Some(error),
+                Err(err) => return Some(Err(err)),
             };
 
             let deployment_outcome = if let Some(contract) = self.settlement_contract {

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -638,16 +638,16 @@ mod tests {
         ]);
         assert_matches!(result.args.mode, InitMode::Rollup(config) => {
             assert_eq!(config.settlement_facts_registry_contract, None);
-        });
 
-        let configure_result = result.args.configure_from_args().await;
-        assert!(configure_result.is_some());
-        let configure_result = configure_result.unwrap();
-        assert!(configure_result.is_err());
-        assert_eq!(
-            configure_result.unwrap_err().to_string(),
-            "Specifying the facts registry contract (using `--settlement-facts-registry`) is \
-             required when settling on a custom chain"
-        );
+            let configure_result = config.configure_from_args().await;
+            assert!(configure_result.is_some());
+            let configure_result = configure_result.unwrap();
+            assert!(configure_result.is_err());
+            assert_eq!(
+                configure_result.unwrap_err().to_string(),
+                "Specifying the facts registry contract (using `--settlement-facts-registry`) is \
+                 required when settling on a custom chain"
+            );
+        });
     }
 }

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -119,15 +119,30 @@ pub struct RollupArgs {
     #[arg(requires_all = ["settlement_chain", "settlement_account", "settlement_account_private_key"])]
     id: Option<String>,
 
-    /// The settlement chain to be used, where the core contract is deployed.
-    ///
-    /// If a custom settlement chain is provided, setting a custom facts registry is required using
-    /// the `--settlement-facts-registry` option. Otherwise, setting a custom facts registry
-    /// with a known chain is a no-op.
-    #[arg(long = "settlement-chain")]
+    #[arg(
+        long = "settlement-chain",
+        help = "The settlement chain to be used, where the core contract is deployed."
+    )]
+    #[arg(long_help = "The settlement chain to be used, where the core contract is deployed.
+
+Possible values:
+  - `mainnet`, `sn_mainnet`: Starknet mainnet
+  - `sepolia`, `sn_sepolia`: Starknet sepolia")]
+    #[cfg_attr(
+        feature = "init-custom-settlement-chain",
+        arg(long_help = "The settlement chain to be used, where the core contract is deployed.
+
+Possible values:
+  - `mainnet`, `sn_mainnet`: Starknet mainnet
+  - `sepolia`, `sn_sepolia`: Starknet sepolia
+  - <URL>: Custom settlement chain URL (requires --settlement-facts-registry)
+
+If a custom settlement chain is provided, setting a custom facts registry is required using
+the `--settlement-facts-registry` option. Otherwise, setting a custom facts registry
+with a known chain is a no-op for now.")
+    )]
     #[arg(requires = "id")]
     settlement_chain: Option<SettlementChain>,
-
     /// The address of the settlement account to be used to configure the core contract.
     #[arg(long = "settlement-account-address")]
     #[arg(requires = "id")]
@@ -425,17 +440,17 @@ struct SettlementChainTryFromStrError {
 }
 
 /// Supported settlement chain options for rollup initialization.
-#[derive(Debug, Clone, strum_macros::Display, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Debug, Clone, strum_macros::Display, PartialEq, Eq)]
 enum SettlementChain {
     Mainnet,
     Sepolia,
     #[cfg(feature = "init-custom-settlement-chain")]
-    #[value(skip)]
     Custom(Url),
 }
 
 impl std::str::FromStr for SettlementChain {
     type Err = SettlementChainTryFromStrError;
+
     fn from_str(s: &str) -> Result<SettlementChain, <Self as ::core::str::FromStr>::Err> {
         let id = s.to_lowercase();
         if &id == "sepolia" || &id == "sn_sepolia" {

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -425,11 +425,12 @@ struct SettlementChainTryFromStrError {
 }
 
 /// Supported settlement chain options for rollup initialization.
-#[derive(Debug, Clone, strum_macros::Display, PartialEq, Eq)]
+#[derive(Debug, Clone, strum_macros::Display, PartialEq, Eq, clap::ValueEnum)]
 enum SettlementChain {
     Mainnet,
     Sepolia,
     #[cfg(feature = "init-custom-settlement-chain")]
+    #[value(skip)]
     Custom(Url),
 }
 

--- a/bin/katana/src/cli/init/prompt.rs
+++ b/bin/katana/src/cli/init/prompt.rs
@@ -128,34 +128,31 @@ pub async fn prompt_rollup() -> Result<PersistentOutcome> {
 
     // The core settlement contract on L1c.
     // Prompt the user whether to deploy the settlement contract or not.
-    let deployment_outcome = if Confirm::new("Deploy settlement contract?")
-        .with_default(true)
-        .prompt()?
-    {
-        let chain_id = cairo_short_string_to_felt(&chain_id)?;
-        deployment::deploy_settlement_contract(account, chain_id).await?
-    }
-    // If denied, prompt the user for an already deployed contract.
-    else {
-        let address = CustomType::<ContractAddress>::new("Settlement contract")
-            .with_parser(contract_exist_parser)
-            .prompt()?;
+    let deployment_outcome =
+        if Confirm::new("Deploy settlement contract?").with_default(true).prompt()? {
+            let chain_id = cairo_short_string_to_felt(&chain_id)?;
+            deployment::deploy_settlement_contract(account, chain_id).await?
+        }
+        // If denied, prompt the user for an already deployed contract.
+        else {
+            let address = CustomType::<ContractAddress>::new("Settlement contract")
+                .with_parser(contract_exist_parser)
+                .prompt()?;
 
-        // Check that the settlement contract has been initialized with the correct program
-        // info.
-        let chain_id = cairo_short_string_to_felt(&chain_id)?;
-        deployment::check_program_info(chain_id, address.into(), &settlement_provider)
-            .await
-            .context(
+            // Check that the settlement contract has been initialized with the correct program
+            // info.
+            let chain_id = cairo_short_string_to_felt(&chain_id)?;
+            deployment::check_program_info(chain_id, address, &settlement_provider).await.context(
                 "Invalid settlement contract. The contract might have been configured incorrectly.",
             )?;
 
-        let block_number = CustomType::<BlockNumber>::new("Settlement contract deployment block")
-            .with_help_message("The block at which the settlement contract was deployed")
-            .prompt()?;
+            let block_number =
+                CustomType::<BlockNumber>::new("Settlement contract deployment block")
+                    .with_help_message("The block at which the settlement contract was deployed")
+                    .prompt()?;
 
-        DeploymentOutcome { contract_address: address, block_number }
-    };
+            DeploymentOutcome { contract_address: address, block_number }
+        };
 
     let slot_paymasters = prompt_slot_paymasters()?;
 

--- a/bin/katana/src/cli/mod.rs
+++ b/bin/katana/src/cli/mod.rs
@@ -46,7 +46,7 @@ impl Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     #[command(about = "Initialize chain")]
-    Init(Box<init::InitArgs>),
+    Init(Box<init::InitCommand>),
 
     #[command(about = "Chain configuration utilities")]
     Config(config::ConfigArgs),

--- a/bin/katana/src/main.rs
+++ b/bin/katana/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 fn main() {
     if let Err(err) = katana::cli::Cli::parse().run() {
-        eprintln!("\x1b[31merror:\x1b[0m {err}");
+        eprintln!("\x1b[31merror:\x1b[0m {err:?}");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
Refactor `katana init` command to use explicit subcommands for rollup and sovereign chain modes. Now running `katana init` requires you to select the mode as a subcommand: `katana init rollup` or `katana init sovereign`. 

One of the reason why we made this change is because the CLI argument configurations will always require you to provide the arguments instead of falling back to prompting. 

The expected behaviour when you literally just run `katana init` is for it to prompt the arguments like so:

<img width="411" height="51" alt="Screenshot 2025-09-23 at 10 03 49 AM" src="https://github.com/user-attachments/assets/e910a787-e412-4c61-b519-ea574d689382" />

But due to how the CLI arguments is being configured, we instead get an error for not providing the arguments using flags:

<img width="1030" height="149" alt="Screenshot 2025-09-23 at 10 04 05 AM" src="https://github.com/user-attachments/assets/d5ab9ab6-ecb3-43f7-bd80-e4b9b646edfc" />

This is mainly because of the `#[arg(required_unless_present = "sovereign")]` tag we're using that forces us to provide the options if `--sovereign` is not present.

https://github.com/dojoengine/katana/blob/d584d4224f75f3648d55d1e4cec773ed638967ff/bin/katana/src/cli/init/mod.rs#L44-L48

Afaik it doesn't seem to be possible to 'fix' this using `clap` derive macro. Even if it does, I believe separating the mode into separate commands feels like a better UX.

## Comparison with current behaviour

- Current: `katana init --id my-chain --settlement-chain sepolia ...`
- New: `katana init rollup --id my-chain --settlement-chain sepolia ...`