### PR TITLE
fix(vrf): fetch nonce directly from vrf contract storage

### DIFF
--- a/crates/cartridge/src/vrf.rs
+++ b/crates/cartridge/src/vrf.rs
@@ -2,9 +2,8 @@
 //! VRF provider contract):
 //!
 //! 1. The VRF provider contract is deployed (if not already deployed).
-//! 2. The Stark VRF proof is generated using the `Source` provided in the call. Since one of the
-//!    `Source` is a nonce for a given address, Katana keeps an in-memory cache of the nonces for
-//!    each address. WARNING: Restarting Katana will reset the cache, hence reset the VRF sequence.
+//! 2. The Stark VRF proof is generated using the `Source` provided in the call.
+//! The seed is precomputed to match smart contract behavior https://github.com/cartridge-gg/vrf/blob/38d71385f939a19829113c122f1ab12dbbe0f877/src/vrf_provider/vrf_provider_component.cairo#L112
 //! 3. The original execution from outside call is then sandwitched between two VRF calls, one for
 //!    submitting the randomness, and one to assert the correct consumption of the randomness.
 //! 4. When using the VRF, the user has the responsability to add a first call to target the VRF

--- a/crates/cartridge/src/vrf.rs
+++ b/crates/cartridge/src/vrf.rs
@@ -2,10 +2,13 @@
 //! VRF provider contract):
 //!
 //! 1. The VRF provider contract is deployed (if not already deployed).
-//! 2. The Stark VRF proof is generated using the `Source` provided in the call.
-//! The seed is precomputed to match smart contract behavior https://github.com/cartridge-gg/vrf/blob/38d71385f939a19829113c122f1ab12dbbe0f877/src/vrf_provider/vrf_provider_component.cairo#L112
+//!
+//! 2. The Stark VRF proof is generated using the `Source` provided in the call. The seed is
+//!    precomputed to match smart contract behavior <https://github.com/cartridge-gg/vrf/blob/38d71385f939a19829113c122f1ab12dbbe0f877/src/vrf_provider/vrf_provider_component.cairo#L112>.
+//!
 //! 3. The original execution from outside call is then sandwitched between two VRF calls, one for
 //!    submitting the randomness, and one to assert the correct consumption of the randomness.
+//!
 //! 4. When using the VRF, the user has the responsability to add a first call to target the VRF
 //!    provider contract `request_random` entrypoint. This call sets which `Source` will be used
 //!    to generate the randomness.

--- a/crates/cartridge/src/vrf.rs
+++ b/crates/cartridge/src/vrf.rs
@@ -16,16 +16,12 @@
 //! from environment variable `KATANA_VRF_PRIVATE_KEY`. It is important to note that changing the
 //! private key will result in a different VRF provider contract address.
 
-use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use ark_ec::short_weierstrass::Affine;
-use katana_primitives::contract::Nonce;
 use katana_primitives::utils::get_contract_address;
 use katana_primitives::{ContractAddress, Felt};
-use num_bigint::{BigInt, BigUint};
-use parking_lot::Mutex;
+use num_bigint::BigInt;
 use stark_vrf::{generate_public_key, BaseField, StarkCurve, StarkVRF};
 use starknet::macros::{felt, short_string};
 use tracing::trace;
@@ -37,7 +33,7 @@ use tracing::trace;
 pub const CARTRIDGE_VRF_CLASS_HASH: Felt =
     felt!("0x07007ea60938ff539f1c0772a9e0f39b4314cfea276d2c22c29a8b64f2a87a58");
 pub const CARTRIDGE_VRF_SALT: Felt = short_string!("cartridge_vrf");
-pub const CARTRIDGE_VRF_DEFAULT_PRIVATE_KEY: Felt = felt!("0x01");
+pub const CARTRIDGE_VRF_DEFAULT_PRIVATE_KEY: Felt = felt!("0x1");
 
 #[derive(Debug, Default, Clone)]
 pub struct StarkVrfProof {
@@ -54,28 +50,27 @@ pub struct VrfContext {
     private_key: Felt,
     public_key: Affine<StarkCurve>,
     contract_address: ContractAddress,
-    cache: Arc<Mutex<HashMap<ContractAddress, Nonce>>>,
 }
 
 impl VrfContext {
     /// Creates a new [`VrfContext`] with the given private key and provider address.
     pub fn new(private_key: Felt, provider: ContractAddress) -> Self {
-        let cache = Arc::new(Mutex::new(HashMap::new()));
         let public_key = generate_public_key(private_key.to_biguint().into());
 
         let contract_address = compute_vrf_address(
             provider,
-            Felt::from(BigUint::from(public_key.x.0)),
-            Felt::from(BigUint::from(public_key.y.0)),
+            Felt::from_hex(&format(public_key.x)).unwrap(),
+            Felt::from_hex(&format(public_key.y)).unwrap(),
         );
 
-        Self { cache, private_key, public_key, contract_address }
+        Self { private_key, public_key, contract_address }
     }
 
     /// Get the public key x and y coordinates as Felt values.
     pub fn get_public_key_xy_felts(&self) -> (Felt, Felt) {
-        let x = Felt::from(BigUint::from(self.public_key.x.0));
-        let y = Felt::from(BigUint::from(self.public_key.y.0));
+        let x = Felt::from_hex(&format(self.public_key.x)).unwrap();
+        let y = Felt::from_hex(&format(self.public_key.y)).unwrap();
+
         (x, y)
     }
 
@@ -94,26 +89,12 @@ impl VrfContext {
         &self.public_key
     }
 
-    /// Returns the current internal nonce of the `address` and consume it. Consuming the nonce will
-    /// increment it by one - ensuring the generated VRF seed will always be unique.
-    ///
-    /// This is when the VRF is requested with nonce as the source of randomness.
-    ///
-    /// Refer to <https://docs.cartridge.gg/vrf/overview#using-the-vrf-provider> for further information.
-    pub fn consume_nonce(&self, address: ContractAddress) -> Nonce {
-        let mut cache = self.cache.lock();
-        let nonce = cache.get(&address).unwrap_or(&Felt::ZERO).to_owned();
-        cache.insert(address, nonce + Felt::ONE);
-        nonce
-    }
-
     /// Computes a VRF proof for the given seed.
     pub fn stark_vrf(&self, seed: Felt) -> anyhow::Result<StarkVrfProof> {
         let private_key = self.private_key.to_string();
         let public_key = self.public_key;
 
         let seed = vec![BaseField::from(seed.to_biguint())];
-
         let ecvrf = StarkVRF::new(public_key)?;
         let proof = ecvrf.prove(&private_key.parse().unwrap(), seed.as_slice())?;
         let sqrt_ratio_hint = ecvrf.hash_to_sqrt_ratio_hint(seed.as_slice());

--- a/crates/rpc/rpc/src/cartridge/mod.rs
+++ b/crates/rpc/rpc/src/cartridge/mod.rs
@@ -456,7 +456,10 @@ async fn handle_vrf_calls(
     let salt_or_nonce = first_call.calldata[2];
 
     let seed = if salt_or_nonce_selector == Felt::ZERO {
-        let key = pedersen_hash(&selector!("VrfProvider_nonces"), &salt_or_nonce);
+        // compute storage key of the VRF contract storage member VrfProvider_nonces:
+        // Map<ContractAddress, felt252>
+        let address = salt_or_nonce;
+        let key = pedersen_hash(&selector!("VrfProvider_nonces"), &address);
         let nonce = state.storage(vrf_ctx.address(), key).unwrap_or_default().unwrap_or_default();
         starknet_crypto::poseidon_hash_many(vec![&nonce, &caller, &chain_id.id()])
     } else if salt_or_nonce_selector == Felt::ONE {


### PR DESCRIPTION
branch from @notV4l (https://github.com/dojoengine/katana/pull/208) rebased to main.

Validated using `nums`, it works fine 👍  