### PR TITLE
fix(provider): historical provider doesn't respect pinned block number

### DIFF
--- a/crates/core/src/backend/storage.rs
+++ b/crates/core/src/backend/storage.rs
@@ -141,7 +141,7 @@ impl Blockchain {
 
         // TODO: convert this to block number instead of BlockHashOrNumber so that it is easier to
         // check if the requested block is within the supported range or not.
-        let database = ForkedProvider::new(db, block_id, provider.clone());
+        let database = ForkedProvider::new(db, block_num, provider.clone());
 
         // initialize parent fork block
         //

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -52,7 +52,7 @@ pub enum ConfirmedBlockIdOrTag {
     L1Accepted,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlockHashOrNumber {
     Hash(BlockHash),

--- a/crates/storage/provider/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/provider/src/providers/fork/mod.rs
@@ -39,6 +39,7 @@ mod trie;
 pub struct ForkedProvider<Db: Database = katana_db::Db> {
     backend: BackendClient,
     provider: Arc<DbProvider<Db>>,
+    block_id: BlockNumber,
 }
 
 impl<Db: Database> ForkedProvider<Db> {
@@ -47,23 +48,27 @@ impl<Db: Database> ForkedProvider<Db> {
     /// - `db`: The database to use for the provider.
     /// - `block_id`: The block number or hash to use as the fork point.
     /// - `provider`: The Starknet JSON-RPC client to use for the provider.
-    pub fn new(db: Db, block_id: BlockHashOrNumber, provider: StarknetClient) -> Self {
-        let backend = Backend::new(provider, block_id).expect("failed to create backend");
+    pub fn new(db: Db, block_id: BlockNumber, provider: StarknetClient) -> Self {
+        let backend = Backend::new(provider).expect("failed to create backend");
         let provider = Arc::new(DbProvider::new(db));
-        Self { provider, backend }
+        Self { provider, backend, block_id }
     }
 
     pub fn backend(&self) -> &BackendClient {
         &self.backend
     }
+
+    pub fn block_id(&self) -> BlockNumber {
+        self.block_id
+    }
 }
 
 impl ForkedProvider<katana_db::Db> {
     /// Creates a new [`ForkedProvider`] using an ephemeral database.
-    pub fn new_ephemeral(block_id: BlockHashOrNumber, provider: StarknetClient) -> Self {
-        let backend = Backend::new(provider, block_id).expect("failed to create backend");
+    pub fn new_ephemeral(block_id: BlockNumber, provider: StarknetClient) -> Self {
+        let backend = Backend::new(provider).expect("failed to create backend");
         let provider = Arc::new(DbProvider::new_in_memory());
-        Self { provider, backend }
+        Self { provider, backend, block_id }
     }
 }
 


### PR DESCRIPTION
The fork version of the  `HistoricalStateProvider` should falls back to requesting data from the forked network ONLY when the pinned block number (i.e., the block number the `HistoricalStateProvider` is created for - the `block_id` given to `<ForkedProvider as StateFactoryProvider>::historical`) is less than or equal to the block number which katana is forked at.

Currently, `HistoricalStateProvider` would immediately falls back to the forked network. The request is then handled by the `Backend` and `Backend` is pinned to the forked block number and not the block number the state provider is for.