### PR TITLE
feat: alias contract for stateful compression

### DIFF
--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -659,7 +659,18 @@ impl TrieWriter for GenesisTrieWriter {
             contract_leafs
                 .into_iter()
                 .map(|(address, leaf)| {
-                    let class_hash = leaf.class_hash.unwrap();
+                    let class_hash = if let Some(class_hash) = leaf.class_hash {
+                        class_hash
+                    } else {
+                        // TODO: there's must be a better way to handle this
+                        assert!(
+                            address == address!("0x1") || address == address!("0x2"),
+                            "Only special contracts may have unspecified class hash."
+                        );
+
+                        ClassHash::ZERO
+                    };
+
                     let nonce = leaf.nonce.unwrap_or_default();
                     let storage_root = leaf.storage_root.unwrap_or_default();
                     let leaf_hash = compute_contract_state_hash(&class_hash, &storage_root, &nonce);

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -292,7 +292,7 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
     }
 
     fn take_execution_output(&mut self) -> ExecutorResult<ExecutionOutput> {
-        let states = utils::state_update_from_cached_state(&self.state);
+        let states = utils::state_update_from_cached_state(&self.state, true);
         let transactions = std::mem::take(&mut self.transactions);
         let stats = std::mem::take(&mut self.stats);
         Ok(ExecutionOutput { stats, states, transactions })

--- a/crates/executor/tests/executor.rs
+++ b/crates/executor/tests/executor.rs
@@ -308,7 +308,12 @@ fn test_executor_with_valid_blocks_impl(
 
     // TODO: asserts the storage updates
     let actual_storage_updates = states.state_updates.storage_updates;
-    assert_eq!(actual_storage_updates.len(), 3, "only 3 contracts whose storage should be updated");
+    assert_eq!(
+        actual_storage_updates.len(),
+        4,
+        "only 4 ( 3 normal contract + 1 for special alias contract '0x2') contracts whose storage \
+         should be updated"
+    );
     assert!(
         actual_storage_updates.contains_key(&DEFAULT_ETH_FEE_TOKEN_ADDRESS),
         "fee token storage must get updated"
@@ -320,6 +325,10 @@ fn test_executor_with_valid_blocks_impl(
     assert!(
         actual_storage_updates.contains_key(&new_acc),
         "newly deployed account storage must get updated"
+    );
+    assert!(
+        actual_storage_updates.contains_key(&address!("0x2")),
+        "alias contract must be allocated"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements support for **stateful compression** (introduced in Starknet v0.13.4) by integrating the alias contract at address `0x2`.

**Starknet v0.13.4 Pre-release notes**: https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-stateful-compression-11

### Alias contract

Stateful compression optimizes state diff encoding by mapping storage keys, contract addresses, and class hashes to shorter indices based on their first occurrence. This significantly reduces the data size for blob submissions to L1, as these values (typically 252-bit hashes) can be referenced by much smaller indices in subsequent state updates.

The alias contract (`0x2`) is a system contract that maintains a global counter and a value→index mapping. When a new storage key, contract address, or class hash appears in a state diff, it gets mapped to the current counter value, allowing subsequent references to use the smaller index instead of the full 32-byte value.

### Changes

- Integrate `allocate_aliases_in_storage` from blockifier to assign indices to new keys during state update extraction
- Update genesis trie writer to handle the alias contract (`0x2`) which has no class hash

### Future work

- Add CLI flag to enable/disable stateful compression

🤖 Generated with [Claude Code](https://claude.com/claude-code)