### PR TITLE
refactor(sync): enforce block range invariant in `StageExecutionInput`

### DIFF
--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -317,7 +317,7 @@ impl<P: StageCheckpointProvider> Pipeline<P> {
             info!(target: "pipeline", %id, from = %checkpoint, %to, "Executing stage.");
 
             // plus 1 because the checkpoint is inclusive
-            let input = StageExecutionInput { from: checkpoint + 1, to };
+            let input = StageExecutionInput::new(checkpoint + 1, to);
             stage.execute(&input).await.map_err(|error| Error::StageExecution { id, error })?;
             self.provider.set_checkpoint(id, to)?;
 

--- a/crates/sync/pipeline/tests/pipeline.rs
+++ b/crates/sync/pipeline/tests/pipeline.rs
@@ -57,11 +57,11 @@ impl Stage for TrackingStage {
     }
 
     fn execute<'a>(&'a mut self, input: &'a StageExecutionInput) -> BoxFuture<'a, StageResult> {
-        let from = input.from;
-        let to = input.to;
-        let executions = self.executions.clone();
         Box::pin(async move {
-            executions.lock().unwrap().push(ExecutionRecord { from, to });
+            self.executions
+                .lock()
+                .unwrap()
+                .push(ExecutionRecord { from: input.from(), to: input.to() });
             Ok(())
         })
     }

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -47,9 +47,6 @@ where
 
     fn execute<'a>(&'a mut self, input: &'a StageExecutionInput) -> BoxFuture<'a, StageResult> {
         Box::pin(async move {
-            // TODO: Implement range validation in the `Pipeline` level - or maybe in each stage as
-            // well?
-            debug_assert!(input.from <= input.to);
 
             let blocks = self
                 .downloader

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -47,7 +47,6 @@ where
 
     fn execute<'a>(&'a mut self, input: &'a StageExecutionInput) -> BoxFuture<'a, StageResult> {
         Box::pin(async move {
-
             let blocks = self
                 .downloader
                 .download_blocks(input.from, input.to)

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -49,7 +49,7 @@ where
         Box::pin(async move {
             let blocks = self
                 .downloader
-                .download_blocks(input.from, input.to)
+                .download_blocks(input.from(), input.to())
                 .await
                 .map_err(Error::Gateway)?;
 

--- a/crates/sync/stage/src/classes.rs
+++ b/crates/sync/stage/src/classes.rs
@@ -66,7 +66,7 @@ where
 
     fn execute<'a>(&'a mut self, input: &'a StageExecutionInput) -> BoxFuture<'a, StageResult> {
         Box::pin(async move {
-            let declared_classes = self.get_declared_classes(input.from, input.to)?;
+            let declared_classes = self.get_declared_classes(input.from(), input.to())?;
 
             if !declared_classes.is_empty() {
                 // fetch the classes artifacts

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -41,11 +41,13 @@ impl StageExecutionInput {
     }
 
     /// Returns the starting block number (inclusive).
+    #[inline]
     pub fn from(&self) -> BlockNumber {
         self.from
     }
 
     /// Returns the ending block number (inclusive).
+    #[inline]
     pub fn to(&self) -> BlockNumber {
         self.to
     }

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -21,11 +21,16 @@ pub type StageResult = Result<(), Error>;
 /// # Invariant
 ///
 /// The `to` field must always be greater than or equal to the `from` field (`to >= from`).
-/// This invariant is enforced at construction time via the [`new`](Self::new) method and must be
-/// maintained by all code paths that create this type.
-#[derive(Debug, Clone, Default)]
+/// This invariant is enforced at construction time via the [`new`](Self::new) method.
+///
+/// **Note**: Since the fields are public, this invariant cannot be fully enforced at the type
+/// level. Code that directly constructs this type via struct literal syntax or modifies the
+/// fields after construction must manually ensure the invariant is maintained. Violating this
+/// invariant may lead to unexpected behavior in [`Stage`] implementations, such as empty
+/// iterations, panics, or incorrect processing logic.
+#[derive(Debug, Clone)]
 pub struct StageExecutionInput {
-    /// The block number to start processing from.
+    /// The block number to start processing from (inclusive).
     pub from: BlockNumber,
     /// The block number to stop processing at (inclusive).
     pub to: BlockNumber,
@@ -39,17 +44,13 @@ impl StageExecutionInput {
     /// Panics if `to < from`, as this violates the type's invariant.
     pub fn new(from: BlockNumber, to: BlockNumber) -> Self {
         assert!(to >= from, "Invalid block range: `to` ({to}) must be >= `from` ({from})");
-        unsafe { Self::new_unchecked(from, to) }
-    }
-
-    /// Creates a new [`StageExecutionInput`] without validating the range invariant.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `to >= from`. Violating this invariant may lead to
-    /// unexpected behavior in [`Stage`] implementations.
-    pub unsafe fn new_unchecked(from: BlockNumber, to: BlockNumber) -> Self {
         Self { from, to }
+    }
+}
+
+impl Default for StageExecutionInput {
+    fn default() -> Self {
+        Self { from: 0, to: 0 }
     }
 }
 

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -21,19 +21,12 @@ pub type StageResult = Result<(), Error>;
 /// # Invariant
 ///
 /// The `to` field must always be greater than or equal to the `from` field (`to >= from`).
-/// This invariant is enforced at construction time via the [`new`](Self::new) method.
-///
-/// **Note**: Since the fields are public, this invariant cannot be fully enforced at the type
-/// level. Code that directly constructs this type via struct literal syntax or modifies the
-/// fields after construction must manually ensure the invariant is maintained. Violating this
-/// invariant may lead to unexpected behavior in [`Stage`] implementations, such as empty
-/// iterations, panics, or incorrect processing logic.
+/// This invariant is enforced at construction time via the [`new`](Self::new) method and
+/// maintained by keeping the fields private.
 #[derive(Debug, Clone)]
 pub struct StageExecutionInput {
-    /// The block number to start processing from (inclusive).
-    pub from: BlockNumber,
-    /// The block number to stop processing at (inclusive).
-    pub to: BlockNumber,
+    from: BlockNumber,
+    to: BlockNumber,
 }
 
 impl StageExecutionInput {
@@ -45,6 +38,16 @@ impl StageExecutionInput {
     pub fn new(from: BlockNumber, to: BlockNumber) -> Self {
         assert!(to >= from, "Invalid block range: `to` ({to}) must be >= `from` ({from})");
         Self { from, to }
+    }
+
+    /// Returns the starting block number (inclusive).
+    pub fn from(&self) -> BlockNumber {
+        self.from
+    }
+
+    /// Returns the ending block number (inclusive).
+    pub fn to(&self) -> BlockNumber {
+        self.to
     }
 }
 

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -23,7 +23,7 @@ pub type StageResult = Result<(), Error>;
 /// The `to` field must always be greater than or equal to the `from` field (`to >= from`).
 /// This invariant is enforced at construction time via the [`new`](Self::new) method and
 /// maintained by keeping the fields private.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StageExecutionInput {
     from: BlockNumber,
     to: BlockNumber,
@@ -50,12 +50,6 @@ impl StageExecutionInput {
     #[inline]
     pub fn to(&self) -> BlockNumber {
         self.to
-    }
-}
-
-impl Default for StageExecutionInput {
-    fn default() -> Self {
-        Self { from: 0, to: 0 }
     }
 }
 

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -223,7 +223,7 @@ async fn download_and_store_blocks(
     }
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
-    let input = StageExecutionInput { from: from_block, to: to_block };
+    let input = StageExecutionInput::new(from_block, to_block);
 
     let result = stage.execute(&input).await;
     assert!(result.is_ok());
@@ -244,7 +244,7 @@ async fn download_failure_returns_error() {
     let provider = MockBlockWriter::new();
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
-    let input = StageExecutionInput { from: block_number, to: block_number };
+    let input = StageExecutionInput::new(block_number, block_number);
 
     let result = stage.execute(&input).await;
 
@@ -274,7 +274,7 @@ async fn storage_failure_returns_error() {
     let provider = MockBlockWriter::new().with_insert_error(error_msg.clone());
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
-    let input = StageExecutionInput { from: block_number, to: block_number };
+    let input = StageExecutionInput::new(block_number, block_number);
 
     let result = stage.execute(&input).await;
 
@@ -300,21 +300,10 @@ async fn storage_failure_returns_error() {
 // Maybe that's a good reason to change its method signature to `fn download_blocks(&self, range:
 // Range<BlockNumber>)` ??
 #[tokio::test]
-#[ignore = "Stage input validation should be done on the `Pipeline` level"]
-async fn empty_range_downloads_nothing() {
-    // When from > to, the range is empty
-    let downloader = MockBlockDownloader::new();
-    let provider = MockBlockWriter::new();
-
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
-    let input = StageExecutionInput { from: 100, to: 99 };
-
-    let result = stage.execute(&input).await;
-    assert!(result.is_ok());
-
-    // No downloads should occur for empty range
-    assert_eq!(downloader.requested_blocks().len(), 0);
-    assert_eq!(provider.stored_block_count(), 0);
+#[should_panic(expected = "Invalid block range")]
+async fn invalid_range_panics() {
+    // When from > to, the range is invalid and should panic at construction time
+    let _ = StageExecutionInput::new(100, 99);
 }
 
 #[tokio::test]
@@ -332,7 +321,7 @@ async fn partial_download_failure_stops_execution() {
     let provider = MockBlockWriter::new();
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
 
-    let input = StageExecutionInput { from: from_block, to: to_block };
+    let input = StageExecutionInput::new(from_block, to_block);
     let result = stage.execute(&input).await;
 
     // Should fail on block 103
@@ -355,7 +344,7 @@ async fn fetch_blocks_from_gateway() {
 
     let mut stage = Blocks::new(&provider, downloader);
 
-    let input = StageExecutionInput { from: from_block, to: to_block };
+    let input = StageExecutionInput::new(from_block, to_block);
     stage.execute(&input).await.expect("failed to execute stage");
 
     // check provider storage

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -294,18 +294,6 @@ async fn storage_failure_returns_error() {
     assert_eq!(provider.stored_block_count(), 0);
 }
 
-// This test is only testing the debug sanity check in Blocks::execute(). Becase the
-// `BlockDownloader` implementation could theoretically return whatever based on the block input
-// because the input of `BlockDownloader::download_blocks` doesn't prohibit invalid block range.
-// Maybe that's a good reason to change its method signature to `fn download_blocks(&self, range:
-// Range<BlockNumber>)` ??
-#[tokio::test]
-#[should_panic(expected = "Invalid block range")]
-async fn invalid_range_panics() {
-    // When from > to, the range is invalid and should panic at construction time
-    let _ = StageExecutionInput::new(100, 99);
-}
-
 #[tokio::test]
 async fn partial_download_failure_stops_execution() {
     let from_block = 100;


### PR DESCRIPTION
Strengthens the `Stage` trait contract by enforcing that `StageExecutionInput.to >= StageExecutionInput.from`. `Stage` implementors can now rely on receiving valid block ranges.