### PR TITLE
Revert Blacksmith runners migration

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   bench:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     steps:

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -28,15 +28,15 @@ jobs:
   # |--------------------|---------------------------|
   #
   setup:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.docker_tag.outputs.tag_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Set Docker tag
         id: docker_tag
@@ -49,7 +49,7 @@ jobs:
           fi
 
   build-and-push-amd64:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-8-cores
     needs: setup
     steps:
       - name: Checkout repository
@@ -69,7 +69,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image for amd64
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
@@ -79,9 +79,10 @@ jobs:
             RUST_VERSION=${{ env.RUST_VERSION }}
             CLIPPY_VERSION=${{ env.CLIPPY_VERSION }}
           platforms: linux/amd64
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-dev:latest-amd64
 
   build-and-push-arm64:
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest-8-cores-arm64
     needs: setup
     steps:
       - name: Checkout repository
@@ -101,7 +102,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image for arm64
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
@@ -111,9 +112,10 @@ jobs:
             RUST_VERSION=${{ env.RUST_VERSION }}
             CLIPPY_VERSION=${{ env.CLIPPY_VERSION }}
           platforms: linux/arm64
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-dev:latest-arm64
 
   create-multiplatform-manifest:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [setup, build-and-push-amd64, build-and-push-arm64]
     steps:
       - name: Login to GitHub Container Registry

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(vars.ALLOWED_CLAUDE_USERS, github.event.review.user.login)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(vars.ALLOWED_CLAUDE_USERS, github.event.issue.user.login)))
 
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -66,7 +66,7 @@ jobs:
       github.event.comment &&
       github.event.comment.body == '/claude-review'
 
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dockerfile-build-test.yml
+++ b/.github/workflows/dockerfile-build-test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-dev-image:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         platform: [linux/amd64]
@@ -19,11 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Test Docker build for ${{ matrix.platform }}
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: false
           file: .github/Dockerfile
@@ -31,3 +31,5 @@ jobs:
           build-args: |
             RUST_VERSION=${{ env.RUST_VERSION }}
             CLIPPY_VERSION=${{ env.CLIPPY_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/generate-db-dispatch.yml
+++ b/.github/workflows/generate-db-dispatch.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   generate-database:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     container:
       image: ghcr.io/dojoengine/katana-dev:latest

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   prepare:
     # The prepare-release branch names comes from the release-dispatch.yml workflow.
     if: (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'prepare-release') || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.release_info.outputs.tag_name }}
     steps:
@@ -41,7 +41,7 @@ jobs:
           fi
 
   build-contracts:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: prepare
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -76,23 +76,23 @@ jobs:
           # The arch is either 386, arm64 or amd64
           # The svm target platform to use for the binary https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
           # Added native_build dimension to control build type
-          - os: blacksmith-8vcpu-ubuntu-2404
+          - os: ubuntu-latest-8-cores
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
             native_build: true
-          - os: blacksmith-8vcpu-ubuntu-2404
+          - os: ubuntu-latest-8-cores
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
             native_build: false
-          - os: blacksmith-8vcpu-ubuntu-2404-arm
+          - os: ubuntu-latest-8-cores-arm64
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: arm64
             svm_target_platform: linux-aarch64
             native_build: true
-          - os: blacksmith-8vcpu-ubuntu-2404-arm
+          - os: ubuntu-latest-8-cores-arm64
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: arm64
@@ -277,7 +277,7 @@ jobs:
           retention-days: 1
 
   create-draft-release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [prepare, release]
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -301,7 +301,7 @@ jobs:
       - run: gh release create ${{ steps.version_info.outputs.version }} ./artifacts/* --generate-notes --draft
 
   docker-build-and-push:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-8-cores
     needs: [prepare, release]
 
     steps:
@@ -315,8 +315,8 @@ jobs:
           path: artifacts/linux
           merge-multiple: true
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -327,7 +327,7 @@ jobs:
 
       - name: Build and push docker image
         if: ${{ contains(needs.prepare.outputs.tag_name, 'preview') }}
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.tag_name }}
@@ -337,7 +337,7 @@ jobs:
 
       - name: Build and push docker image
         if: ${{ !contains(needs.prepare.outputs.tag_name, 'preview') }}
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   fmt:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -43,7 +43,7 @@ jobs:
 
   generate-test-artifacts:
     needs: [fmt]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -89,7 +89,7 @@ jobs:
 
   build-katana-binary:
     needs: [fmt, clippy, generate-test-artifacts]
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-32-cores
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -128,7 +128,7 @@ jobs:
 
   clippy:
     needs: [generate-test-artifacts]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-4-cores
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -158,7 +158,7 @@ jobs:
 
   test:
     needs: [fmt, clippy, generate-test-artifacts, build-katana-binary]
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-32-cores
     timeout-minutes: 30
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
@@ -216,7 +216,7 @@ jobs:
 
   snos-integration-test:
     needs: [fmt, clippy]
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-32-cores
     timeout-minutes: 30
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
@@ -253,7 +253,7 @@ jobs:
 
   explorer-reverse-proxy:
     needs: [fmt, clippy, build-katana-binary]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
@@ -285,7 +285,7 @@ jobs:
 
   dojo-integration-test:
     needs: [fmt, clippy, build-katana-binary]
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest-32-cores
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     container:
       image: ghcr.io/dojoengine/katana-dev:latest

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   current-main-size:
     name: Current main branch binary size
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     outputs:
@@ -33,9 +33,6 @@ jobs:
         with:
           key: weekly-binary-size-main
 
-      - name: Make contracts
-        run: make contracts
-
       - name: Get binary size (main)
         id: binary-size
         run: |
@@ -48,7 +45,7 @@ jobs:
 
   latest-release-size:
     name: Latest release binary size
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     outputs:
@@ -66,9 +63,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: weekly-binary-size-release
-
-      - name: Make contracts
-        run: make contracts
 
       - name: Get latest release and binary size
         id: binary-size
@@ -91,7 +85,7 @@ jobs:
   generate-report:
     name: Generate binary size report
     needs: [current-main-size, latest-release-size]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
 


### PR DESCRIPTION
This reverts the Blacksmith runners migration introduced in #276. No specific reason for the revert. Mainly because it's a bit of a hassle to be on different runner service with the rest of the org.