### PR TITLE
refactor(rpc): use `katana-rpc-client` in `ForkedClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6310,6 +6310,7 @@ dependencies = [
  "katana-provider",
  "katana-rpc",
  "katana-rpc-api",
+ "katana-rpc-client",
  "katana-stage",
  "katana-starknet",
  "katana-tasks",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -21,6 +21,7 @@ katana-primitives.workspace = true
 katana-provider.workspace = true
 katana-rpc = { workspace = true }
 katana-rpc-api.workspace = true
+katana-rpc-client.workspace = true
 katana-stage.workspace = true
 katana-tasks.workspace = true
 katana-tracing.workspace = true

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -47,6 +47,7 @@ use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::starknet::{StarknetApiServer, StarknetTraceApiServer, StarknetWriteApiServer};
 #[cfg(feature = "explorer")]
 use katana_rpc_api::starknet_ext::StarknetApiExtServer;
+use katana_rpc_client::starknet::Client as StarknetClient;
 use katana_stage::Sequencing;
 use katana_tasks::TaskManager;
 use tracing::info;
@@ -149,7 +150,8 @@ impl Node {
 
             // TODO: it'd bee nice if the client can be shared on both the rpc and forked backend
             // side
-            let rpc_client = HttpClientBuilder::new().build(cfg.url.as_ref())?;
+            let http_client = HttpClientBuilder::new().build(cfg.url.as_ref())?;
+            let rpc_client = StarknetClient::new(http_client);
             let forked_client = ForkedClient::new(rpc_client, block_num);
 
             (bc, db, Some(forked_client))

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -16,6 +16,7 @@ katana-primitives.workspace = true
 katana-genesis = { workspace = true, optional = true }
 katana-provider = { workspace = true, features = [ "test-utils" ] }
 katana-rpc-api = { workspace = true, features = [ "client" ] }
+katana-rpc-client.workspace = true
 katana-rpc-types.workspace = true
 katana-rpc-types-builder.workspace = true
 katana-tasks.workspace = true


### PR DESCRIPTION
Replace the direct raw `HttpClient` usage in `ForkedClient` with the higher-level `katana_rpc_client::starknet::Client` wrapper. This simplifies error handling and provides better consistency across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)