### PR TITLE
feat(sync): validate chain invariant

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -652,49 +652,4 @@ mod tests {
         let actual = Header::concat_counts(0xFFFFFFFF, 0, 0, L1DataAvailabilityMode::Calldata);
         assert_eq!(actual, expected);
     }
-
-    /// Helper function to create a minimal test `SealedBlockWithStatus`.
-    ///
-    /// Creates a block with the given number and automatically sets the parent hash
-    /// to the hash of block N-1 (using `Felt::from(block_number - 1)`).
-    pub fn create_sealed_block_with_status(block_number: BlockNumber) -> SealedBlockWithStatus {
-        create_sealed_block_with_status_and_parent(
-            block_number,
-            Felt::from(block_number.saturating_sub(1)),
-        )
-    }
-
-    /// Helper function to create a test `SealedBlockWithStatus` with a specific parent hash.
-    ///
-    /// Useful for testing scenarios where you need to control the parent hash explicitly,
-    /// such as testing chain invariant violations.
-    pub fn create_sealed_block_with_status_and_parent(
-        block_number: BlockNumber,
-        parent_hash: Felt,
-    ) -> SealedBlockWithStatus {
-        let header = Header {
-            number: block_number,
-            parent_hash,
-            timestamp: block_number,
-            sequencer_address: ContractAddress::default(),
-            l1_gas_prices: GasPrices::default(),
-            l1_data_gas_prices: GasPrices::default(),
-            l2_gas_prices: GasPrices::default(),
-            l1_da_mode: L1DataAvailabilityMode::Calldata,
-            starknet_version: StarknetVersion::LATEST,
-            state_root: Felt::ZERO,
-            state_diff_commitment: Felt::ZERO,
-            transactions_commitment: Felt::ZERO,
-            receipts_commitment: Felt::ZERO,
-            events_commitment: Felt::ZERO,
-            transaction_count: 0,
-            events_count: 0,
-            state_diff_length: 0,
-        };
-
-        SealedBlockWithStatus {
-            block: SealedBlock { hash: Felt::from(block_number), header, body: Vec::new() },
-            status: FinalityStatus::AcceptedOnL2,
-        }
-    }
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -652,4 +652,49 @@ mod tests {
         let actual = Header::concat_counts(0xFFFFFFFF, 0, 0, L1DataAvailabilityMode::Calldata);
         assert_eq!(actual, expected);
     }
+
+    /// Helper function to create a minimal test `SealedBlockWithStatus`.
+    ///
+    /// Creates a block with the given number and automatically sets the parent hash
+    /// to the hash of block N-1 (using `Felt::from(block_number - 1)`).
+    pub fn create_sealed_block_with_status(block_number: BlockNumber) -> SealedBlockWithStatus {
+        create_sealed_block_with_status_and_parent(
+            block_number,
+            Felt::from(block_number.saturating_sub(1)),
+        )
+    }
+
+    /// Helper function to create a test `SealedBlockWithStatus` with a specific parent hash.
+    ///
+    /// Useful for testing scenarios where you need to control the parent hash explicitly,
+    /// such as testing chain invariant violations.
+    pub fn create_sealed_block_with_status_and_parent(
+        block_number: BlockNumber,
+        parent_hash: Felt,
+    ) -> SealedBlockWithStatus {
+        let header = Header {
+            number: block_number,
+            parent_hash,
+            timestamp: block_number,
+            sequencer_address: ContractAddress::default(),
+            l1_gas_prices: GasPrices::default(),
+            l1_data_gas_prices: GasPrices::default(),
+            l2_gas_prices: GasPrices::default(),
+            l1_da_mode: L1DataAvailabilityMode::Calldata,
+            starknet_version: StarknetVersion::LATEST,
+            state_root: Felt::ZERO,
+            state_diff_commitment: Felt::ZERO,
+            transactions_commitment: Felt::ZERO,
+            receipts_commitment: Felt::ZERO,
+            events_commitment: Felt::ZERO,
+            transaction_count: 0,
+            events_count: 0,
+            state_diff_length: 0,
+        };
+
+        SealedBlockWithStatus {
+            block: SealedBlock { hash: Felt::from(block_number), header, body: Vec::new() },
+            status: FinalityStatus::AcceptedOnL2,
+        }
+    }
 }

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -7,15 +7,17 @@ use katana_gateway::types::{
     Block, BlockStatus, ConfirmedStateUpdate, ErrorCode, GatewayError, StateDiff, StateUpdate,
     StateUpdateWithBlock,
 };
-use katana_primitives::block::{BlockHash, BlockNumber, SealedBlockWithStatus};
+use katana_primitives::block::{
+    BlockHash, BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,
+};
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::StateUpdatesWithClasses;
-use katana_primitives::{ContractAddress, Felt};
+use katana_primitives::{felt, ContractAddress, Felt};
 use katana_provider::api::block::{BlockHashProvider, BlockNumberProvider, BlockWriter};
 use katana_provider::test_utils::test_provider;
-use katana_provider::ProviderResult;
+use katana_provider::{ProviderError, ProviderResult};
 use katana_stage::blocks::{BatchBlockDownloader, BlockDownloader, Blocks};
 use katana_stage::{Stage, StageExecutionInput};
 use rstest::rstest;
@@ -119,7 +121,7 @@ impl BlockDownloader for MockBlockDownloader {
 ///
 /// Tracks all insert operations and can be configured to return errors.
 #[derive(Clone)]
-struct MockBlockWriter {
+struct MockProvider {
     /// Stored blocks with their receipts and state updates.
     blocks: Arc<Mutex<Vec<(SealedBlockWithStatus, StateUpdatesWithClasses, Vec<Receipt>)>>>,
     /// Whether to return an error on insert.
@@ -128,13 +130,19 @@ struct MockBlockWriter {
     error_message: Arc<Mutex<String>>,
 }
 
-impl MockBlockWriter {
+impl MockProvider {
     fn new() -> Self {
         Self {
             blocks: Arc::new(Mutex::new(Vec::new())),
             should_fail: Arc::new(Mutex::new(false)),
             error_message: Arc::new(Mutex::new(String::new())),
         }
+    }
+
+    /// Add a block directly to the provider's storage.
+    fn with_block(self, block: SealedBlockWithStatus) -> Self {
+        self.blocks.lock().unwrap().push((block, Default::default(), Default::default()));
+        self
     }
 
     /// Configure the mock to fail on insert operations.
@@ -155,7 +163,7 @@ impl MockBlockWriter {
     }
 }
 
-impl BlockWriter for MockBlockWriter {
+impl BlockWriter for MockProvider {
     fn insert_block_with_states_and_receipts(
         &self,
         block: SealedBlockWithStatus,
@@ -174,14 +182,14 @@ impl BlockWriter for MockBlockWriter {
     }
 }
 
-impl BlockHashProvider for MockBlockWriter {
+impl BlockHashProvider for MockProvider {
     fn latest_hash(&self) -> ProviderResult<BlockHash> {
         self.blocks
             .lock()
             .unwrap()
             .last()
             .map(|(block, _, _)| block.block.hash)
-            .ok_or_else(|| katana_provider::ProviderError::MissingBlock)
+            .ok_or(ProviderError::MissingLatestBlockHash)
     }
 
     fn block_hash_by_num(&self, num: BlockNumber) -> ProviderResult<Option<BlockHash>> {
@@ -195,13 +203,45 @@ impl BlockHashProvider for MockBlockWriter {
     }
 }
 
-/// Helper function to create a minimal test block.
-fn create_test_block(block_number: BlockNumber) -> StateUpdateWithBlock {
-    create_test_block_with_parent(block_number, Felt::from(block_number.saturating_sub(1)))
+/// Helper function to create a minimal test `SealedBlockWithStatus`.
+///
+/// Creates a block with the given number and automatically sets the parent hash
+/// to the hash of block N-1 (using `Felt::from(block_number - 1)`).
+fn create_stored_block(block_number: BlockNumber) -> SealedBlockWithStatus {
+    let header = Header {
+        number: block_number,
+        parent_hash: Felt::from(block_number.saturating_sub(1)),
+        timestamp: block_number,
+        sequencer_address: ContractAddress::default(),
+        l1_gas_prices: Default::default(),
+        l1_data_gas_prices: Default::default(),
+        l2_gas_prices: Default::default(),
+        l1_da_mode: L1DataAvailabilityMode::Calldata,
+        starknet_version: Default::default(),
+        state_root: Felt::ZERO,
+        state_diff_commitment: Felt::ZERO,
+        transactions_commitment: Felt::ZERO,
+        receipts_commitment: Felt::ZERO,
+        events_commitment: Felt::ZERO,
+        transaction_count: 0,
+        events_count: 0,
+        state_diff_length: 0,
+    };
+
+    SealedBlockWithStatus {
+        block: SealedBlock { hash: Felt::from(block_number), header, body: Vec::new() },
+        status: FinalityStatus::AcceptedOnL2,
+    }
+}
+
+/// Helper function to create a minimal test block. The created block has a parent hash == block
+/// number - 1 for simplicity sake
+fn create_downloaded_block(block_number: BlockNumber) -> StateUpdateWithBlock {
+    create_downloaded_block_with_parent(block_number, Felt::from(block_number.saturating_sub(1)))
 }
 
 /// Helper function to create a test block with a specific parent hash.
-fn create_test_block_with_parent(
+fn create_downloaded_block_with_parent(
     block_number: BlockNumber,
     parent_hash: Felt,
 ) -> StateUpdateWithBlock {
@@ -244,11 +284,11 @@ async fn download_and_store_blocks(
     #[case] to_block: BlockNumber,
     #[case] expected_blocks: Vec<BlockNumber>,
 ) {
-    let provider = MockBlockWriter::new();
+    let provider = MockProvider::new().with_block(create_stored_block(from_block - 1));
     let mut downloader = MockBlockDownloader::new();
 
     for block_num in from_block..=to_block {
-        downloader = downloader.with_block(block_num, create_test_block(block_num));
+        downloader = downloader.with_block(block_num, create_downloaded_block(block_num));
     }
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
@@ -260,8 +300,8 @@ async fn download_and_store_blocks(
     // Verify download_blocks was called with the correct block numbers in the correct sequence
     assert_eq!(downloader.requested_blocks(), expected_blocks);
     // Verify insert_block_with_states_and_receipts was called with the correct block numbers in the
-    // correct sequence
-    assert_eq!(provider.stored_block_numbers(), expected_blocks);
+    // correct sequence. Ignore the first stored block.
+    assert_eq!(provider.stored_block_numbers()[1..], expected_blocks);
 }
 
 #[tokio::test]
@@ -270,7 +310,7 @@ async fn download_failure_returns_error() {
     let error_msg = "Network error".to_string();
 
     let downloader = MockBlockDownloader::new().with_error(block_number, error_msg.clone());
-    let provider = MockBlockWriter::new();
+    let provider = MockProvider::new();
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
     let input = StageExecutionInput::new(block_number, block_number);
@@ -296,11 +336,13 @@ async fn download_failure_returns_error() {
 #[tokio::test]
 async fn storage_failure_returns_error() {
     let block_number = 100;
-    let test_block = create_test_block(block_number);
+    let test_block = create_downloaded_block(block_number);
     let error_msg = "Storage full".to_string();
 
     let downloader = MockBlockDownloader::new().with_block(block_number, test_block);
-    let provider = MockBlockWriter::new().with_insert_error(error_msg.clone());
+    let provider = MockProvider::new()
+        .with_insert_error(error_msg.clone())
+        .with_block(create_stored_block(block_number - 1));
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
     let input = StageExecutionInput::new(block_number, block_number);
@@ -319,8 +361,8 @@ async fn storage_failure_returns_error() {
 
     // Verify download was attempted
     assert_eq!(downloader.requested_blocks(), vec![100]);
-    // Verify no blocks were stored
-    assert_eq!(provider.stored_block_count(), 0);
+    // Verify no blocks were stored (except block `block_number - 1`)
+    assert_eq!(provider.stored_block_count(), 1);
 }
 
 #[tokio::test]
@@ -331,11 +373,11 @@ async fn partial_download_failure_stops_execution() {
     // Configure first 3 blocks to succeed, 4th to fail
     let mut downloader = MockBlockDownloader::new();
     for block_num in from_block..=102 {
-        downloader = downloader.with_block(block_num, create_test_block(block_num));
+        downloader = downloader.with_block(block_num, create_downloaded_block(block_num));
     }
     downloader = downloader.with_error(103, "Block not found".to_string());
 
-    let provider = MockBlockWriter::new();
+    let provider = MockProvider::new();
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
 
     let input = StageExecutionInput::new(from_block, to_block);
@@ -370,74 +412,73 @@ async fn fetch_blocks_from_gateway() {
 }
 
 #[tokio::test]
-async fn chain_invariant_violation_within_batch() {
-    let provider = MockBlockWriter::new();
-    let mut downloader = MockBlockDownloader::new();
+async fn downloaded_blocks_do_not_form_valid_chain_with_stored_blocks() {
+    use katana_stage::blocks;
 
-    // Create blocks where block 102 has an invalid parent hash
-    downloader = downloader.with_block(100, create_test_block(100));
-    downloader = downloader.with_block(101, create_test_block(101));
-    // Block 102 with incorrect parent hash (should be Felt::from(101))
-    downloader = downloader.with_block(102, create_test_block_with_parent(102, Felt::from(999)));
+    let provider = MockProvider::new().with_block(create_stored_block(99));
+    let downloader = MockBlockDownloader::new()
+        .with_block(100, create_downloaded_block_with_parent(100, felt!("0x1337")));
+
+    let mut stage = Blocks::new(provider.clone(), downloader.clone());
+    let input = StageExecutionInput::new(100, 100);
+
+    let result = stage.execute(&input).await;
+
+    let expected_error = blocks::Error::ChainInvariantViolation {
+        block_num: 100,
+        parent_hash: felt!("0x1337"),
+        expected_hash: felt!("99"),
+    };
+
+    // Should fail with chain invariant violation
+    assert!(result.is_err());
+    if let Err(err) = result {
+        match err {
+            katana_stage::Error::Blocks(e) => {
+                assert_eq!(e.to_string(), expected_error.to_string());
+            }
+            _ => panic!("Expected Error::Blocks variant, got: {err:#?}"),
+        }
+    }
+
+    // Verify no blocks were stored due to validation failure (except for block 99)
+    assert_eq!(provider.stored_block_count(), 1);
+}
+
+#[tokio::test]
+async fn downloaded_blocks_do_not_form_valid_chain() {
+    use katana_stage::blocks;
+
+    let provider = MockProvider::new().with_block(create_stored_block(99));
+    let downloader = MockBlockDownloader::new()
+        .with_block(100, create_downloaded_block(100))
+        .with_block(101, create_downloaded_block(101))
+        // Create blocks where block 102 has an invalid parent hash
+        // Block 102 with incorrect parent hash (should be 101)
+        .with_block(102, create_downloaded_block_with_parent(102, Felt::from(999)));
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone());
     let input = StageExecutionInput::new(100, 102);
 
     let result = stage.execute(&input).await;
 
-    // Should fail with chain invariant violation
-    assert!(result.is_err());
-    if let Err(err) = result {
-        match err {
-            katana_stage::Error::Blocks(e) => {
-                let err_str = e.to_string();
-                assert!(err_str.contains("chain invariant violation"));
-                assert!(err_str.contains("block 102"));
-            }
-            _ => panic!("Expected Error::Blocks variant, got: {err:#?}"),
-        }
-    }
-
-    // Verify no blocks were stored due to validation failure
-    assert_eq!(provider.stored_block_count(), 0);
-}
-
-#[tokio::test]
-async fn chain_invariant_violation_with_storage() {
-    let provider = MockBlockWriter::new();
-
-    // First, store block 100 in storage
-    let mut downloader = MockBlockDownloader::new();
-    downloader = downloader.with_block(100, create_test_block(100));
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
-    let input = StageExecutionInput::new(100, 100);
-    stage.execute(&input).await.expect("should store block 100");
-    assert_eq!(provider.stored_block_count(), 1);
-
-    // Now try to download block 101 with incorrect parent hash
-    let mut downloader = MockBlockDownloader::new();
-    // Block 101 with incorrect parent hash (should be Felt::from(100))
-    downloader = downloader.with_block(101, create_test_block_with_parent(101, Felt::from(999)));
-
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
-    let input = StageExecutionInput::new(101, 101);
-
-    let result = stage.execute(&input).await;
+    let expected_error = blocks::Error::ChainInvariantViolation {
+        block_num: 102,
+        parent_hash: felt!("999"),
+        expected_hash: felt!("101"),
+    };
 
     // Should fail with chain invariant violation
     assert!(result.is_err());
     if let Err(err) = result {
         match err {
             katana_stage::Error::Blocks(e) => {
-                let err_str = e.to_string();
-                assert!(err_str.contains("chain invariant violation"));
-                assert!(err_str.contains("block 101"));
+                assert_eq!(e.to_string(), expected_error.to_string());
             }
             _ => panic!("Expected Error::Blocks variant, got: {err:#?}"),
         }
     }
 
-    // Verify block 101 was not stored (only block 100 should exist)
+    // Verify no blocks were stored due to validation failure (except for block 99)
     assert_eq!(provider.stored_block_count(), 1);
-    assert_eq!(provider.stored_block_numbers(), vec![100]);
 }


### PR DESCRIPTION
Implements validation for the chain invariant in the `Blocks` stage to ensure the integrity of downloaded blocks before persisting them to storage. Without this validation, the sync process could store disconnected or malicious blocks that don't form a valid chain, leading to an incoherent database state.

The validation enforces the fundamental blockchain invariant: block N's parent hash must match block N-1's hash. For the first block in each downloaded batch (if not block 0), the validator fetches the parent hash from storage using `BlockHashProvider` to ensure continuity with already-stored blocks. The remaining blocks in the batch are validated against the blocks before it.
