### PR TITLE
refactor(rpc): enter span context in task spawns

### DIFF
--- a/crates/rpc/rpc/src/cartridge/mod.rs
+++ b/crates/rpc/rpc/src/cartridge/mod.rs
@@ -270,7 +270,11 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
         R: Send + 'static,
     {
         let this = self.clone();
-        match self.task_spawner.spawn_blocking(move || func(this)).await {
+        let span = tracing::Span::current();
+        match self.task_spawner.spawn_blocking(move || {
+            let _enter = span.enter();
+            func(this)
+        }).await {
             TaskResult::Ok(result) => Ok(result),
             TaskResult::Err(err) => {
                 Err(StarknetApiError::unexpected(format!("internal task execution failed: {err}")))

--- a/crates/rpc/rpc/src/cartridge/mod.rs
+++ b/crates/rpc/rpc/src/cartridge/mod.rs
@@ -271,10 +271,14 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
     {
         let this = self.clone();
         let span = tracing::Span::current();
-        match self.task_spawner.spawn_blocking(move || {
-            let _enter = span.enter();
-            func(this)
-        }).await {
+        match self
+            .task_spawner
+            .spawn_blocking(move || {
+                let _enter = span.enter();
+                func(this)
+            })
+            .await
+        {
             TaskResult::Ok(result) => Ok(result),
             TaskResult::Err(err) => {
                 Err(StarknetApiError::unexpected(format!("internal task execution failed: {err}")))

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -182,10 +182,15 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
     {
         let this = self.clone();
         let span = tracing::Span::current();
-        match self.inner.task_spawner.spawn_blocking(move || {
-            let _enter = span.enter();
-            func(this)
-        }).await {
+        match self
+            .inner
+            .task_spawner
+            .spawn_blocking(move || {
+                let _enter = span.enter();
+                func(this)
+            })
+            .await
+        {
             TaskResult::Ok(result) => Ok(result),
             TaskResult::Err(err) => {
                 Err(StarknetApiError::unexpected(format!("internal task execution failed: {err}")))


### PR DESCRIPTION
Ensures `tracing` span context is properly propagated when spawning blocking tasks in RPC handlers.

## Changes

- **`StarknetApi`**: Added span context entry in `on_cpu_blocking_task` and `on_io_blocking_task` methods
- **`CartridgeApi`**: Added span context entry in `on_io_bound_task` method

## Convention

**Span context entry is handled at the application level (RPC layer), not in the `TaskManager`/`TaskSpawner` infrastructure.** This design keeps the task management layer agnostic to tracing concerns, while allowing application code to maintain proper trace correlation across thread boundaries.

The implementation captures the current span before spawning tasks and enters it within the spawned closure, ensuring all tracing events in blocking tasks are properly associated with their parent RPC call.

Related #289 

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)