### PR TITLE
feat(gateway): implements `get_public_key` and `get_signature` endpoints

### DIFF
--- a/crates/gateway/src/bin/client.rs
+++ b/crates/gateway/src/bin/client.rs
@@ -55,6 +55,10 @@ enum Command {
     GetClass(ClassCommand),
     /// Fetch a compiled class by hash.
     GetCompiledClass(ClassCommand),
+    /// Fetch the public key for a sequencer address.
+    GetPublicKey,
+    /// Fetch the signature of a block.
+    GetSignature(GetSignatureCommand),
 }
 
 #[derive(Debug, Args)]
@@ -81,6 +85,13 @@ struct ClassCommand {
     #[arg(value_name = "HASH")]
     class_hash: ClassHash,
 
+    /// Block ID (number, hash, 'latest'). Defaults to 'latest'
+    #[arg(long, default_value = "latest")]
+    block: BlockIdArg,
+}
+
+#[derive(Debug, Args)]
+struct GetSignatureCommand {
     /// Block ID (number, hash, 'latest'). Defaults to 'latest'
     #[arg(long, default_value = "latest")]
     block: BlockIdArg,
@@ -140,6 +151,15 @@ async fn run() -> Result<()> {
                 .await
                 .map_err(map_gateway_error)?;
             print_json(class)?;
+        }
+        Command::GetPublicKey => {
+            let public_key = gateway.get_public_key().await.map_err(map_gateway_error)?;
+            println!("{public_key:#x}")
+        }
+        Command::GetSignature(cmd) => {
+            let block_id = cmd.block.0;
+            let signature = gateway.get_signature(block_id).await.map_err(map_gateway_error)?;
+            print_json(signature)?;
         }
     }
 

--- a/crates/gateway/src/client.rs
+++ b/crates/gateway/src/client.rs
@@ -15,8 +15,8 @@ use url::Url;
 
 use crate::types::{
     AddDeclareTransactionResponse, AddDeployAccountTransactionResponse,
-    AddInvokeTransactionResponse, Block, BlockId, ContractClass, GatewayError, StateUpdate,
-    StateUpdateWithBlock,
+    AddInvokeTransactionResponse, Block, BlockId, BlockSignature, ContractClass, GatewayError,
+    SequencerPublicKey, StateUpdate, StateUpdateWithBlock,
 };
 
 /// HTTP request header for the feeder gateway API key. This allow bypassing the rate limiting.
@@ -112,6 +112,14 @@ impl Client {
             .block_id(block_id)
             .send()
             .await
+    }
+
+    pub async fn get_public_key(&self) -> Result<SequencerPublicKey, Error> {
+        self.feeder_gateway("get_public_key").send().await
+    }
+
+    pub async fn get_signature(&self, block_id: BlockId) -> Result<BlockSignature, Error> {
+        self.feeder_gateway("get_signature").block_id(block_id).send().await
     }
 
     pub async fn add_invoke_transaction(

--- a/crates/gateway/src/server/handlers.rs
+++ b/crates/gateway/src/server/handlers.rs
@@ -240,7 +240,7 @@ pub enum ApiError {
 
 impl ApiError {
     pub fn gateway_error(code: ErrorCode, message: impl Into<String>) -> Self {
-        Self::Gateway(GatewayError { code, message: message.into() })
+        Self::Gateway(GatewayError { code, message: message.into(), problems: None })
     }
 
     /// Convert to HTTP status code.

--- a/crates/gateway/src/types/error.rs
+++ b/crates/gateway/src/types/error.rs
@@ -1,47 +1,37 @@
+use std::fmt;
+
 use katana_rpc_api::error::starknet::StarknetApiError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, thiserror::Error)]
-#[error("{message} ({code:?})")]
+#[error("{message} ({code})")]
 pub struct GatewayError {
     pub code: ErrorCode,
     pub message: String,
+    #[serde(default)]
+    pub problems: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorCode {
-    #[serde(rename = "StarknetErrorCode.BLOCK_NOT_FOUND")]
     BlockNotFound,
-    #[serde(rename = "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT")]
     EntryPointNotFoundInContract,
-    #[serde(rename = "StarknetErrorCode.INVALID_PROGRAM")]
     InvalidProgram,
-    #[serde(rename = "StarknetErrorCode.TRANSACTION_FAILED")]
     TransactionFailed,
-    #[serde(rename = "StarknetErrorCode.TRANSACTION_NOT_FOUND")]
     TransactionNotFound,
-    #[serde(rename = "StarknetErrorCode.UNINITIALIZED_CONTRACT")]
     UninitializedContract,
-    #[serde(rename = "StarkErrorCode.MALFORMED_REQUEST")]
     MalformedRequest,
-    #[serde(rename = "StarknetErrorCode.UNDECLARED_CLASS")]
     UndeclaredClass,
-    #[serde(rename = "StarknetErrorCode.INVALID_TRANSACTION_NONCE")]
     InvalidTransactionNonce,
-    #[serde(rename = "StarknetErrorCode.VALIDATE_FAILURE")]
     ValidateFailure,
-    #[serde(rename = "StarknetErrorCode.CLASS_ALREADY_DECLARED")]
     ClassAlreadyDeclared,
-    #[serde(rename = "StarknetErrorCode.COMPILATION_FAILED")]
     CompilationFailed,
-    #[serde(rename = "StarknetErrorCode.INVALID_COMPILED_CLASS_HASH")]
     InvalidCompiledClassHash,
-    #[serde(rename = "StarknetErrorCode.DUPLICATED_TRANSACTION")]
     DuplicatedTransaction,
-    #[serde(rename = "StarknetErrorCode.INVALID_CONTRACT_CLASS")]
     InvalidContractClass,
-    #[serde(rename = "StarknetErrorCode.DEPRECATED_ENDPOINT")]
     DeprecatedEndpoint,
+    NotFound,
+    Unknown(String),
 }
 
 impl TryFrom<StarknetApiError> for GatewayError {
@@ -66,6 +56,94 @@ impl TryFrom<StarknetApiError> for GatewayError {
             _ => return Err(value), // Return back the error for unmapped variants
         };
 
-        Ok(GatewayError { code, message: value.to_string() })
+        Ok(GatewayError { code, message: value.to_string(), problems: None })
+    }
+}
+
+impl ErrorCode {
+    fn as_str(&self) -> &str {
+        match self {
+            ErrorCode::NotFound => "404",
+            ErrorCode::BlockNotFound => "StarknetErrorCode.BLOCK_NOT_FOUND",
+            ErrorCode::EntryPointNotFoundInContract => {
+                "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT"
+            }
+            ErrorCode::InvalidProgram => "StarknetErrorCode.INVALID_PROGRAM",
+            ErrorCode::TransactionFailed => "StarknetErrorCode.TRANSACTION_FAILED",
+            ErrorCode::TransactionNotFound => "StarknetErrorCode.TRANSACTION_NOT_FOUND",
+            ErrorCode::UninitializedContract => "StarknetErrorCode.UNINITIALIZED_CONTRACT",
+            ErrorCode::MalformedRequest => "StarkErrorCode.MALFORMED_REQUEST",
+            ErrorCode::UndeclaredClass => "StarknetErrorCode.UNDECLARED_CLASS",
+            ErrorCode::InvalidTransactionNonce => "StarknetErrorCode.INVALID_TRANSACTION_NONCE",
+            ErrorCode::ValidateFailure => "StarknetErrorCode.VALIDATE_FAILURE",
+            ErrorCode::ClassAlreadyDeclared => "StarknetErrorCode.CLASS_ALREADY_DECLARED",
+            ErrorCode::CompilationFailed => "StarknetErrorCode.COMPILATION_FAILED",
+            ErrorCode::InvalidCompiledClassHash => "StarknetErrorCode.INVALID_COMPILED_CLASS_HASH",
+            ErrorCode::DuplicatedTransaction => "StarknetErrorCode.DUPLICATED_TRANSACTION",
+            ErrorCode::InvalidContractClass => "StarknetErrorCode.INVALID_CONTRACT_CLASS",
+            ErrorCode::DeprecatedEndpoint => "StarknetErrorCode.DEPRECATED_ENDPOINT",
+            ErrorCode::Unknown(code) => code.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ErrorCode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorCode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        let code = match value.as_str() {
+            "404" => ErrorCode::NotFound,
+            "StarknetErrorCode.BLOCK_NOT_FOUND" => ErrorCode::BlockNotFound,
+            "StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT" => {
+                ErrorCode::EntryPointNotFoundInContract
+            }
+            "StarknetErrorCode.INVALID_PROGRAM" => ErrorCode::InvalidProgram,
+            "StarknetErrorCode.TRANSACTION_FAILED" => ErrorCode::TransactionFailed,
+            "StarknetErrorCode.TRANSACTION_NOT_FOUND" => ErrorCode::TransactionNotFound,
+            "StarknetErrorCode.UNINITIALIZED_CONTRACT" => ErrorCode::UninitializedContract,
+            "StarkErrorCode.MALFORMED_REQUEST" => ErrorCode::MalformedRequest,
+            "StarknetErrorCode.UNDECLARED_CLASS" => ErrorCode::UndeclaredClass,
+            "StarknetErrorCode.INVALID_TRANSACTION_NONCE" => ErrorCode::InvalidTransactionNonce,
+            "StarknetErrorCode.VALIDATE_FAILURE" => ErrorCode::ValidateFailure,
+            "StarknetErrorCode.CLASS_ALREADY_DECLARED" => ErrorCode::ClassAlreadyDeclared,
+            "StarknetErrorCode.COMPILATION_FAILED" => ErrorCode::CompilationFailed,
+            "StarknetErrorCode.INVALID_COMPILED_CLASS_HASH" => ErrorCode::InvalidCompiledClassHash,
+            "StarknetErrorCode.DUPLICATED_TRANSACTION" => ErrorCode::DuplicatedTransaction,
+            "StarknetErrorCode.INVALID_CONTRACT_CLASS" => ErrorCode::InvalidContractClass,
+            "StarknetErrorCode.DEPRECATED_ENDPOINT" => ErrorCode::DeprecatedEndpoint,
+            other => ErrorCode::Unknown(other.to_string()),
+        };
+
+        Ok(code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{ErrorCode, GatewayError};
+
+    #[test]
+    fn not_found_error() {
+        let json = json!({
+          "code": "404",
+          "message": "404: Not Found",
+          "problems": "Not Found"
+        });
+
+        let error = serde_json::from_value::<GatewayError>(json).unwrap();
+        assert!(matches!(error, GatewayError { code: ErrorCode::NotFound, .. }));
     }
 }

--- a/crates/gateway/src/types/mod.rs
+++ b/crates/gateway/src/types/mod.rs
@@ -41,6 +41,9 @@ pub use transaction::*;
 /// The contract class type returns by `/get_class_by_hash` endpoint.
 pub type ContractClass = katana_rpc_types::Class;
 
+/// Sequencer public key returned by the `/get_public_key` endpoint.
+pub type SequencerPublicKey = Felt;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BlockId {
     Number(BlockNumber),
@@ -76,6 +79,13 @@ pub enum BlockStatus {
 
     #[serde(rename = "ACCEPTED_ON_L1")]
     AcceptedOnL1,
+}
+
+/// Block signature returned by the `/signature` endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockSignature {
+    pub block_hash: BlockHash,
+    pub signature: [Felt; 2],
 }
 
 // The reason why we're not using the GasPrices from the `katana_primitives` crate is because

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -99,12 +99,14 @@ impl BlockDownloader for MockBlockDownloader {
                         return Err(katana_gateway::client::Error::Sequencer(GatewayError {
                             code: ErrorCode::BlockNotFound,
                             message: error.clone(),
+                            problems: None,
                         }))
                     }
                     None => {
                         return Err(katana_gateway::client::Error::Sequencer(GatewayError {
                             code: ErrorCode::BlockNotFound,
                             message: format!("No response configured for block {}", block_num),
+                            problems: None,
                         }))
                     }
                 }


### PR DESCRIPTION
These endpoints will be necessary for verifying that the synced blocks are sequenced by the right address i.e., the `sequencer_address` field in the block header. 

`get_public_key` returns the public key of sequencer associated by the gateway, while `get_signature` returns the signature of the block as signed using the sequencer's public key. 

As currently there's only a single centralized entity that acts as the sequencer (i.e., the official sequencer operated by StarkWare), this is how the public key and signature are obtained. Eventually this may change once Starknet employ decentralized sequencing.