### PR TITLE
fix(storage): store replaced class updates

### DIFF
--- a/bin/katana/tests/fixtures.rs
+++ b/bin/katana/tests/fixtures.rs
@@ -101,14 +101,13 @@ fn populate_db(db: &TempDb) {
         }
 
         let mut deployed_contracts = BTreeMap::new();
-
-        for _ in 0..10 {
-            deployed_contracts.insert(arbitrary!(ContractAddress), arbitrary!(ClassHash));
-        }
-
         let mut replaced_classes = BTreeMap::new();
+
+        // this is to ensure that the contract addresses in replaced_classes exist ie is deployed.
         for _ in 0..10 {
-            replaced_classes.insert(arbitrary!(ContractAddress), arbitrary!(ClassHash));
+            let address = arbitrary!(ContractAddress);
+            deployed_contracts.insert(address, arbitrary!(ClassHash));
+            replaced_classes.insert(address, arbitrary!(ClassHash));
         }
 
         let state_updates = StateUpdates {

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -14,7 +14,7 @@ katana-metrics.workspace = true
 katana-pool.workspace = true
 katana-primitives.workspace = true
 katana-genesis = { workspace = true, optional = true }
-katana-provider.workspace = true
+katana-provider = { workspace = true, features = [ "test-utils" ] }
 katana-rpc-api = { workspace = true, features = [ "client" ] }
 katana-rpc-types.workspace = true
 katana-rpc-types-builder.workspace = true

--- a/crates/storage/db/src/models/contract.rs
+++ b/crates/storage/db/src/models/contract.rs
@@ -12,20 +12,97 @@ pub struct ContractInfoChangeList {
     pub nonce_change_list: BlockList,
 }
 
+/// The type of event that triggered the class change.
+#[derive(Debug, Default, PartialEq, Eq)]
+#[cfg_attr(test, derive(::arbitrary::Arbitrary))]
+pub enum ContractClassChangeType {
+    /// The contract was deployed with the given class hash.
+    #[default]
+    Deployed,
+    /// The class change is made using the `replace_class` syscall.
+    Replaced,
+}
+
 #[derive(Debug, Default, PartialEq, Eq)]
 #[cfg_attr(test, derive(::arbitrary::Arbitrary))]
 pub struct ContractClassChange {
+    /// The type of class change.
+    pub r#type: ContractClassChangeType,
+    /// The address of the contract whose class has changed.
     pub contract_address: ContractAddress,
     /// The updated class hash of `contract_address`.
     pub class_hash: ClassHash,
 }
 
-impl Compress for ContractClassChange {
+impl ContractClassChange {
+    /// Creates a new `ContractClassChange` instance representing a deployed contract.
+    pub fn deployed(contract_address: ContractAddress, class_hash: ClassHash) -> Self {
+        Self { r#type: ContractClassChangeType::Deployed, contract_address, class_hash }
+    }
+
+    /// Creates a new `ContractClassChange` instance representing a replaced class
+    pub fn replaced(contract_address: ContractAddress, new_class_hash: ClassHash) -> Self {
+        Self {
+            r#type: ContractClassChangeType::Replaced,
+            contract_address,
+            class_hash: new_class_hash,
+        }
+    }
+
+    fn decompress_current(bytes: &[u8]) -> Result<Self, CodecError> {
+        let r#type = ContractClassChangeType::decompress(&bytes[0..1])?;
+        let contract_address = ContractAddress::decode(&bytes[1..33])?;
+        let class_hash = ClassHash::decompress(&bytes[33..])?;
+        Ok(Self { r#type, contract_address, class_hash })
+    }
+
+    /// Backward compatibility purposes.
+    ///
+    /// The old format doesn't distinguish between a class change that happen because of a contract
+    /// deployment or a class replacement via the `replace_class` system call. Thus, we are
+    /// unable to determine the type of class change and have to just assume it's a deployment.
+    #[cold]
+    fn decompress_legacy(bytes: &[u8]) -> Result<Self, CodecError> {
+        let contract_address = ContractAddress::decode(&bytes[0..32])?;
+        let class_hash = ClassHash::decompress(&bytes[32..])?;
+        Ok(Self { r#type: ContractClassChangeType::Deployed, contract_address, class_hash })
+    }
+}
+
+impl Compress for ContractClassChangeType {
     type Compressed = Vec<u8>;
     fn compress(self) -> Result<Self::Compressed, CodecError> {
+        let byte: u8 = match self {
+            ContractClassChangeType::Deployed => 0,
+            ContractClassChangeType::Replaced => 1,
+        };
+        Ok(vec![byte])
+    }
+}
+
+impl Decompress for ContractClassChangeType {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+        if bytes.is_empty() {
+            return Err(CodecError::Decompress("can't decompress empty bytes".to_string()));
+        }
+
+        match bytes[0] {
+            0 => Ok(ContractClassChangeType::Deployed),
+            1 => Ok(ContractClassChangeType::Replaced),
+            _ => Err(CodecError::Decompress("unknown ContractClassChangeType variant".to_string())),
+        }
+    }
+}
+
+impl Compress for ContractClassChange {
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
         let mut buf = Vec::new();
-        buf.extend_from_slice(self.contract_address.encode().as_ref());
-        buf.extend_from_slice(self.class_hash.compress()?.as_ref());
+        buf.extend(self.r#type.compress()?);
+        buf.extend(self.contract_address.encode());
+        buf.extend(self.class_hash.compress()?);
         Ok(buf)
     }
 }
@@ -33,9 +110,12 @@ impl Compress for ContractClassChange {
 impl Decompress for ContractClassChange {
     fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, crate::error::CodecError> {
         let bytes = bytes.as_ref();
-        let contract_address = ContractAddress::decode(&bytes[0..32])?;
-        let class_hash = ClassHash::decompress(&bytes[32..])?;
-        Ok(Self { contract_address, class_hash })
+
+        if let Ok(result) = Self::decompress_current(bytes) {
+            Ok(result)
+        } else {
+            ContractClassChange::decompress_legacy(bytes)
+        }
     }
 }
 

--- a/crates/storage/db/src/models/contract.rs
+++ b/crates/storage/db/src/models/contract.rs
@@ -50,9 +50,9 @@ impl ContractClassChange {
     }
 
     fn decompress_current(bytes: &[u8]) -> Result<Self, CodecError> {
-        let r#type = ContractClassChangeType::decompress(&bytes[0..1])?;
-        let contract_address = ContractAddress::decode(&bytes[1..33])?;
-        let class_hash = ClassHash::decompress(&bytes[33..])?;
+        let contract_address = ContractAddress::decode(&bytes[0..32])?;
+        let class_hash = ClassHash::decompress(&bytes[32..64])?;
+        let r#type = ContractClassChangeType::decompress(&bytes[64..])?;
         Ok(Self { r#type, contract_address, class_hash })
     }
 
@@ -100,9 +100,9 @@ impl Compress for ContractClassChange {
 
     fn compress(self) -> Result<Self::Compressed, CodecError> {
         let mut buf = Vec::new();
-        buf.extend(self.r#type.compress()?);
-        buf.extend(self.contract_address.encode());
+        buf.extend(self.contract_address.encode()); // this must be encoded first becase it's the subkey
         buf.extend(self.class_hash.compress()?);
+        buf.extend(self.r#type.compress()?);
         Ok(buf)
     }
 }

--- a/crates/storage/provider/provider-api/src/error.rs
+++ b/crates/storage/provider/provider-api/src/error.rs
@@ -102,6 +102,20 @@ pub enum ProviderError {
         storage_key: StorageKey,
     },
 
+    /// Error when a contract info is not found but is expected to exist.
+    #[error("Missing contract info for contract {address}")]
+    MissingContractInfo {
+        /// The address of contract whose `ContractInfo` table entry is missing.
+        address: ContractAddress,
+    },
+
+    /// Error when a contract info change set is not found but is expected to exist.
+    #[error("Missing contract info change set for contract {address}")]
+    MissingContractInfoChangeSet {
+        /// The address of contract whose `ContractInfoChangeSet` table entry is missing.
+        address: ContractAddress,
+    },
+
     #[error("Missing class hash for contract {address}")]
     MissingContractClassHash { address: ContractAddress },
 

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -837,11 +837,17 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
             }
 
             for (addr, new_class_hash) in states.state_updates.replaced_classes {
-                let mut info = db_tx.get::<tables::ContractInfo>(addr)?.unwrap();
+                let mut info = db_tx
+                    .get::<tables::ContractInfo>(addr)?
+                    .ok_or(ProviderError::MissingContractInfo { address: addr })?;
+
                 info.class_hash = new_class_hash;
                 db_tx.put::<tables::ContractInfo>(addr, info)?;
 
-                let mut change_set = db_tx.get::<tables::ContractInfoChangeSet>(addr)?.unwrap();
+                let mut change_set = db_tx
+                    .get::<tables::ContractInfoChangeSet>(addr)?
+                    .ok_or(ProviderError::MissingContractInfoChangeSet { address: addr })?;
+
                 change_set.class_change_list.insert(block_number);
                 db_tx.put::<tables::ContractInfoChangeSet>(addr, change_set)?;
 

--- a/crates/storage/provider/provider/src/providers/fork/state.rs
+++ b/crates/storage/provider/provider/src/providers/fork/state.rs
@@ -270,7 +270,9 @@ impl<Db: Database> StateProvider for HistoricalStateProvider<Db> {
             Ok(res)
         } else if let res @ Some(class_hash) = self.backend.get_class_hash_at(address)? {
             let block = self.provider.block();
-            let entry = ContractClassChange { contract_address: address, class_hash };
+            // TODO: this is technically wrong, we probably should insert the `ClassChangeHistory`
+            // entry on the state update level instead.
+            let entry = ContractClassChange::deployed(address, class_hash);
 
             self.db.db().tx_mut()?.put::<tables::ClassChangeHistory>(block, entry)?;
             Ok(res)


### PR DESCRIPTION
Currently, Katana doesn't store the entries of the `StateUpdates.replaced_classes` field. For context, the field is a mapping of class changes that are made using the `replace_class` syscall on an already deployed contract.

We can't store the `replaced_classes` entries directly in the `ClassChangeHistory` table without any modification. The table is currently intended to store class changes that happen due to contract deployments i.e., the entries in `StateUpdates.deployed_contracts`. The table value doesn't distinguish on the event that cause the class change. So, the simplest approach is to add a new field in the value type of the `ClassChangeHistory` table for preserving that information:

```rust
#[derive(Debug, Default, PartialEq, Eq)]
#[cfg_attr(test, derive(::arbitrary::Arbitrary))]
pub struct ContractClassChange {
    /// The type of class change.
    pub r#type: ContractClassChangeType,
    /// The address of the contract whose class has changed.
    pub contract_address: ContractAddress,
    /// The updated class hash of `contract_address`.
    pub class_hash: ClassHash,
}
```