### PR TITLE
ci: exclude `db-compat-test` from test job builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,12 +199,12 @@ jobs:
       - name: Run tests
         if: github.event_name != 'pull_request'
         run: |
-          cargo nextest run --all-features --workspace --exclude snos-integration-test --build-jobs 20
+          cargo nextest run --all-features --workspace --exclude snos-integration-test --exclude db-compat-test --build-jobs 20
 
       - name: Run tests w/ code coverage
         if: github.event_name == 'pull_request'
         run: |
-          cargo llvm-cov nextest --no-report --all-features --workspace --exclude snos-integration-test --build-jobs 20
+          cargo llvm-cov nextest --no-report --all-features --workspace --exclude snos-integration-test --exclude db-compat-test --build-jobs 20
           cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload code coverage


### PR DESCRIPTION
## Summary
- Excludes `db-compat-test` crate from being built in the test job
- Reduces unnecessary build time since this crate is not executed by the test harness

## Changes
Added `--exclude db-compat-test` flag to both test commands in the workflow:
- Regular test run (`cargo nextest run`)
- Code coverage test run (`cargo llvm-cov nextest`)

This optimization skips building a crate that isn't used during testing, improving CI efficiency.

🤖 Generated with [Claude Code](https://claude.ai/code)