### PR TITLE
feat(bin): add new subcommand for inspecting state tries

### DIFF
--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 [dependencies]
 katana-chain-spec.workspace = true
 katana-cli.workspace = true
+katana-provider.workspace = true
 katana-db = { workspace = true, features = [ "arbitrary" ] }
 katana-genesis.workspace = true
 katana-primitives.workspace = true
@@ -47,8 +48,6 @@ vergen = { version = "9.0.0", features = [ "build", "cargo", "emit_and_set" ] }
 vergen-gitcl = { version = "1.0.0", features = [ "build", "cargo", "rustc", "si" ] }
 
 [dev-dependencies]
-katana-provider.workspace = true
-
 arbitrary.workspace = true
 similar-asserts.workspace = true
 assert_matches.workspace = true

--- a/bin/katana/src/cli/db/mod.rs
+++ b/bin/katana/src/cli/db/mod.rs
@@ -8,6 +8,7 @@ use comfy_table::Table;
 
 mod prune;
 mod stats;
+mod trie;
 mod version;
 
 #[derive(Debug, Args)]
@@ -28,6 +29,9 @@ enum Commands {
 
     /// Prune historical trie data.
     Prune(prune::PruneArgs),
+
+    /// Inspect trie roots stored in the database.
+    Trie(trie::TrieArgs),
 }
 
 impl DbArgs {
@@ -36,6 +40,7 @@ impl DbArgs {
             Commands::Prune(args) => args.execute(),
             Commands::Stats(args) => args.execute(),
             Commands::Version(args) => args.execute(),
+            Commands::Trie(args) => args.execute(),
         }
     }
 }

--- a/bin/katana/src/cli/db/trie.rs
+++ b/bin/katana/src/cli/db/trie.rs
@@ -58,7 +58,7 @@ impl TrieArgs {
                 let address = storage.address;
                 state_provider
                     .storage_root(address)?
-                    .ok_or_else(|| anyhow!("storage trie not found for contract {address:#x}"))?
+                    .ok_or_else(|| anyhow!("storage trie not found for contract {address}"))?
             }
         };
 

--- a/bin/katana/src/cli/db/trie.rs
+++ b/bin/katana/src/cli/db/trie.rs
@@ -1,0 +1,80 @@
+use anyhow::{anyhow, Context, Result};
+use clap::{Args, Subcommand};
+use katana_primitives::block::BlockHashOrNumber;
+use katana_primitives::contract::ContractAddress;
+use katana_primitives::Felt;
+use katana_provider::api::state::{StateFactoryProvider, StateProvider, StateRootProvider};
+use katana_provider::providers::db::DbProvider;
+
+use super::open_db_ro;
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq, Clone))]
+pub struct TrieArgs {
+    /// Path to the database directory.
+    #[arg(short, long)]
+    pub path: String,
+
+    /// Block number to inspect. Defaults to the latest state when omitted.
+    #[arg(short, long)]
+    pub block: Option<u64>,
+
+    #[command(subcommand)]
+    pub command: TrieCommand,
+}
+
+#[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq, Clone))]
+pub enum TrieCommand {
+    /// Inspect the root of the classes trie.
+    Classes,
+    /// Inspect the root of the contracts trie.
+    Contracts,
+    /// Inspect the root of a contract's storage trie.
+    Storage(StorageArgs),
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct StorageArgs {
+    /// Address of the contract whose storage trie root should be inspected.
+    #[arg(value_name = "CONTRACT_ADDRESS")]
+    pub address: ContractAddress,
+}
+
+impl TrieArgs {
+    pub fn execute(self) -> Result<()> {
+        let root = self.root()?;
+        println!("{root:#x}");
+        Ok(())
+    }
+
+    fn root(&self) -> Result<Felt> {
+        let state_provider = self.state_provider()?;
+
+        let root = match &self.command {
+            TrieCommand::Classes => state_provider.classes_root()?,
+            TrieCommand::Contracts => state_provider.contracts_root()?,
+            TrieCommand::Storage(storage) => {
+                let address = storage.address;
+                state_provider
+                    .storage_root(address)?
+                    .ok_or_else(|| anyhow!("storage trie not found for contract {address:#x}"))?
+            }
+        };
+
+        Ok(root)
+    }
+
+    fn state_provider(&self) -> Result<Box<dyn StateProvider>> {
+        let provider = DbProvider::new(open_db_ro(&self.path)?);
+
+        match self.block {
+            Some(block) => provider
+                .historical(BlockHashOrNumber::Num(block))
+                .with_context(|| format!("failed to get state at block {block}"))?
+                .ok_or_else(|| anyhow!("block {block} not found")),
+
+            None => provider.latest().context("failed to get latest state"),
+        }
+    }
+}


### PR DESCRIPTION
Adds a new subcommand, `katana db trie`, for inspecting the Starknet state tries - classes, contracts, and storages. The command allows to get the root (either latest or at a specific block) of each trie.

I find that this becomes very useful during the development of `StateTrie` stage especially when implementing the unwinding feature where I need to verify the resultant trie root after unwinding is valid.