### PR TITLE
feat(gateway): handle unknown response format gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,6 +6176,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -12786,6 +12805,30 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wiremock"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -37,6 +37,8 @@ anyhow.workspace = true
 katana-utils.workspace = true
 rstest.workspace = true
 similar-asserts.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
+wiremock = "0.6"
 
 # This binary is mainly for debugging purposes only
 [[bin]]


### PR DESCRIPTION
Sometimes the feeder gateway returns a response that is unrecognized by the `Response` enum. In which case, the request would fail with a `serde` deserialization error with an unhelpful error message. Here, we captures the unknown response body format and include it in the error message to make debugging much easier. 