### PR TITLE
feat(rpc): implement `starknet_getCompiledCasm` method

### DIFF
--- a/crates/rpc/rpc-api/src/starknet.rs
+++ b/crates/rpc/rpc-api/src/starknet.rs
@@ -16,7 +16,7 @@ use katana_rpc_types::broadcasted::{
     AddInvokeTransactionResponse, BroadcastedDeclareTx, BroadcastedDeployAccountTx,
     BroadcastedInvokeTx, BroadcastedTx,
 };
-use katana_rpc_types::class::Class;
+use katana_rpc_types::class::{CasmClass, Class};
 use katana_rpc_types::event::{EventFilterWithPage, GetEventsResponse};
 use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
@@ -120,6 +120,10 @@ pub trait StarknetApi {
         block_id: BlockIdOrTag,
         contract_address: ContractAddress,
     ) -> RpcResult<Class>;
+
+    /// Get the compiled CASM code resulting from compiling a given class.
+    #[method(name = "getCompiledCasm")]
+    async fn get_compiled_casm(&self, class_hash: ClassHash) -> RpcResult<CasmClass>;
 
     /// Get the number of transactions in a block given a block id.
     #[method(name = "getBlockTransactionCount")]

--- a/crates/rpc/rpc-client/src/starknet.rs
+++ b/crates/rpc/rpc-client/src/starknet.rs
@@ -15,7 +15,7 @@ use katana_rpc_types::broadcasted::{
     AddInvokeTransactionResponse, BroadcastedDeclareTx, BroadcastedDeployAccountTx,
     BroadcastedInvokeTx, BroadcastedTx,
 };
-use katana_rpc_types::class::Class;
+use katana_rpc_types::class::{CasmClass, Class};
 use katana_rpc_types::event::{EventFilterWithPage, GetEventsResponse};
 use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
@@ -138,6 +138,11 @@ impl Client {
         contract_address: ContractAddress,
     ) -> Result<Class> {
         self.client.get_class_at(block_id, contract_address).await.map_err(Into::into)
+    }
+
+    /// Get the compiled CASM code resulting from compiling a given class.
+    pub async fn get_compiled_casm(&self, class_hash: ClassHash) -> Result<CasmClass> {
+        self.client.get_compiled_casm(class_hash).await.map_err(Into::into)
     }
 
     /// Get the number of transactions in a block given a block id.

--- a/crates/rpc/rpc-types/src/class.rs
+++ b/crates/rpc/rpc-types/src/class.rs
@@ -23,6 +23,9 @@ use starknet_api::deprecated_contract_class::{
 };
 use starknet_api::serde_utils::deserialize_optional_contract_class_abi_entry_vector;
 
+/// The return type for the `starknet_getCompiledClass` JSON-RPC method.
+pub type CasmClass = katana_primitives::class::CompiledClass;
+
 /// RPC representation of the Starknet class.
 ///
 /// This is the RPC equivalent of [ContractClass].

--- a/crates/rpc/rpc/src/starknet/mod.rs
+++ b/crates/rpc/rpc/src/starknet/mod.rs
@@ -8,7 +8,7 @@ use katana_core::service::block_producer::{BlockProducer, BlockProducerMode, Pen
 use katana_executor::{ExecutionResult, ExecutorFactory};
 use katana_pool::{TransactionPool, TxPool};
 use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, FinalityStatus, PartialHeader};
-use katana_primitives::class::ClassHash;
+use katana_primitives::class::{ClassHash, CompiledClass};
 use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::env::BlockEnv;
@@ -25,7 +25,7 @@ use katana_provider::api::transaction::{
 };
 use katana_provider::api::ProviderError;
 use katana_rpc_api::error::starknet::{
-    PageSizeTooBigData, ProofLimitExceededData, StarknetApiError,
+    CompilationErrorData, PageSizeTooBigData, ProofLimitExceededData, StarknetApiError,
 };
 use katana_rpc_types::block::{
     BlockHashAndNumberResponse, BlockNumberResponse, GetBlockWithReceiptsResponse,
@@ -328,6 +328,27 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         let hash = self.class_hash_at_address(block_id, contract_address).await?;
         let class = self.class_at_hash(block_id, hash).await?;
         Ok(class)
+    }
+
+    async fn compiled_class_at_hash(
+        &self,
+        class_hash: ClassHash,
+    ) -> StarknetApiResult<CompiledClass> {
+        self.on_io_blocking_task(move |this| {
+            // Get the latest state to retrieve the class
+            let state = this.state(&BlockIdOrTag::Latest)?;
+
+            let Some(class) = state.class(class_hash)? else {
+                return Err(StarknetApiError::ClassHashNotFound);
+            };
+
+            class.compile().map_err(|e| {
+                StarknetApiError::CompilationError(CompilationErrorData {
+                    compilation_error: e.to_string(),
+                })
+            })
+        })
+        .await?
     }
 
     fn storage_at(

--- a/crates/rpc/rpc/src/starknet/read.rs
+++ b/crates/rpc/rpc/src/starknet/read.rs
@@ -22,7 +22,6 @@ use katana_rpc_types::block::{
     GetBlockWithTxHashesResponse, MaybePreConfirmedBlock,
 };
 use katana_rpc_types::broadcasted::BroadcastedTx;
-use katana_rpc_types::class::Class;
 use katana_rpc_types::event::{EventFilterWithPage, GetEventsResponse};
 use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
@@ -30,7 +29,7 @@ use katana_rpc_types::state_update::GetStateUpdateResponse;
 use katana_rpc_types::transaction::RpcTxWithHash;
 use katana_rpc_types::trie::{ContractStorageKeys, GetStorageProofResponse};
 use katana_rpc_types::{
-    CallResponse, EstimateFeeSimulationFlag, FeeEstimate, FunctionCall, TxStatus,
+    CallResponse, CasmClass, Class, EstimateFeeSimulationFlag, FeeEstimate, FunctionCall, TxStatus,
 };
 
 use super::StarknetApi;
@@ -126,6 +125,10 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
 
     async fn get_class(&self, block_id: BlockIdOrTag, class_hash: ClassHash) -> RpcResult<Class> {
         Ok(self.class_at_hash(block_id, class_hash).await?)
+    }
+
+    async fn get_compiled_casm(&self, class_hash: ClassHash) -> RpcResult<CasmClass> {
+        Ok(self.compiled_class_at_hash(class_hash).await?)
     }
 
     async fn get_events(&self, filter: EventFilterWithPage) -> RpcResult<GetEventsResponse> {


### PR DESCRIPTION
Implements `starknet_getCompiledCasm` method of the Starknet JSON-RPC specification. It was initially introduced in RPC [v0.8.0]. This method returns the CASM i.e., compiled Sierra class, or the legacy contract class type.

[v0.8.0]: https://github.com/starkware-libs/starknet-specs/blob/b4f81445c79b2a8b2b09ff5bb2b7eddca78a32de/api/starknet_executables.json#L10-L40