### PR TITLE
refactor(node): update tip watcher to be subscription-based

### DIFF
--- a/crates/node/src/full/mod.rs
+++ b/crates/node/src/full/mod.rs
@@ -1,13 +1,9 @@
 //! Experimental full node implementation.
 
-mod exit;
-mod tip_watcher;
-
 use std::future::IntoFuture;
 use std::sync::Arc;
 
 use anyhow::Result;
-use exit::NodeStoppedFuture;
 use katana_gateway::client::Client as SequencerGateway;
 use katana_metrics::exporters::prometheus::PrometheusRecorder;
 use katana_metrics::{Report, Server as MetricsServer};
@@ -20,11 +16,16 @@ use katana_provider::providers::db::DbProvider;
 use katana_stage::blocks::BatchBlockDownloader;
 use katana_stage::{Blocks, Classes};
 use katana_tasks::TaskManager;
-use tip_watcher::ChainTipWatcher;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::config::db::DbConfig;
 use crate::config::metrics::MetricsConfig;
+
+mod exit;
+pub mod tip_watcher;
+
+use exit::NodeStoppedFuture;
+use tip_watcher::ChainTipWatcher;
 
 type TxPool =
     Pool<ExecutableTxWithHash, NoopValidator<ExecutableTxWithHash>, FiFo<ExecutableTxWithHash>>;
@@ -120,7 +121,15 @@ impl Node {
         };
 
         let tip_watcher = ChainTipWatcher::new(core_contract);
+
         let mut tip_subscription = tip_watcher.subscribe();
+        let pipeline_handle_clone = pipeline_handle.clone();
+
+        self.task_manager
+            .task_spawner()
+            .build_task()
+            .name("Pipeline")
+            .spawn(self.pipeline.into_future());
 
         self.task_manager
             .task_spawner()
@@ -129,21 +138,17 @@ impl Node {
             .name("Chain tip watcher")
             .spawn(tip_watcher.into_future());
 
-        // Subscribe to tip updates and update the pipeline
-        let pipeline_handle_clone = pipeline_handle.clone();
-        self.task_manager.task_spawner().build_task().name("Pipeline").spawn(async move {
+        // spawn a task for updating the pipeline's tip based on chain tip changes
+        self.task_manager.task_spawner().spawn(async move {
             loop {
-                tokio::select! {
-                    res = tip_subscription.changed() => {
-                        match res {
-                            Ok(new_tip) => pipeline_handle_clone.set_tip(new_tip),
-                            Err(err) => error!(error = ?err, "Error updating pipeline tip.")
-                        }
+                match tip_subscription.changed().await {
+                    Ok(new_tip) => pipeline_handle_clone.set_tip(new_tip),
+                    Err(err) => {
+                        error!(error = ?err, "Error updating pipeline tip.");
+                        break;
                     }
-                    _ = self.pipeline.into_future() => {},
                 }
             }
-            Ok(())
         });
 
         Ok(LaunchedNode {

--- a/crates/node/src/full/tip_watcher.rs
+++ b/crates/node/src/full/tip_watcher.rs
@@ -4,45 +4,63 @@ use std::time::Duration;
 use alloy_provider::Provider;
 use anyhow::Result;
 use futures::future::BoxFuture;
-use katana_pipeline::PipelineHandle;
+use katana_primitives::block::BlockNumber;
 use katana_starknet::StarknetCore;
-use tracing::{error, info, trace};
+use tokio::sync::watch;
+use tracing::{error, info};
 
-type TipWatcherFut = BoxFuture<'static, Result<()>>;
+pub type TipWatcherFut = BoxFuture<'static, Result<()>>;
 
-#[derive(Debug)]
 pub struct ChainTipWatcher<P> {
     /// The Starknet Core Contract client for fetching the latest block.
     core_contract: StarknetCore<P>,
-    /// The pipeline handle for setting the tip.
-    pipeline_handle: PipelineHandle,
     /// Interval for checking the new tip.
     watch_interval: Duration,
+    /// Watch channel for notifying subscribers of the latest tip.
+    tip_sender: watch::Sender<BlockNumber>,
 }
 
 impl<P: alloy_provider::Provider> ChainTipWatcher<P> {
-    pub fn new(core_contract: StarknetCore<P>, pipeline_handle: PipelineHandle) -> Self {
+    pub fn new(core_contract: StarknetCore<P>) -> Self {
+        let (tip_tx, _) = watch::channel(0);
         let watch_interval = Duration::from_secs(30);
-        Self { core_contract, pipeline_handle, watch_interval }
+        Self { core_contract, watch_interval, tip_sender: tip_tx }
+    }
+
+    /// Set the watch interval for checking new tips.
+    pub fn interval(mut self, interval: Duration) -> Self {
+        self.watch_interval = interval;
+        self
+    }
+
+    /// Subscribe to tip updates.
+    ///
+    /// Returns a subscription that always reflects the latest tip block number.
+    pub fn subscribe(&self) -> TipSubscription {
+        TipSubscription(self.tip_sender.subscribe())
     }
 
     pub async fn run(&self) -> Result<()> {
         let interval_in_secs = self.watch_interval.as_secs();
         info!(target: "node", interval = %interval_in_secs, "Chain tip watcher started.");
 
-        let mut prev_tip = 0;
+        let mut prev_tip: BlockNumber = 0;
 
         loop {
-            let block_number = self.core_contract.state_block_number().await?;
+            let block_number = self.core_contract.state_block_number().await? as BlockNumber;
 
             if prev_tip != block_number {
-                trace!(target: "node", block = %block_number, "New tip received");
-                self.pipeline_handle.set_tip(block_number as u64);
+                info!(block = %block_number, "New tip found.");
                 prev_tip = block_number;
+                self.broadcast_tip(block_number);
             }
 
             tokio::time::sleep(self.watch_interval).await;
         }
+    }
+
+    fn broadcast_tip(&self, block_number: BlockNumber) {
+        let _ = self.tip_sender.send(block_number);
     }
 }
 
@@ -53,8 +71,41 @@ impl<P: Provider + 'static> IntoFuture for ChainTipWatcher<P> {
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
             self.run().await.inspect_err(|error| {
-                error!(target: "pipeline", %error, "Tip watcher failed.");
+                error!(target: "node", %error, "Tip watcher failed.");
             })
         })
+    }
+}
+
+impl<P: std::fmt::Debug> std::fmt::Debug for ChainTipWatcher<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChainTipWatcher")
+            .field("core_contract", &self.core_contract)
+            .field("subscribers", &self.tip_sender.receiver_count())
+            .field("watch_interval", &self.watch_interval)
+            .finish()
+    }
+}
+
+/// A subscription to chain tip updates.
+#[derive(Clone)]
+pub struct TipSubscription(watch::Receiver<BlockNumber>);
+
+impl TipSubscription {
+    /// Get the current tip block number.
+    pub fn tip(&self) -> BlockNumber {
+        *self.0.borrow()
+    }
+
+    /// Wait for the tip to change and return the new value.
+    pub async fn changed(&mut self) -> Result<BlockNumber> {
+        self.0.changed().await?;
+        Ok(*self.0.borrow_and_update())
+    }
+}
+
+impl std::fmt::Debug for TipSubscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TipSubscription").field("current_tip", &self.tip()).finish()
     }
 }


### PR DESCRIPTION
The idea behind this change is to decouple the `ChainTipWatcher` struct from the specific components that need to react to tip changes. 

The `ChainTipWatcher` is currently associated with the syncing `Pipeline` - it holds a handle to the pipeline component that it'd use for updating the pipeline's tip. The current design is fine but it would require adding another component's 'handle' to the `ChainTipWatcher` struct for every new component.

I initially started with turning the `ChainTipWatcher` to use 'hooks' that would be executed every time a new tip is received. But that would put the responsibility of running the hooks to `ChainTipWatcher` itself and I think subscription-based design makes the component more lightweight and completely shoves that responsibility away from it. But this means we need to create a dedicated task for each component that needs to react to chain tip changes.