### PR TITLE
feat(cli): `katana node` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5847,6 +5847,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "similar-asserts",
  "spinoff",
  "starknet",
  "strum_macros 0.25.3",

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -50,6 +50,7 @@ vergen-gitcl = { version = "1.0.0", features = [ "build", "cargo", "rustc", "si"
 katana-provider.workspace = true
 
 arbitrary.workspace = true
+similar-asserts.workspace = true
 assert_matches.workspace = true
 proptest = "1.0"
 rstest.workspace = true

--- a/bin/katana/src/cli/config.rs
+++ b/bin/katana/src/cli/config.rs
@@ -5,6 +5,7 @@ use katana_primitives::chain::ChainId;
 use starknet::core::utils::parse_cairo_short_string;
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ConfigArgs {
     /// The chain id.
     #[arg(value_parser = ChainId::parse)]

--- a/bin/katana/src/cli/db/mod.rs
+++ b/bin/katana/src/cli/db/mod.rs
@@ -11,12 +11,14 @@ mod stats;
 mod version;
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct DbArgs {
     #[command(subcommand)]
     commands: Commands,
 }
 
 #[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 enum Commands {
     /// Retrieves database statistics
     Stats(stats::StatsArgs),

--- a/bin/katana/src/cli/db/prune.rs
+++ b/bin/katana/src/cli/db/prune.rs
@@ -15,6 +15,7 @@ use super::open_db_ro;
 use crate::cli::db::open_db_rw;
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct PruneArgs {
     /// Path to the database directory.
     #[arg(short, long)]

--- a/bin/katana/src/cli/db/stats.rs
+++ b/bin/katana/src/cli/db/stats.rs
@@ -17,6 +17,7 @@ macro_rules! byte_unit {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct StatsArgs {
     /// Path to the database directory.
     #[arg(short, long)]

--- a/bin/katana/src/cli/db/version.rs
+++ b/bin/katana/src/cli/db/version.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use katana_db::version::{get_db_version, CURRENT_DB_VERSION};
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct VersionArgs {
     /// Path to the database directory.
     ///

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -84,6 +84,7 @@ mod settlement;
 mod slot;
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct InitCommand {
     #[command(subcommand)]
     pub mode: InitMode,
@@ -91,6 +92,7 @@ pub struct InitCommand {
 
 /// initialization mode selection for different chain types.
 #[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum InitMode {
     #[command(about = "Initialize a rollup chain")]
     Rollup(Box<RollupArgs>),
@@ -109,6 +111,7 @@ pub enum InitMode {
 ///
 /// If no arguments are provided, the command will prompt interactively for them.
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct RollupArgs {
     /// The id of the new chain to be initialized.
     ///
@@ -183,6 +186,7 @@ with a known chain is a no-op for now.")
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct SovereignArgs {
     /// The id of the new chain to be initialized.
     ///

--- a/bin/katana/src/cli/init/slot.rs
+++ b/bin/katana/src/cli/init/slot.rs
@@ -8,6 +8,7 @@ use katana_genesis::Genesis;
 use katana_primitives::{ContractAddress, Felt, U256};
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[command(next_help_heading = "Slot options")]
 pub struct SlotArgs {
     /// Enable `slot`-specific features.
@@ -33,7 +34,7 @@ pub struct SlotArgs {
     pub paymaster_accounts: Option<Vec<PaymasterAccountArgs>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaymasterAccountArgs {
     /// The public key of the paymaster account.
     pub public_key: Felt,

--- a/bin/katana/src/cli/mod.rs
+++ b/bin/katana/src/cli/mod.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use anyhow::{Context, Result};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
-use katana_cli::NodeArgs;
+use katana_cli::{NodeCli, SequencerNodeArgs};
 use tokio::runtime::Runtime;
 
 mod config;
@@ -23,7 +23,7 @@ pub struct Cli {
     commands: Option<Commands>,
 
     #[command(flatten)]
-    node: NodeArgs,
+    node: SequencerNodeArgs,
 }
 
 impl Cli {
@@ -36,6 +36,7 @@ impl Cli {
                 Commands::Init(args) => execute_async(args.execute())?,
                 #[cfg(feature = "client")]
                 Commands::Rpc(args) => execute_async(args.execute())?,
+                Commands::Node(args) => execute_async(args.execute())?,
             };
         }
 
@@ -60,6 +61,9 @@ enum Commands {
     #[cfg(feature = "client")]
     #[command(about = "RPC client for interacting with Katana")]
     Rpc(rpc::RpcArgs),
+
+    #[command(about = "Run and manage Katana nodes")]
+    Node(NodeCli),
 }
 
 #[derive(Debug, Args)]

--- a/bin/katana/src/cli/rpc/mod.rs
+++ b/bin/katana/src/cli/rpc/mod.rs
@@ -6,6 +6,7 @@ mod client;
 mod starknet;
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct RpcArgs {
     #[command(subcommand)]
     command: starknet::StarknetCommands,
@@ -26,6 +27,7 @@ impl RpcArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[command(next_help_heading = "Server options")]
 pub struct ServerOptions {
     /// Katana RPC endpoint URL

--- a/bin/katana/src/cli/rpc/starknet.rs
+++ b/bin/katana/src/cli/rpc/starknet.rs
@@ -10,6 +10,7 @@ use katana_primitives::{ContractAddress, Felt};
 use super::client::Client;
 
 #[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum StarknetCommands {
     /// Get Starknet JSON-RPC specification version
     #[command(name = "spec")]
@@ -88,6 +89,7 @@ pub enum StarknetCommands {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct BlockIdArgs {
     /// Block ID (number, hash, 'latest', or 'pending'). Defaults to 'latest'
     #[arg(default_value = "latest")]
@@ -95,6 +97,7 @@ pub struct BlockIdArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetBlockArgs {
     /// Block ID (number, hash, 'latest', or 'pending'). Defaults to 'latest'
     #[arg(default_value = "latest")]
@@ -110,6 +113,7 @@ pub struct GetBlockArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct TxHashArgs {
     /// Transaction hash
     #[arg(value_name = "TX_HASH")]
@@ -117,6 +121,7 @@ pub struct TxHashArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetTransactionArgs {
     /// Transaction hash
     #[arg(value_name = "TX_HASH")]
@@ -128,6 +133,7 @@ pub struct GetTransactionArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetStorageAtArgs {
     /// Contract address
     #[arg(value_name = "ADDRESS")]
@@ -143,6 +149,7 @@ pub struct GetStorageAtArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetTransactionByBlockIdAndIndexArgs {
     /// Block ID (number, hash, 'latest', or 'pending'). Defaults to 'latest'
     #[arg(default_value = "latest")]
@@ -153,6 +160,7 @@ pub struct GetTransactionByBlockIdAndIndexArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetClassArgs {
     /// Class hash
     #[arg(value_name = "CLASS_HASH")]
@@ -165,6 +173,7 @@ pub struct GetClassArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetClassHashAtArgs {
     /// Contract address
     #[arg(value_name = "ADDRESS")]
@@ -177,6 +186,7 @@ pub struct GetClassHashAtArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetClassAtArgs {
     /// Contract address
     #[arg(value_name = "ADDRESS")]
@@ -189,6 +199,7 @@ pub struct GetClassAtArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct CallArgs {
     /// Contract address
     #[arg(value_name = "ADDRESS")]
@@ -207,12 +218,14 @@ pub struct CallArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetEventsArgs {
     /// Event filter JSON
     filter: String,
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetNonceArgs {
     /// The contract address whose nonce is requested
     #[arg(value_name = "ADDRESS")]
@@ -225,6 +238,7 @@ pub struct GetNonceArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetStorageProofArgs {
     /// Class hashes JSON array
     #[arg(long)]
@@ -245,6 +259,7 @@ pub struct GetStorageProofArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct TraceBlockTransactionsArg {
     /// Block ID (number, hash, 'latest', or 'l1_accepted'). Defaults to 'latest'
     #[arg(default_value = "latest")]
@@ -396,9 +411,11 @@ impl StarknetCommands {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct BlockIdArg(pub BlockIdOrTag);
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ConfirmedBlockIdArg(pub ConfirmedBlockIdOrTag);
 
 impl std::str::FromStr for BlockIdArg {

--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -25,8 +25,7 @@ use starknet::core::utils::cairo_short_string_to_felt;
 
 use crate::SettlementLayer;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChainSpec {
     /// The rollup network chain id.
     pub id: ChainId,
@@ -110,8 +109,7 @@ impl ChainSpec {
 /// Tokens that can be used for transaction fee payments in the chain. As
 /// supported on Starknet.
 // TODO: include both l1 and l2 addresses
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeeContracts {
     /// L2 ETH fee token address. Used for paying pre-V3 transactions.
     pub eth: ContractAddress,

--- a/crates/chain-spec/src/lib.rs
+++ b/crates/chain-spec/src/lib.rs
@@ -8,7 +8,7 @@ use url::Url;
 pub mod dev;
 pub mod rollup;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChainSpec {
     Dev(dev::ChainSpec),
     Rollup(rollup::ChainSpec),
@@ -64,8 +64,7 @@ impl Default for ChainSpec {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum SettlementLayer {
     Ethereum {

--- a/crates/chain-spec/src/rollup/file.rs
+++ b/crates/chain-spec/src/rollup/file.rs
@@ -151,7 +151,7 @@ struct ChainSpecFile {
 /// The local directory name where the chain configuration files are stored.
 const KATANA_LOCAL_DIR: &str = "katana";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ChainConfigDir {
     Absolute(PathBuf),
     Local(LocalChainConfigDir),
@@ -202,7 +202,7 @@ impl ChainConfigDir {
 }
 
 // > LOCAL_DIR/$chain_id/
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LocalChainConfigDir(PathBuf);
 
 impl LocalChainConfigDir {

--- a/crates/chain-spec/src/rollup/mod.rs
+++ b/crates/chain-spec/src/rollup/mod.rs
@@ -15,8 +15,7 @@ pub use utils::DEFAULT_APPCHAIN_FEE_TOKEN_ADDRESS;
 use crate::SettlementLayer;
 
 /// The rollup chain specification.
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChainSpec {
     /// The rollup network chain id.
     pub id: ChainId,
@@ -56,8 +55,7 @@ impl ChainSpec {
 }
 
 /// Token that can be used for transaction fee payments on the chain.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeeContract {
     pub strk: ContractAddress,
 }

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -39,7 +39,7 @@ use crate::utils::{self, parse_chain_config_dir, parse_seed};
 
 pub(crate) const LOG_TARGET: &str = "katana::cli";
 
-#[derive(Parser, Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Parser, Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
 #[command(next_help_heading = "Sequencer node options")]
 pub struct SequencerNodeArgs {
     /// Don't print anything on startup.

--- a/crates/cli/src/file.rs
+++ b/crates/cli/src/file.rs
@@ -5,7 +5,7 @@ use katana_messaging::MessagingConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::options::*;
-use crate::NodeArgs;
+use crate::SequencerNodeArgs;
 
 /// Node arguments configuration file.
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -36,10 +36,10 @@ impl NodeArgsConfig {
     }
 }
 
-impl TryFrom<NodeArgs> for NodeArgsConfig {
+impl TryFrom<SequencerNodeArgs> for NodeArgsConfig {
     type Error = anyhow::Error;
 
-    fn try_from(args: NodeArgs) -> Result<Self> {
+    fn try_from(args: SequencerNodeArgs) -> Result<Self> {
         // Ensure the config file is merged with the CLI arguments.
         let args = args.with_config_file()?;
 

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 pub use clap::Parser;
 use serde::{Deserialize, Serialize};
 
@@ -42,6 +42,6 @@ pub struct FullNodeArgs {
 
 impl FullNodeArgs {
     pub async fn execute(&self) -> Result<()> {
-        unimplemented!()
+        Err(anyhow!("Full node is not implemented yet!"))
     }
 }

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::options::*;
 
-#[derive(Parser, Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Parser, Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
 #[command(next_help_heading = "Full node options")]
 pub struct FullNodeArgs {
     /// Don't print anything on startup.

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+pub use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+use crate::options::*;
+
+#[derive(Parser, Debug, Serialize, Deserialize, Default, Clone)]
+#[command(next_help_heading = "Full node options")]
+pub struct FullNodeArgs {
+    /// Don't print anything on startup.
+    #[arg(long)]
+    pub silent: bool,
+
+    /// Directory path of the database to initialize from.
+    ///
+    /// The path must either be an empty directory or a directory which already contains a
+    /// previously initialized Katana database.
+    #[arg(long)]
+    #[arg(value_name = "PATH")]
+    pub db_dir: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub logging: LoggingOptions,
+
+    #[command(flatten)]
+    pub tracer: TracerOptions,
+
+    #[cfg(feature = "server")]
+    #[command(flatten)]
+    pub metrics: MetricsOptions,
+
+    #[cfg(feature = "server")]
+    #[command(flatten)]
+    pub server: ServerOptions,
+
+    #[cfg(feature = "explorer")]
+    #[command(flatten)]
+    pub explorer: ExplorerOptions,
+}
+
+impl FullNodeArgs {
+    pub async fn execute(&self) -> Result<()> {
+        unimplemented!()
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,9 +1,38 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
 pub mod args;
 pub mod file;
+pub mod full;
 pub mod options;
 pub mod utils;
 
-pub use args::NodeArgs;
+pub use args::SequencerNodeArgs;
 pub use options::*;
+
+use crate::full::FullNodeArgs;
+
+#[derive(Debug, Args)]
+pub struct NodeCli {
+    #[command(subcommand)]
+    command: NodeSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum NodeSubcommand {
+    #[command(about = "Launch a full node")]
+    Full(FullNodeArgs),
+    #[command(about = "Launch a sequencer node")]
+    Sequencer(SequencerNodeArgs),
+}
+
+impl NodeCli {
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            NodeSubcommand::Full(args) => args.execute().await,
+            NodeSubcommand::Sequencer(args) => args.with_config_file()?.execute().await,
+        }
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -14,14 +14,14 @@ pub use options::*;
 
 use crate::full::FullNodeArgs;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, PartialEq)]
 pub struct NodeCli {
     #[command(subcommand)]
-    command: NodeSubcommand,
+    pub command: NodeSubcommand,
 }
 
-#[derive(Debug, Subcommand)]
-enum NodeSubcommand {
+#[derive(Debug, Subcommand, PartialEq)]
+pub enum NodeSubcommand {
     #[command(about = "Launch a full node", hide = true)]
     Full(Box<FullNodeArgs>),
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -22,10 +22,11 @@ pub struct NodeCli {
 
 #[derive(Debug, Subcommand)]
 enum NodeSubcommand {
-    #[command(about = "Launch a full node")]
-    Full(FullNodeArgs),
+    #[command(about = "Launch a full node", hide = true)]
+    Full(Box<FullNodeArgs>),
+
     #[command(about = "Launch a sequencer node")]
-    Sequencer(SequencerNodeArgs),
+    Sequencer(Box<SequencerNodeArgs>),
 }
 
 impl NodeCli {

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Deserializer, Serializer};
 use tracing::info;
 
 use crate::args::LOG_TARGET;
-use crate::NodeArgs;
+use crate::SequencerNodeArgs;
 
 pub fn parse_seed(seed: &str) -> [u8; 32] {
     let seed = seed.as_bytes();
@@ -51,7 +51,7 @@ pub fn parse_block_hash_or_number(value: &str) -> Result<BlockHashOrNumber> {
     }
 }
 
-pub fn print_intro(args: &NodeArgs, chain: &ChainSpec) {
+pub fn print_intro(args: &SequencerNodeArgs, chain: &ChainSpec) {
     let mut accounts = chain.genesis().accounts().peekable();
     let account_class_hash = accounts.peek().map(|e| e.1.class_hash());
     let seed = &args.development.seed;

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use self::allocation::{GenesisAccountAlloc, GenesisAllocation, GenesisContractAlloc};
 
 /// Genesis block configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Genesis {
     /// The genesis block parent hash.
     pub parent_hash: BlockHash,

--- a/crates/messaging/src/lib.rs
+++ b/crates/messaging/src/lib.rs
@@ -89,7 +89,7 @@ impl From<TransportError> for Error {
 }
 
 /// The config used to initialize the messaging service.
-#[derive(Debug, Default, Deserialize, Clone, Serialize, PartialEq)]
+#[derive(Debug, Default, Deserialize, Clone, Serialize, PartialEq, Eq)]
 pub struct MessagingConfig {
     /// The settlement chain.
     pub chain: String,

--- a/crates/node/src/config/db.rs
+++ b/crates/node/src/config/db.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 /// Database configurations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DbConfig {
     /// The path to the database directory.
     pub dir: Option<PathBuf>,

--- a/crates/node/src/config/dev.rs
+++ b/crates/node/src/config/dev.rs
@@ -5,7 +5,7 @@ use katana_gas_price_oracle::{
 use katana_primitives::block::GasPrices;
 
 /// Development configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DevConfig {
     /// Whether to enable paying fees for transactions.
     ///
@@ -35,7 +35,7 @@ pub struct DevConfig {
 
 // TODO: move to gas oracle options
 /// Fixed gas prices for development.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FixedL1GasPriceConfig {
     pub l2_gas_prices: GasPrices,
     pub l1_gas_prices: GasPrices,

--- a/crates/node/src/config/execution.rs
+++ b/crates/node/src/config/execution.rs
@@ -6,7 +6,7 @@ pub const DEFAULT_VALIDATION_MAX_STEPS: u32 = 1_000_000;
 #[cfg(feature = "native")]
 pub const DEFAULT_ENABLE_NATIVE_COMPILATION: bool = false;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecutionConfig {
     pub invocation_max_steps: u32,
     pub validation_max_steps: u32,

--- a/crates/node/src/config/fork.rs
+++ b/crates/node/src/config/fork.rs
@@ -2,7 +2,7 @@ use katana_primitives::block::BlockHashOrNumber;
 use url::Url;
 
 /// Node forking configurations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForkingConfig {
     /// The JSON-RPC URL of the network to fork from.
     pub url: Url,

--- a/crates/node/src/config/gateway.rs
+++ b/crates/node/src/config/gateway.rs
@@ -9,7 +9,7 @@ pub const DEFAULT_GATEWAY_PORT: u16 = 5051;
 pub const DEFAULT_GATEWAY_TIMEOUT_SECS: u64 = 20;
 
 /// Configuration for the gateway server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GatewayConfig {
     /// The IP address the gateway server will bind to.
     pub addr: IpAddr,

--- a/crates/node/src/config/metrics.rs
+++ b/crates/node/src/config/metrics.rs
@@ -6,7 +6,7 @@ pub const DEFAULT_METRICS_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 pub const DEFAULT_METRICS_PORT: u16 = 9100;
 
 /// Node metrics configurations.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct MetricsConfig {
     /// The address to bind the metrics server to.
     pub addr: IpAddr,

--- a/crates/node/src/config/mod.rs
+++ b/crates/node/src/config/mod.rs
@@ -25,7 +25,7 @@ use sequencing::SequencingConfig;
 /// Node configurations.
 ///
 /// List of all possible options that can be used to configure a node.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Config {
     /// The chain specification.
     pub chain: Arc<ChainSpec>,

--- a/crates/node/src/config/paymaster.rs
+++ b/crates/node/src/config/paymaster.rs
@@ -1,6 +1,6 @@
 use url::Url;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaymasterConfig {
     /// The root URL for the Cartridge API.
     pub cartridge_api_url: Url,

--- a/crates/node/src/config/rpc.rs
+++ b/crates/node/src/config/rpc.rs
@@ -37,7 +37,7 @@ pub enum RpcModuleKind {
 }
 
 /// Configuration for the RPC server.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RpcConfig {
     pub addr: IpAddr,
     pub port: u16,

--- a/crates/node/src/config/sequencing.rs
+++ b/crates/node/src/config/sequencing.rs
@@ -1,7 +1,7 @@
 use katana_executor::BlockLimits;
 
 /// Configurations related to block production.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SequencingConfig {
     /// The time in milliseconds for a block to be produced.
     pub block_time: Option<u64>,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -51,7 +51,7 @@ pub enum ConfirmedBlockIdOrTag {
     L1Accepted,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlockHashOrNumber {
     Hash(BlockHash),

--- a/crates/tracing/src/fmt.rs
+++ b/crates/tracing/src/fmt.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::time::{self};
 
 /// Format for logging output.
-#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize, Default, Eq)]
 pub enum LogFormat {
     /// Full text format with colors and human-readable layout.
     #[default]


### PR DESCRIPTION
Introduce a dedicated subcommand for starting a Katana node, `katana node`. 

```
$ katana node
Run and manage Katana nodes

Usage: katana node <COMMAND>

Commands:
  sequencer  Launch a sequencer node
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

You can still launch the node by running `katana` without any subcommand - it's a short form for `katana node sequencer`. This behaviour mainly for maintaining backward compatibility.
