### PR TITLE
feat(provider): return mock trie root for fork provider

### DIFF
--- a/.github/workflows/snos-release.yml
+++ b/.github/workflows/snos-release.yml
@@ -1,0 +1,8 @@
+# Due to workflow limitation of github, this file is merely here
+# to support triggering the workflow on a dev branch, without having
+# to merge it into main.
+#
+# gh workflow run snos-release.yml --ref feat/update-gen-and-statefull-compr -f preview=v1.7.0-snos.1
+#
+# This can be deleted once the development branch is merged back to main.
+#

--- a/.github/workflows/snos-release.yml
+++ b/.github/workflows/snos-release.yml
@@ -1,8 +1,0 @@
-# Due to workflow limitation of github, this file is merely here
-# to support triggering the workflow on a dev branch, without having
-# to merge it into main.
-#
-# gh workflow run snos-release.yml --ref feat/update-gen-and-statefull-compr -f preview=v1.7.0-snos.1
-#
-# This can be deleted once the development branch is merged back to main.
-#

--- a/crates/storage/provider/provider/src/providers/fork/trie.rs
+++ b/crates/storage/provider/provider/src/providers/fork/trie.rs
@@ -16,7 +16,9 @@ impl<Db: Database> TrieWriter for ForkedProvider<Db> {
         block_number: BlockNumber,
         state_updates: &StateUpdates,
     ) -> ProviderResult<Felt> {
-        self.provider.trie_insert_contract_updates(block_number, state_updates)
+        let _ = block_number;
+        let _ = state_updates;
+        Ok(Felt::ZERO)
     }
 
     fn trie_insert_declared_classes(
@@ -24,6 +26,8 @@ impl<Db: Database> TrieWriter for ForkedProvider<Db> {
         block_number: BlockNumber,
         updates: &BTreeMap<ClassHash, CompiledClassHash>,
     ) -> ProviderResult<Felt> {
-        self.provider.trie_insert_declared_classes(block_number, updates)
+        let _ = block_number;
+        let _ = updates;
+        Ok(Felt::ZERO)
     }
 }


### PR DESCRIPTION
State tries doesn't actually work yet with `ForkProvider` so it's better to just return a `Felt::ZERO` to make that more obvious otherwise it's easy to mistakenly think that the trie roots returned by the methods are valid (they aren't).