### PR TITLE
fix(contracts): prevent unnecessary build script triggers

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -4,6 +4,7 @@ license.workspace = true
 name = "katana-contracts"
 repository.workspace = true
 version.workspace = true
+build = "build.rs"
 
 [dependencies]
 katana-contracts-macro = { path = "macro" }

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -12,7 +12,7 @@ fn main() {
     println!("cargo:rerun-if-changed=contracts/messaging");
     println!("cargo:rerun-if-changed=contracts/test-contracts");
     println!("cargo:rerun-if-changed=contracts/vrf");
-    
+
     // Also track the build script itself
     println!("cargo:rerun-if-changed=build.rs");
 
@@ -97,13 +97,13 @@ fn should_skip_build(contracts_dir: &Path, build_dir: &Path) -> bool {
     // Get the oldest modification time from the build directory
     // We use oldest to ensure all build artifacts are newer than sources
     let build_time = get_oldest_mtime_in_dir(build_dir);
-    
+
     if build_time.is_none() {
         return false;
     }
-    
+
     let build_time = build_time.unwrap();
-    
+
     // Check if any source files are newer than the build artifacts
     let source_dirs = [
         contracts_dir.join("account"),
@@ -112,7 +112,7 @@ fn should_skip_build(contracts_dir: &Path, build_dir: &Path) -> bool {
         contracts_dir.join("test-contracts"),
         contracts_dir.join("vrf"),
     ];
-    
+
     for dir in &source_dirs {
         if let Some(source_time) = get_newest_mtime_recursive(dir) {
             if source_time > build_time {
@@ -120,7 +120,7 @@ fn should_skip_build(contracts_dir: &Path, build_dir: &Path) -> bool {
             }
         }
     }
-    
+
     // Check Scarb.toml (but not Scarb.lock)
     if let Ok(metadata) = fs::metadata(contracts_dir.join("Scarb.toml")) {
         if let Ok(source_time) = metadata.modified() {
@@ -129,7 +129,7 @@ fn should_skip_build(contracts_dir: &Path, build_dir: &Path) -> bool {
             }
         }
     }
-    
+
     true
 }
 
@@ -150,11 +150,11 @@ fn get_oldest_mtime_in_dir(path: &Path) -> Option<SystemTime> {
 
 fn get_newest_mtime_recursive(path: &Path) -> Option<SystemTime> {
     let mut latest_time = None;
-    
+
     if let Ok(entries) = fs::read_dir(path) {
         for entry in entries.flatten() {
             let path = entry.path();
-            
+
             if path.is_file() {
                 // Check all source files, not just .cairo
                 // This includes .toml files in subdirectories
@@ -184,7 +184,7 @@ fn get_newest_mtime_recursive(path: &Path) -> Option<SystemTime> {
             }
         }
     }
-    
+
     latest_time
 }
 

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -1,9 +1,20 @@
 use std::path::Path;
 use std::process::Command;
+use std::time::SystemTime;
 use std::{env, fs};
 
 fn main() {
-    println!("cargo:rerun-if-changed=contracts/");
+    // Track specific source directories and files that should trigger a rebuild
+    // Important: We don't track Scarb.lock as scarb itself updates it
+    println!("cargo:rerun-if-changed=contracts/Scarb.toml");
+    println!("cargo:rerun-if-changed=contracts/account");
+    println!("cargo:rerun-if-changed=contracts/legacy");
+    println!("cargo:rerun-if-changed=contracts/messaging");
+    println!("cargo:rerun-if-changed=contracts/test-contracts");
+    println!("cargo:rerun-if-changed=contracts/vrf");
+    
+    // Also track the build script itself
+    println!("cargo:rerun-if-changed=build.rs");
 
     let contracts_dir = Path::new("contracts");
     let target_dir = contracts_dir.join("target/dev");
@@ -21,8 +32,15 @@ fn main() {
         return;
     }
 
-    // Only build if we're not in a docs build or if explicitly requested
+    // Only build if we're not in a docs build
     if env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
+    // Check if we need to rebuild by comparing source and target timestamps
+    // This prevents unnecessary scarb runs which update Scarb.lock
+    if should_skip_build(&contracts_dir, &build_dir) {
+        println!("cargo:warning=Contracts are up to date, skipping scarb build");
         return;
     }
 
@@ -68,6 +86,106 @@ fn main() {
     } else {
         println!("cargo:warning=No contract artifacts found in target/dev");
     }
+}
+
+fn should_skip_build(contracts_dir: &Path, build_dir: &Path) -> bool {
+    // If build directory doesn't exist, we need to build
+    if !build_dir.exists() {
+        return false;
+    }
+
+    // Get the oldest modification time from the build directory
+    // We use oldest to ensure all build artifacts are newer than sources
+    let build_time = get_oldest_mtime_in_dir(build_dir);
+    
+    if build_time.is_none() {
+        return false;
+    }
+    
+    let build_time = build_time.unwrap();
+    
+    // Check if any source files are newer than the build artifacts
+    let source_dirs = [
+        contracts_dir.join("account"),
+        contracts_dir.join("legacy"),
+        contracts_dir.join("messaging"),
+        contracts_dir.join("test-contracts"),
+        contracts_dir.join("vrf"),
+    ];
+    
+    for dir in &source_dirs {
+        if let Some(source_time) = get_newest_mtime_recursive(dir) {
+            if source_time > build_time {
+                return false;
+            }
+        }
+    }
+    
+    // Check Scarb.toml (but not Scarb.lock)
+    if let Ok(metadata) = fs::metadata(contracts_dir.join("Scarb.toml")) {
+        if let Ok(source_time) = metadata.modified() {
+            if source_time > build_time {
+                return false;
+            }
+        }
+    }
+    
+    true
+}
+
+fn get_oldest_mtime_in_dir(path: &Path) -> Option<SystemTime> {
+    fs::read_dir(path).ok().and_then(|entries| {
+        entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                if e.path().is_file() {
+                    e.metadata().ok().and_then(|m| m.modified().ok())
+                } else {
+                    None
+                }
+            })
+            .min()
+    })
+}
+
+fn get_newest_mtime_recursive(path: &Path) -> Option<SystemTime> {
+    let mut latest_time = None;
+    
+    if let Ok(entries) = fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            
+            if path.is_file() {
+                // Check all source files, not just .cairo
+                // This includes .toml files in subdirectories
+                if let Some(ext) = path.extension() {
+                    let ext_str = ext.to_str().unwrap_or("");
+                    if ext_str == "cairo" || ext_str == "toml" {
+                        if let Ok(metadata) = entry.metadata() {
+                            if let Ok(mtime) = metadata.modified() {
+                                latest_time = Some(match latest_time {
+                                    None => mtime,
+                                    Some(t) if mtime > t => mtime,
+                                    Some(t) => t,
+                                });
+                            }
+                        }
+                    }
+                }
+            } else if path.is_dir() {
+                // Recursively check subdirectories
+                if let Some(dir_time) = get_newest_mtime_recursive(&path) {
+                    latest_time = Some(match latest_time {
+                        None => dir_time,
+                        Some(t) if dir_time > t => dir_time,
+                        Some(t) => t,
+                    });
+                }
+            }
+        }
+    }
+    
+    latest_time
 }
 
 fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
Fixes build script triggering on every `cargo build` even when contract files haven't changed

## Problem

The `katana-contracts` build script was being triggered unnecessarily on every `cargo build` command, even when no files in the `crates/contracts/contracts` directory had changed.

## Root Causes

* The build script was watching the entire `contracts/` directory with `cargo:rerun-if-changed=contracts/`, which is unreliable in Cargo
* `scarb build` updates `Scarb.lock` file timestamp even when content doesn't change

## Solution

Instead of watching the entire `contracts/` directory, the script watches the nested directories instead to avoid including `Scarb.lock` file in the watch list.

🤖 Generated with [Claude Code](https://claude.ai/code)