### PR TITLE
refactor(provider): move state validation out of storage layer

### DIFF
--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -159,6 +159,14 @@ impl<EF: ExecutorFactory> Backend<EF> {
         receipts: Vec<Receipt>,
         traces: Vec<TypedTransactionExecutionInfo>,
     ) -> Result<(), BlockProductionError> {
+        // Validate that all declared classes have their corresponding class artifacts
+        if let Err(missing) = states.validate_classes() {
+            return Err(BlockProductionError::InconsistentState(format!(
+                "missing class artifacts for declared classes: {:#?}",
+                missing,
+            )));
+        }
+
         self.blockchain
             .provider()
             .insert_block_with_states_and_receipts(block, states, receipts, traces)?;

--- a/crates/core/src/service/block_producer.rs
+++ b/crates/core/src/service/block_producer.rs
@@ -53,6 +53,9 @@ pub enum BlockProductionError {
 
     #[error("transaction execution error: {0}")]
     TransactionExecutionError(#[from] katana_executor::ExecutorError),
+
+    #[error("inconsistent state updates: {0}")]
+    InconsistentState(String),
 }
 
 impl BlockProductionError {

--- a/crates/storage/provider/provider-api/src/block.rs
+++ b/crates/storage/provider/provider-api/src/block.rs
@@ -143,6 +143,11 @@ pub trait BlockProvider:
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait BlockWriter: Send + Sync {
     /// Store an executed block along with its execution output to the storage.
+    ///
+    /// Implementors may choose to perform validation or consistency checks on the
+    /// provided `block` and its associated execution output, but it is the caller's responsibility
+    /// to ensure that the `states`, `receipts`, and `executions` are actually the result of
+    /// executing `block` before calling this method.
     fn insert_block_with_states_and_receipts(
         &self,
         block: SealedBlockWithStatus,

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -718,30 +718,23 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
                 db_tx.put::<tables::TxTraces>(tx_number, execution)?;
             }
 
-            // insert classes
-            let mut classes_registry = states.classes;
-
-            for (class_hash, compiled_hash) in states.state_updates.declared_classes {
-                db_tx.put::<tables::CompiledClassHashes>(class_hash, compiled_hash)?;
-
-                db_tx.put::<tables::ClassDeclarationBlock>(class_hash, block_number)?;
-                db_tx.put::<tables::ClassDeclarations>(block_number, class_hash)?;
-
-                let entry = classes_registry.remove(&class_hash);
-                let class = entry.ok_or(ProviderError::MissingContractClass(class_hash))?;
+            // insert all class artifacts
+            for (class_hash, class) in states.classes {
                 db_tx.put::<tables::Classes>(class_hash, class)?;
             }
 
+            // insert compiled class hashes and declarations for declared classes
+            for (class_hash, compiled_hash) in states.state_updates.declared_classes {
+                db_tx.put::<tables::CompiledClassHashes>(class_hash, compiled_hash)?;
+                db_tx.put::<tables::ClassDeclarationBlock>(class_hash, block_number)?;
+                db_tx.put::<tables::ClassDeclarations>(block_number, class_hash)?;
+            }
+
+            // insert declarations for deprecated declared classes
             for class_hash in states.state_updates.deprecated_declared_classes {
                 db_tx.put::<tables::ClassDeclarationBlock>(class_hash, block_number)?;
                 db_tx.put::<tables::ClassDeclarations>(block_number, class_hash)?;
-
-                let entry = classes_registry.remove(&class_hash);
-                let class = entry.ok_or(ProviderError::MissingContractClass(class_hash))?;
-                db_tx.put::<tables::Classes>(class_hash, class)?;
             }
-
-            assert!(classes_registry.is_empty(), "all declared classes should've been stored");
 
             // insert storage changes
             {


### PR DESCRIPTION
Refactors the storage layer to remove validation logic and move it to the caller's responsibility.

## Changes

1. **Removed validation from `DbProvider::insert_block_with_states_and_receipts`**
   - Previously (in #173), the method would fail if declared classes didn't have their artifacts in `states.classes`
   - Now stores all class artifacts independently without enforcing consistency
   - The method's responsibility is simply to store the provided data, not validate it

2. **Updated `BlockWriter` trait documentation**
   - Clarifies that implementors may perform validation, but it's the caller's responsibility to ensure data consistency
   - Makes it explicit that the method doesn't guarantee validation

3. **Added `StateUpdatesWithClasses::validate_classes()` method**
   - Provides a convenient way to validate class artifacts consistency
   - Returns `Err(Vec<ClassHash>)` with missing class hashes if validation fails

4. **Added validation in `Backend::store_block()`**
   - Calls `validate_classes()` before storing the block
   - Ensures data consistency at the appropriate layer

## Rationale

The storage layer should be responsible for storing data, not validating business logic. This separation of concerns:
- Makes the storage implementation more flexible
- Allows callers to make informed decisions about when/how to validate
- Keeps validation logic at the appropriate layer (business logic, not storage)

Supersedes [#173]

[#173]: https://github.com/dojoengine/katana/pull/173