### PR TITLE
feat(tasks): add task identification system

### DIFF
--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -6,6 +6,6 @@ mod spawner;
 mod task;
 
 pub use blocking::*;
-pub use manager::*;
+pub use manager::{TaskId, TaskManager};
 pub use spawner::*;
 pub use task::*;


### PR DESCRIPTION
## Summary

Implements unique task IDs for all tasks spawned via `TaskManager` to improve debugging and visibility during development.

## Changes

- **TaskId Type**: Added a new `TaskId` type that uniquely identifies each spawned task
  - Implements `Display`, `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, and `Hash`
  - IDs are generated sequentially using an atomic counter for thread-safety

- **Shutdown Initiator Tracking**: Tasks that trigger graceful shutdown are now tracked
  - Added `shutdown_initiator` field to store the ID of the task that initiated shutdown
  - Public method `TaskManager::shutdown_initiator()` returns the initiator task ID

- **Enhanced Logging**: All task completion and panic messages now include task IDs
  - Tasks with graceful shutdown log at `info` level with ID and name
  - Regular task completion logs at `debug` level with ID and name
  - Format: `id = <task_id>, task = <optional_name>`

- **TaskBuilder Integration**: Each `TaskBuilder` gets a unique ID when created
  - Added `TaskBuilder::id()` method to retrieve the task's ID before spawning
  - ID is automatically assigned when calling `build_task()`

## Benefits

- **Better Debugging**: Identify exactly which task caused graceful shutdown
- **Improved Tracing**: All log messages include task IDs for easier task execution tracking
- **Backward Compatible**: Existing code continues to work without changes
- **Thread-Safe**: Uses atomic operations for ID generation

## Usage Example

```rust
let manager = TaskManager::current();
let spawner = manager.task_spawner();

let task = spawner.build_task()
    .name("Block production")
    .graceful_shutdown()
    .spawn(some_future);

// Later, after shutdown:
if let Some(task_id) = manager.shutdown_initiator() {
    println!("Shutdown was initiated by task: {}", task_id);
}
```

## Testing

- Updated existing tests to verify shutdown initiator tracking
- All tests pass successfully
- Code is properly formatted according to project standards

Closes DOJ-1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)