### PR TITLE
feat(stage): verify downloaded class hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6586,6 +6586,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "num-traits",
+ "rayon",
  "rstest 0.18.2",
  "starknet",
  "starknet-types-core",

--- a/crates/sync/stage/Cargo.toml
+++ b/crates/sync/stage/Cargo.toml
@@ -21,6 +21,7 @@ backon.workspace = true
 starknet-types-core.workspace = true
 futures.workspace = true
 num-traits.workspace = true
+rayon.workspace = true
 starknet.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/sync/stage/src/classes.rs
+++ b/crates/sync/stage/src/classes.rs
@@ -10,16 +10,28 @@ use katana_provider::api::contract::ContractClassWriter;
 use katana_provider::api::state_update::StateUpdateProvider;
 use katana_provider::api::ProviderError;
 use katana_rpc_types::class::ConversionError;
+use rayon::prelude::*;
 use tracing::{debug, error};
 
 use super::{Stage, StageExecutionInput, StageExecutionOutput, StageResult};
 use crate::downloader::{BatchDownloader, Downloader, DownloaderResult};
 
 /// A stage for downloading and storing contract classes.
-#[derive(Debug)]
 pub struct Classes<P> {
     provider: P,
     downloader: BatchDownloader<ClassDownloader>,
+    /// Thread pool for parallel class hash verification
+    verification_pool: rayon::ThreadPool,
+}
+
+impl<P> std::fmt::Debug for Classes<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Classes")
+            .field("provider", &std::any::type_name::<P>())
+            .field("downloader", &self.downloader)
+            .field("verification_pool", &"<ThreadPool>")
+            .finish()
+    }
 }
 
 impl<P> Classes<P> {
@@ -27,7 +39,14 @@ impl<P> Classes<P> {
     pub fn new(provider: P, gateway: SequencerGateway, batch_size: usize) -> Self {
         let downloader = ClassDownloader { gateway };
         let downloader = BatchDownloader::new(downloader, batch_size);
-        Self { provider, downloader }
+
+        // Create a dedicated thread pool for class hash verification
+        // Use the number of available CPUs for optimal parallelization
+        let verification_pool = rayon::ThreadPoolBuilder::new()
+            .build()
+            .expect("Failed to create verification thread pool");
+
+        Self { provider, downloader, verification_pool }
     }
 }
 
@@ -76,9 +95,52 @@ where
                     .await
                     .map_err(Error::Gateway)?;
 
-                debug!(target: "stage", id = self.id(), total = %class_artifacts.len(), "Storing class artifacts.");
-                for (key, rpc_class) in declared_classes.iter().zip(class_artifacts) {
-                    let class = rpc_class.try_into().map_err(Error::Conversion)?;
+                debug!(target: "stage", id = self.id(), total = %class_artifacts.len(), "Verifying class artifacts.");
+
+                // First pass: verify class hashes in parallel using the dedicated thread pool
+                // We need to convert to primitives types for verification
+                let verification_results: Vec<
+                    Result<katana_primitives::class::ContractClass, Error>,
+                > = {
+                    let pool = &self.verification_pool;
+                    pool.install(|| {
+                        declared_classes
+                            .par_iter()
+                            .zip(class_artifacts.par_iter())
+                            .map(|(key, rpc_class)| {
+                                // Convert to primitives type
+                                let class: katana_primitives::class::ContractClass =
+                                    rpc_class.clone().try_into().map_err(Error::Conversion)?;
+
+                                // Compute the class hash
+                                let computed_hash = class.class_hash().map_err(|source| {
+                                    Error::ClassHashComputation { block: key.block, source }
+                                })?;
+
+                                // Verify it matches the expected hash
+                                if computed_hash != key.class_hash {
+                                    return Err(Error::ClassHashMismatch {
+                                        expected: key.class_hash,
+                                        actual: computed_hash,
+                                        block: key.block,
+                                    });
+                                }
+
+                                Ok(class)
+                            })
+                            .collect()
+                    })
+                };
+
+                // Check if any verification failed
+                let verified_classes: Vec<_> =
+                    verification_results.into_iter().collect::<Result<Vec<_>, _>>()?;
+
+                debug!(target: "stage", id = self.id(), total = %verified_classes.len(), "Storing class artifacts.");
+
+                // Second pass: insert the verified classes into storage
+                // This must be done sequentially as database only supports single write transaction
+                for (key, class) in declared_classes.iter().zip(verified_classes) {
                     self.provider.set_class(key.class_hash, class)?;
                 }
             }
@@ -106,6 +168,29 @@ pub enum Error {
 
     #[error(transparent)]
     Provider(#[from] ProviderError),
+
+    /// Error when a downloaded class produces a different hash than expected
+    #[error(
+        "class hash mismatch for class at block {block}: expected {expected:#x}, got {actual:#x}"
+    )]
+    ClassHashMismatch {
+        /// The expected class hash
+        expected: ClassHash,
+        /// The actual computed class hash
+        actual: ClassHash,
+        /// The block number where the class was declared
+        block: BlockNumber,
+    },
+
+    /// Error when computing the class hash
+    #[error("failed to compute class hash for class at block {block}: {source}")]
+    ClassHashComputation {
+        /// The block number where the class was declared
+        block: BlockNumber,
+        /// The underlying error
+        #[source]
+        source: katana_primitives::class::ComputeClassHashError,
+    },
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This change adds verification to ensure that downloaded class artifacts in the `Classes` stage produce the correct class hashes. 

Since computing class hashes is CPU-intensive, the verification is performed in parallel using a dedicated `rayon` thread pool owned by the `Classes` stage. Due to database constraints that only allow a single write transaction at a time, the implementation uses a two-pass approach where the first pass verifies all classes in parallel and the second pass sequentially inserts the verified classes into storage.

If a downloaded class produces a different hash than expected, the stage will fail with a descriptive error. 