### PR TITLE
refactor(sync): remove `async_trait` from `Stage` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6572,7 +6572,6 @@ name = "katana-stage"
 version = "1.7.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "backon",
  "futures",
  "katana-core",

--- a/crates/sync/stage/Cargo.toml
+++ b/crates/sync/stage/Cargo.toml
@@ -17,7 +17,6 @@ katana-rpc-types.workspace = true
 katana-tasks.workspace = true
 
 anyhow.workspace = true
-async-trait.workspace = true
 backon.workspace = true
 futures.workspace = true
 num-traits.workspace = true

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -44,10 +44,32 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
+/// A stage in the sync pipeline.
+///
+/// Stages are the building blocks of the sync pipeline. Each stage performs a specific task
+/// in the synchronization process (e.g., downloading blocks, downloading classes, executing
+/// transactions).
+///
+/// # Implementation Note
+///
+/// The [`execute`](Stage::execute) method returns a [`BoxFuture`] instead of `impl Future` to
+/// maintain dyn-compatibility. This allows the pipeline to store different stage implementations
+/// in a `Vec<Box<dyn Stage>>`, enabling dynamic composition of sync stages at runtime.
+///
+/// While this introduces a small heap allocation for the future, it's negligible compared to
+/// the actual async work performed by stages (network I/O, database operations, etc.).
 pub trait Stage: Send + Sync {
     /// Returns the id which uniquely identifies the stage.
     fn id(&self) -> &'static str;
 
     /// Executes the stage.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The execution input containing the range of blocks to process
+    ///
+    /// # Returns
+    ///
+    /// A [`BoxFuture`] that resolves to a [`StageResult`] upon completion.
     fn execute<'a>(&'a mut self, input: &'a StageExecutionInput) -> BoxFuture<'a, StageResult>;
 }

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use futures::future::BoxFuture;
 use katana_primitives::block::BlockNumber;
 use katana_provider::api::ProviderError;
 
@@ -43,11 +44,10 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
-#[async_trait::async_trait]
 pub trait Stage: Send + Sync {
     /// Returns the id which uniquely identifies the stage.
     fn id(&self) -> &'static str;
 
     /// Executes the stage.
-    async fn execute(&mut self, input: &StageExecutionInput) -> StageResult;
+    fn execute<'a>(&'a mut self, input: &'a StageExecutionInput) -> BoxFuture<'a, StageResult>;
 }


### PR DESCRIPTION
This PR refactors the `Stage` trait to remove the dependency on the `async_trait` macro by using explicit `BoxFuture` return types instead.

The `async_trait` macro internally boxes futures to maintain dyn-compatibility (it converts `async fn` to `fn() -> Pin<Box<dyn Future>>`). By using `BoxFuture` explicitly, we:

- **Remove the dependency**: No need for the `async_trait` proc-macro crate
- **Improve explicitness**: The boxing cost is visible in the trait signature
- **Maintain dyn-compatibility**: `Pipeline` can still use `Vec<Box<dyn Stage>>`

**Note**: This change produces functionally identical code to what `async_trait` generates - we're just being explicit about it rather than relying on macro expansion.