### PR TITLE
feat(sync): return lower bound of stages' last block processed

### DIFF
--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -16,7 +16,7 @@ use num_traits::ToPrimitive;
 use starknet::core::types::ResourcePrice;
 use tracing::debug;
 
-use crate::{Stage, StageExecutionInput, StageResult};
+use crate::{Stage, StageExecutionInput, StageExecutionOutput, StageResult};
 
 mod downloader;
 
@@ -69,7 +69,7 @@ where
                 }
             }
 
-            Ok(())
+            Ok(StageExecutionOutput { last_block_processed: input.to() })
         })
     }
 }

--- a/crates/sync/stage/src/classes.rs
+++ b/crates/sync/stage/src/classes.rs
@@ -12,7 +12,7 @@ use katana_provider::api::ProviderError;
 use katana_rpc_types::class::ConversionError;
 use tracing::{debug, error};
 
-use super::{Stage, StageExecutionInput, StageResult};
+use super::{Stage, StageExecutionInput, StageExecutionOutput, StageResult};
 use crate::downloader::{BatchDownloader, Downloader, DownloaderResult};
 
 /// A stage for downloading and storing contract classes.
@@ -83,7 +83,7 @@ where
                 }
             }
 
-            Ok(())
+            Ok(StageExecutionOutput { last_block_processed: input.to() })
         })
     }
 }

--- a/crates/sync/stage/src/lib.rs
+++ b/crates/sync/stage/src/lib.rs
@@ -16,7 +16,7 @@ pub use sequencing::Sequencing;
 pub use trie::StateTrie;
 
 /// The result type of a stage execution. See [Stage::execute].
-pub type StageResult = Result<(), Error>;
+pub type StageResult = Result<StageExecutionOutput, Error>;
 
 /// Input parameters for stage execution.
 ///
@@ -55,8 +55,10 @@ impl StageExecutionInput {
     }
 }
 
+/// Output from a stage execution containing the progress information.
 #[derive(Debug, Default)]
 pub struct StageExecutionOutput {
+    /// The last block number that was successfully processed by the stage.
     pub last_block_processed: BlockNumber,
 }
 
@@ -112,7 +114,8 @@ pub trait Stage: Send + Sync {
     ///
     /// # Returns
     ///
-    /// A [`BoxFuture`] that resolves to a [`StageResult`] upon completion.
+    /// A future that resolves to a [`StageResult`] containing [`StageExecutionOutput`]
+    /// with the last successfully processed block number of the stage.
     ///
     /// # Block Range
     ///

--- a/crates/sync/stage/src/trie.rs
+++ b/crates/sync/stage/src/trie.rs
@@ -8,7 +8,7 @@ use starknet::macros::short_string;
 use starknet_types_core::hash::{Poseidon, StarkHash};
 use tracing::{error, trace, trace_span};
 
-use crate::{Stage, StageExecutionInput, StageResult};
+use crate::{Stage, StageExecutionInput, StageExecutionOutput, StageResult};
 
 /// A stage for computing and validating state tries.
 ///
@@ -95,7 +95,7 @@ where
                 );
             }
 
-            Ok(())
+            Ok(StageExecutionOutput { last_block_processed: input.to() })
         })
     }
 }


### PR DESCRIPTION
This is to allow the pipeline to always execute a stage with a block range that is limited by the configured pipeline batch size - prevents the case where a stage might get executed with an extremely large block range.

Let's give an example of a `Pipeline` with a batch size of 10, and consists of two stages - Stage A, and Stage B - and they each have a checkpoint of **5** and **30** respectively (assuming that we're resuming the pipeline from an existing broken previous run). 

If the first `Pipeline::run_to` cycle has an input, `to`, of 10, Stage A will be executed from 5 -> 10 while Stage B gets _skipped_ (because its checkpoint >= 10). Then, the method will return block number **30** because Stage B is the **last** stage to be executed:

```rust
if checkpoint >= to {
    info!(target: "pipeline", %id, "Skipping stage.");

    if i == last_stage_idx {
        return Ok(checkpoint);
    }

    continue;
}
```

On the next iteration of `Pipeline::run_to`, the method will be called with a `to` of **30**. This will trigger an execution of Stage A with starting from block 10 -> 30. Obviously this example uses small numbers for simplicity, but you could imagine if the checkpoint difference between the Stage A and Stage B is very large, Stage A could get executed with an insanely large range of blocks (eg 0..10,000) and because we don't yet handle partial failure all the progress would be lost if an error occur partway.
