### PR TITLE
feat: add migrated class hashes in state update

### DIFF
--- a/bin/katana/tests/fixtures.rs
+++ b/bin/katana/tests/fixtures.rs
@@ -78,6 +78,13 @@ fn populate_db(db: &TempDb) {
             classes.insert(hash, ContractClass::Legacy(Default::default()));
         }
 
+        let mut migrated_compiled_classes = BTreeMap::new();
+        for _ in 0..10 {
+            let hash = arbitrary!(ClassHash);
+            let compiled_class_hash = arbitrary!(ClassHash);
+            migrated_compiled_classes.insert(hash, compiled_class_hash);
+        }
+
         let mut nonce_updates = BTreeMap::new();
         for _ in 0..10 {
             nonce_updates.insert(arbitrary!(ContractAddress), arbitrary!(Nonce));
@@ -110,9 +117,12 @@ fn populate_db(db: &TempDb) {
             replaced_classes,
             deployed_contracts,
             deprecated_declared_classes,
+            migrated_compiled_classes,
         };
 
-        provider.trie_insert_declared_classes(num, &state_updates.declared_classes).unwrap();
+        provider
+            .trie_insert_declared_classes(num, state_updates.declared_classes.clone().into_iter())
+            .unwrap();
         provider.trie_insert_contract_updates(num, &state_updates).unwrap();
 
         let mut block = Block::default();

--- a/crates/executor/src/implementation/blockifier/utils.rs
+++ b/crates/executor/src/implementation/blockifier/utils.rs
@@ -564,6 +564,7 @@ pub(super) fn state_update_from_cached_state(state: &CachedState<'_>) -> StateUp
             deployed_contracts,
             deprecated_declared_classes,
             replaced_classes: BTreeMap::default(),
+            migrated_compiled_classes: BTreeMap::default(),
         },
     }
 }

--- a/crates/gateway/gateway-client/tests/fixtures/0.14.1/state_update/mainnet_4130000.json
+++ b/crates/gateway/gateway-client/tests/fixtures/0.14.1/state_update/mainnet_4130000.json
@@ -1,0 +1,330 @@
+{
+  "block_hash": "0x1935ec0e5c7758fdc11a78ed9d4cadd4225eab826aabd98fe2d04b45ca4c150",
+  "new_root": "0x7e72ca880e4fa1f4987257d90b2642860a4574a03b79ac830f6fb5968520977",
+  "old_root": "0x484d8010568613b1878e03085989536d9112d89e2979297f0fbd741a3f73138",
+  "state_diff": {
+    "storage_diffs": {
+      "0x1": [
+        {
+          "key": "0x3f04c6",
+          "value": "0x3e53fff98965235e64b766ad713b1d9730027c6cf41ffb2ace60c1979b02bc7"
+        }
+      ],
+      "0x2": [
+        {
+          "key": "0x0",
+          "value": "0x78b0fb7"
+        },
+        {
+          "key": "0xd58a4bdab51dbf1e5c9178814cc4adf01ebe0c872d0ed61b4e54922cc1b996",
+          "value": "0x78b0fb1"
+        },
+        {
+          "key": "0x37a3f18631ffdfbc04751ecf46226bcca4194f7ee3743da23d45503e78a8031",
+          "value": "0x78b0fb4"
+        },
+        {
+          "key": "0x37a3f18631ffdfbc04751ecf46226bcca4194f7ee3743da23d45503e78a8032",
+          "value": "0x78b0fb5"
+        },
+        {
+          "key": "0x3ee4ba0f59886159d92a35f96ded219dd7f69c30953f9b68d333f10a27e312b",
+          "value": "0x78b0fb2"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0b",
+          "value": "0x78b0fad"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0c",
+          "value": "0x78b0fae"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0d",
+          "value": "0x78b0faf"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0e",
+          "value": "0x78b0fb0"
+        },
+        {
+          "key": "0x5e4542324cd70f0da676f0418afaecd12405976d2356fec26293a460a48bf13",
+          "value": "0x78b0fb6"
+        },
+        {
+          "key": "0x67e2b7df13c81d03441781ccd8f64bfdb0fce02f5ddc22cb35c8144c59c02f6",
+          "value": "0x78b0fb3"
+        },
+        {
+          "key": "0x6d410d47be5497b0dafef14e24c8767731a6e50126ff8fa99f25a0d0ee02788",
+          "value": "0x78b0fac"
+        }
+      ],
+      "0x3df887ee9fcdbde0d5cee8bd63fa66dee1662a1f44b075f744952cc99b6b13": [
+        {
+          "key": "0xfc7fce0137ef0fdf47d2297ba791a15d3f3f1801dc7ef0b2aa311ad5d4034c",
+          "value": "0x155d5ef96092800c8f58"
+        },
+        {
+          "key": "0x29904f220cd5d7c3928339c9760e0459aa13e8f35214b3e510f51042a8e027d",
+          "value": "0x744d8b7db6286804a"
+        },
+        {
+          "key": "0x29904f220cd5d7c3928339c9760e0459aa13e8f35214b3e510f51042a8e027f",
+          "value": "0xeddb83"
+        },
+        {
+          "key": "0x29904f220cd5d7c3928339c9760e0459aa13e8f35214b3e510f51042a8e0281",
+          "value": "0x69393984"
+        },
+        {
+          "key": "0x29904f220cd5d7c3928339c9760e0459aa13e8f35214b3e510f51042a8e0284",
+          "value": "0xd09a27d0809e1caf7"
+        }
+      ],
+      "0x12f173ebf374db69c33c4176b4c2bd4cde1bca1ceb7ff88b52dc42e7c5f66f1": [
+        {
+          "key": "0x3342fa999fea16067b1f01baf96673f31a25f2b1443e6754d93fc40b57e8df2",
+          "value": "0x1682fb66a5adc2bb"
+        },
+        {
+          "key": "0x3342fa999fea16067b1f01baf96673f31a25f2b1443e6754d93fc40b57e8df6",
+          "value": "0x69393984"
+        }
+      ],
+      "0x18469ed2d40a016a602371173c7287e25f85cb6abb6fc0866d3c444e2837603": [
+        {
+          "key": "0x6d410d47be5497b0dafef14e24c8767731a6e50126ff8fa99f25a0d0ee02788",
+          "value": "0x1"
+        }
+      ],
+      "0x1b14326182638866e10d804d7a9e9fd51a522c8ac59ab9b1b11975d21fae9c7": [
+        {
+          "key": "0xefb0884a0332bee3218e5114a1f5a8b94b7f3a0aa4b620ecd81bc37c64598f",
+          "value": "0x5880301"
+        },
+        {
+          "key": "0x329c7ad716328e6d50f9ca0db199b7680edd1f9888de9e870e256b4d829dd57",
+          "value": "0x75585"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0b",
+          "value": "0xa90224"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0c",
+          "value": "0x3f04d0"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0d",
+          "value": "0x69393933"
+        },
+        {
+          "key": "0x51434bb3f996080c738de8a0ef10304fa880084fd55cb896c136e4873854f0e",
+          "value": "0x69393984"
+        }
+      ],
+      "0x223e2f1b09f495eb4784de5da08751eef6339294e3e02f525c49b3c4df38880": [
+        {
+          "key": "0x324fce85c2297d7ff9c265222108145baf05cde91f2da32b3877560d78916ac",
+          "value": "0xdff7d"
+        }
+      ],
+      "0x2ef591697f0fd9adc0ba9dbe0ca04dabad80cf95f08ba02e435d9cb6698a28a": [
+        {
+          "key": "0x1379c436357371c42e43fedcbd051f6fe836d50df1d57bd62bedc69f7a9ca03",
+          "value": "0xe00000921c0000db955581216d5f5521415f20c1210e100000c02647b"
+        }
+      ],
+      "0x377c2d65debb3978ea81904e7d59740da1f07412e30d01c5ded1c5d6f1ddc43": [
+        {
+          "key": "0xd58a4bdab51dbf1e5c9178814cc4adf01ebe0c872d0ed61b4e54922cc1b996",
+          "value": "0x69dcb48a56745cdc27194572d04f1e5a95781371c95244bd4588669488a6ca0"
+        },
+        {
+          "key": "0x3ee4ba0f59886159d92a35f96ded219dd7f69c30953f9b68d333f10a27e312b",
+          "value": "0x18469ed2d40a016a602371173c7287e25f85cb6abb6fc0866d3c444e2837603"
+        },
+        {
+          "key": "0x484b46148d37383593029fa3b4c09a5e0e3cb66bbcf5fc66529fa452ccc6e34",
+          "value": "0x8"
+        },
+        {
+          "key": "0x6e1a3e69a0abb3927c8349aee9a5d839de8053af580fdfa7ad5f22c0fe663fb",
+          "value": "0xae"
+        }
+      ],
+      "0x3c4b9713e7d408681f8f541b999cfba9d0a85cd4152140e75d97353d5ecc8f0": [
+        {
+          "key": "0x2208eb7142b20a00788438f9ba35fdef173c7680ba652fbfa239fef3addf2b1",
+          "value": "0x1e52d71"
+        },
+        {
+          "key": "0x33043a6019faaaacd896299801314dabcc91bc7d39ce3e8d557f431280a456b",
+          "value": "0x3c557401365e136ba378b"
+        },
+        {
+          "key": "0x3fc73af821c877aa6ced977a0bc34de21bb584b2954c82c06c80d3bc0cce026",
+          "value": "0x8139fd44b2b34049169b3c5b5da"
+        }
+      ],
+      "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d": [
+        {
+          "key": "0x129226399a3e8e88b4c9f04e61229c79b33bcd6e6204fce73b383cf5c93fc33",
+          "value": "0x2e8c2f263c8319c36b"
+        },
+        {
+          "key": "0x232431de833901e6d877a0ac4bfd9e1d4a2ccafee5f9dfd8b9e1ba5575a48db",
+          "value": "0x56a660814c34e396"
+        },
+        {
+          "key": "0x32d1ea410b5bc194a70d11ed61ed4ccd46fb14c08014c3dae9d0b43eefa5426",
+          "value": "0x168dc46f10f91510"
+        },
+        {
+          "key": "0x341b8d18ee008343d6a5ca5b846c332e31416d9a531473330016d5a4bedcd88",
+          "value": "0x744d8b7db6286804a"
+        },
+        {
+          "key": "0x3d7ccfb9e9c5944c7a3226921716da0d42239892dbde7b12c1e5597d31c4124",
+          "value": "0x3138ac97ca17d45c7515"
+        },
+        {
+          "key": "0x428b8bf52f845d23614a1144ecb19fec6156cdb86ed63f4ffa89d467c9d56f0",
+          "value": "0x9e18c2326c4c9ec30c"
+        },
+        {
+          "key": "0x5496768776e3db30053404f18067d81a6e06f5a2b0de326e21298fd9d569a9a",
+          "value": "0x131fb601e0da1c14012ed"
+        },
+        {
+          "key": "0x54c222c4c7612af283391cc175e9ba95b706989f0ebf07502f9ac5ed89f1d6c",
+          "value": "0x2aca9acc8480ec7ac"
+        },
+        {
+          "key": "0x69156455e9666009c6db030647b6779b5137551d6f5b16c4ea53a1b3a425561",
+          "value": "0xc2a36c4dd1c70ace0"
+        },
+        {
+          "key": "0x71b83ef0f4cb2ccaa36ef634622714589223ed6e67ad6eae365827a5f829161",
+          "value": "0x9c5d62bbf9a9466b88"
+        },
+        {
+          "key": "0x7baedaf13ef4d370383337a289792e2ae5747607cf278d8ceeb30274355c1e1",
+          "value": "0x9bc76445c15ef04128"
+        }
+      ],
+      "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": [
+        {
+          "key": "0x3d7ccfb9e9c5944c7a3226921716da0d42239892dbde7b12c1e5597d31c4124",
+          "value": "0x6ba79cb95c262a20"
+        },
+        {
+          "key": "0x4ce9e044cc4ea3671f19777c34fbb4e6c42f40b39b409fe794602732b423e35",
+          "value": "0x7584268fc4b3fe2"
+        }
+      ],
+      "0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8": [
+        {
+          "key": "0x28635d134a5c3c8534adbf4b3fcf41028eac53e6f04a6835290b78cbef31807",
+          "value": "0xba"
+        },
+        {
+          "key": "0x32d1ea410b5bc194a70d11ed61ed4ccd46fb14c08014c3dae9d0b43eefa5426",
+          "value": "0x0"
+        },
+        {
+          "key": "0x38e0503b87211df933ca34a5a6f1677f88d16890ec6fb843e975e273e80467e",
+          "value": "0x2078dcd414"
+        },
+        {
+          "key": "0x4ce9e044cc4ea3671f19777c34fbb4e6c42f40b39b409fe794602732b423e35",
+          "value": "0x8d29f2be"
+        },
+        {
+          "key": "0x4e1c1355394243f72d1536f721b2b63aed57a67a5b60817cde5e3af9faa194f",
+          "value": "0x5bb128bb54c5"
+        }
+      ],
+      "0x5a7a86d6113c8860f90f96ea1c8e70a747333feabb40b0584c3936fa6f86717": [
+        {
+          "key": "0x67e2b7df13c81d03441781ccd8f64bfdb0fce02f5ddc22cb35c8144c59c02f6",
+          "value": "0x1"
+        }
+      ],
+      "0x62da0780fae50d68cecaa5a051606dc21217ba290969b302db4dd99d2e9b470": [
+        {
+          "key": "0x37a3f18631ffdfbc04751ecf46226bcca4194f7ee3743da23d45503e78a8031",
+          "value": "0x3"
+        },
+        {
+          "key": "0x37a3f18631ffdfbc04751ecf46226bcca4194f7ee3743da23d45503e78a8032",
+          "value": "0x69393984"
+        }
+      ],
+      "0x68400056dccee818caa7e8a2c305f9a60d255145bac22d6c5c9bf9e2e046b71": [
+        {
+          "key": "0x3e9df762c67f04c3d19de6f877d7906e3a52e992c3f97013dc2450ab7851c9",
+          "value": "0x6ba79cb95c262a20"
+        },
+        {
+          "key": "0x1f5dba4f0e386fe3e03022985e50076614214c29faad4f1a66fd553c39c47ed",
+          "value": "0x3138ac97ca17d45c7515"
+        }
+      ],
+      "0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8": [
+        {
+          "key": "0x32d1ea410b5bc194a70d11ed61ed4ccd46fb14c08014c3dae9d0b43eefa5426",
+          "value": "0x85a2e"
+        },
+        {
+          "key": "0x341b8d18ee008343d6a5ca5b846c332e31416d9a531473330016d5a4bedcd88",
+          "value": "0xeddb83"
+        },
+        {
+          "key": "0x493875a3926558b908441a8fd6642a9f5b85f7fc5e39289c3a83b72b2eca837",
+          "value": "0x2ad3b8411"
+        }
+      ],
+      "0x69dcb48a56745cdc27194572d04f1e5a95781371c95244bd4588669488a6ca0": [
+        {
+          "key": "0x5e4542324cd70f0da676f0418afaecd12405976d2356fec26293a460a48bf13",
+          "value": "0x1"
+        }
+      ],
+      "0x7229d1454093674673a530cd0d37beef3fc0f1b3116d95c62c5c032f1827d87": [
+        {
+          "key": "0x38c22f06d1a1a3c7432edc69ea247f27fe02c8463b142118b802c9791bbc2ba",
+          "value": "0x11237d6a"
+        },
+        {
+          "key": "0x52239ed1307efbb7852382b35cd1328f3ae408fc01d99ca882db67a61ee1407",
+          "value": "0x0"
+        },
+        {
+          "key": "0x52239ed1307efbb7852382b35cd1328f3ae408fc01d99ca882db67a61ee1408",
+          "value": "0x0"
+        }
+      ]
+    },
+    "deployed_contracts": [],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "nonces": {
+      "0x338e702f015198672d2e087c93b403b35e7c90c2ba436f8397a03a661830fe": "0x51b3f",
+      "0x10aeeaa11d863f2e53373106e6807cec1fc6e8ed95a4e8b710665b7068dd8e6": "0xc268",
+      "0x2d0356738e30a3ce3d7ec6368e64d286ef71fa444990676ef1e083f68edd266": "0x2ac53",
+      "0x662776dac110a170767d83da4f1d8fae022df7aa8a78252eb9c501c68d49604": "0x1bb63",
+      "0x70366dd8425e129d7dbd7f6db2bb948bba8616563f83f043507a20c11e0d187": "0x1bb7f",
+      "0x7c0b8a20b433194608a907c6666ecd532991ac3d90a571d38547b62ebc5e21a": "0x3b",
+      "0x7c183208cf2fc08503ed1edb44694295a07d0adc25bb6dad1b40f4540a427fa": "0x1baee"
+    },
+    "replaced_classes": [],
+    "migrated_compiled_classes": [
+      {
+        "class_hash": "0x4ac055f14361bb6f7bf4b9af6e96ca68825e6037e9bdf87ea0b2c641dea73ae",
+        "compiled_class_hash": "0x17f3b8f7225a160ec0542ea5c44ee876f2b132e7dee00ec36f2422d8155a4e4"
+      }
+    ]
+  }
+}

--- a/crates/gateway/gateway-client/tests/mainnet.rs
+++ b/crates/gateway/gateway-client/tests/mainnet.rs
@@ -32,6 +32,7 @@ async fn get_block(gateway: Client, #[case] block_number: BlockNumber, #[case] e
 #[case::v0_11_1(65000, test_data("0.11.1/state_update/mainnet_65000.json"))]
 #[case::v0_12_2(350000, test_data("0.12.2/state_update/mainnet_350000.json"))]
 #[case::v0_13_0(550000, test_data("0.13.0/state_update/mainnet_550000.json"))]
+#[case::v0_14_1(4130000, test_data("0.14.1/state_update/mainnet_4130000.json"))]
 #[tokio::test]
 async fn get_state_update(
     gateway: Client,

--- a/crates/gateway/gateway-types/src/conversion.rs
+++ b/crates/gateway/gateway-types/src/conversion.rs
@@ -66,6 +66,7 @@ impl From<katana_rpc_types::StateDiff> for StateDiff {
 
         let migrated_compiled_classes = value
             .migrated_compiled_classes
+            .unwrap_or_default()
             .into_iter()
             .map(|(class_hash, compiled_class_hash)| DeclaredContract {
                 class_hash,
@@ -671,7 +672,7 @@ mod from_rpc_test {
     use katana_primitives::contract::ContractAddress;
     use katana_primitives::{address, felt};
 
-    use crate::StateDiff;
+    use crate::{DeclaredContract, StateDiff};
 
     #[test]
     fn state_diff_conversion() {
@@ -692,7 +693,10 @@ mod from_rpc_test {
             declared_classes,
             nonces: BTreeMap::new(),
             replaced_classes: BTreeMap::new(),
-            migrated_compiled_classes: BTreeMap::new(),
+            migrated_compiled_classes: Some(BTreeMap::from_iter([
+                (felt!("0xa1"), felt!("0xb1")),
+                (felt!("0xa2"), felt!("0xb2")),
+            ])),
         };
 
         let converted: StateDiff = rpc_state_diff.into();
@@ -717,5 +721,15 @@ mod from_rpc_test {
         // Verify deprecated declared classes
         assert_eq!(converted.old_declared_contracts.len(), 1);
         assert!(converted.old_declared_contracts.contains(&felt!("0x4")));
+
+        // Verify migrated class hashes
+        assert_eq!(converted.migrated_compiled_classes.len(), 2);
+        assert_eq!(
+            converted.migrated_compiled_classes,
+            vec![
+                DeclaredContract { class_hash: felt!("0xa1"), compiled_class_hash: felt!("0xb1") },
+                DeclaredContract { class_hash: felt!("0xa2"), compiled_class_hash: felt!("0xb2") }
+            ]
+        );
     }
 }

--- a/crates/gateway/gateway-types/src/conversion.rs
+++ b/crates/gateway/gateway-types/src/conversion.rs
@@ -64,6 +64,15 @@ impl From<katana_rpc_types::StateDiff> for StateDiff {
             })
             .collect();
 
+        let migrated_compiled_classes = value
+            .migrated_compiled_classes
+            .into_iter()
+            .map(|(class_hash, compiled_class_hash)| DeclaredContract {
+                class_hash,
+                compiled_class_hash,
+            })
+            .collect();
+
         let replaced_classes = value
             .replaced_classes
             .into_iter()
@@ -77,6 +86,7 @@ impl From<katana_rpc_types::StateDiff> for StateDiff {
             declared_classes,
             nonces: value.nonces,
             replaced_classes,
+            migrated_compiled_classes,
         }
     }
 }
@@ -305,6 +315,12 @@ impl From<StateDiff> for katana_primitives::state::StateUpdates {
             .map(|contract| (contract.class_hash, contract.compiled_class_hash))
             .collect();
 
+        let migrated_compiled_classes = value
+            .migrated_compiled_classes
+            .into_iter()
+            .map(|contract| (contract.class_hash, contract.compiled_class_hash))
+            .collect();
+
         let replaced_classes = value
             .replaced_classes
             .into_iter()
@@ -318,6 +334,7 @@ impl From<StateDiff> for katana_primitives::state::StateUpdates {
             deployed_contracts,
             nonce_updates: value.nonces,
             deprecated_declared_classes: BTreeSet::from_iter(value.old_declared_contracts),
+            migrated_compiled_classes,
         }
     }
 }
@@ -624,6 +641,7 @@ mod from_primitives_test {
             }],
             nonces: BTreeMap::new(),
             replaced_classes: vec![],
+            migrated_compiled_classes: Vec::new(),
         };
 
         let converted: katana_primitives::state::StateUpdates = state_diff.into();
@@ -674,6 +692,7 @@ mod from_rpc_test {
             declared_classes,
             nonces: BTreeMap::new(),
             replaced_classes: BTreeMap::new(),
+            migrated_compiled_classes: BTreeMap::new(),
         };
 
         let converted: StateDiff = rpc_state_diff.into();

--- a/crates/gateway/gateway-types/src/lib.rs
+++ b/crates/gateway/gateway-types/src/lib.rs
@@ -19,12 +19,8 @@
 //! - [`DeployAccountTxV3`]: Uses the custom DA mode and resource bounds
 //! - [`L1HandlerTx`]: Optional `nonce` field
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use katana_primitives::block::{BlockHash, BlockNumber};
 pub use katana_primitives::class::CasmContractClass;
-use katana_primitives::class::{ClassHash, CompiledClassHash};
-use katana_primitives::contract::{Nonce, StorageKey, StorageValue};
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::{ContractAddress, Felt};
 pub use katana_rpc_types::class::RpcSierraContractClass;
@@ -34,10 +30,12 @@ use starknet::core::types::ResourcePrice;
 mod conversion;
 mod error;
 mod receipt;
+mod state_update;
 mod transaction;
 
 pub use error::*;
 pub use receipt::*;
+pub use state_update::*;
 pub use transaction::*;
 
 /// The contract class type returns by `/get_class_by_hash` endpoint.
@@ -142,255 +140,6 @@ pub struct Block {
     pub transactions: Vec<ConfirmedTransaction>,
 }
 
-/// The state update type returns by `/get_state_update` endpoint, with `includeBlock=true`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StateUpdateWithBlock {
-    pub state_update: StateUpdate,
-    pub block: Block,
-}
-
-// The main reason why aren't using the state update RPC types is because the state diff
-// serialization is different.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
-pub enum StateUpdate {
-    Confirmed(ConfirmedStateUpdate),
-    PreConfirmed(PreConfirmedStateUpdate),
-}
-
-/// State update of a pre-confirmed block.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreConfirmedStateUpdate {
-    /// The previous global state root
-    pub old_root: Felt,
-    /// State diff
-    pub state_diff: StateDiff,
-}
-
-/// State update of a confirmed block.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ConfirmedStateUpdate {
-    /// Block hash
-    pub block_hash: BlockHash,
-    /// The new global state root
-    pub new_root: Felt,
-    /// The previous global state root
-    pub old_root: Felt,
-    /// State diff
-    pub state_diff: StateDiff,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StorageDiff {
-    pub key: StorageKey,
-    pub value: StorageValue,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DeployedContract {
-    pub address: ContractAddress,
-    pub class_hash: ClassHash,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DeclaredContract {
-    pub class_hash: ClassHash,
-    pub compiled_class_hash: CompiledClassHash,
-}
-
 fn default_l2_gas_price() -> ResourcePrice {
     ResourcePrice { price_in_fri: Felt::from(1), price_in_wei: Felt::from(1) }
-}
-
-// todo(kariy): merge the serialization of gateway into the rpc types
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StateDiff {
-    pub storage_diffs: BTreeMap<ContractAddress, Vec<StorageDiff>>,
-    pub deployed_contracts: Vec<DeployedContract>,
-    pub old_declared_contracts: Vec<Felt>,
-    pub declared_classes: Vec<DeclaredContract>,
-    pub nonces: BTreeMap<ContractAddress, Nonce>,
-    pub replaced_classes: Vec<DeployedContract>,
-    pub migrated_compiled_classes: Vec<DeclaredContract>,
-}
-
-impl StateDiff {
-    /// Returns a new [`StateDiff`] that contains all updates from `self` and `other`,
-    /// preferring the values from `other` when both diffs touch the same entry.
-    pub fn merge(mut self, other: StateDiff) -> StateDiff {
-        let StateDiff {
-            storage_diffs,
-            deployed_contracts,
-            old_declared_contracts,
-            declared_classes,
-            nonces,
-            replaced_classes,
-            migrated_compiled_classes,
-        } = other;
-
-        Self::merge_storage_diffs(&mut self.storage_diffs, storage_diffs);
-        Self::merge_deployed_contracts(&mut self.deployed_contracts, deployed_contracts);
-        Self::merge_deployed_contracts(&mut self.replaced_classes, replaced_classes);
-        Self::merge_declared_classes(&mut self.declared_classes, declared_classes);
-        Self::merge_declared_classes(
-            &mut self.migrated_compiled_classes,
-            migrated_compiled_classes,
-        );
-        Self::merge_old_declared_contracts(
-            &mut self.old_declared_contracts,
-            old_declared_contracts,
-        );
-        self.nonces.extend(nonces);
-
-        self
-    }
-
-    fn merge_storage_diffs(
-        target: &mut BTreeMap<ContractAddress, Vec<StorageDiff>>,
-        updates: BTreeMap<ContractAddress, Vec<StorageDiff>>,
-    ) {
-        for (address, diffs) in updates {
-            let entry = target.entry(address).or_default();
-            let mut index_by_key: BTreeMap<StorageKey, usize> =
-                entry.iter().enumerate().map(|(idx, diff)| (diff.key, idx)).collect();
-
-            for diff in diffs {
-                if let Some(idx) = index_by_key.get(&diff.key).copied() {
-                    entry[idx] = diff;
-                } else {
-                    index_by_key.insert(diff.key, entry.len());
-                    entry.push(diff);
-                }
-            }
-        }
-    }
-
-    fn merge_deployed_contracts(
-        target: &mut Vec<DeployedContract>,
-        incoming: Vec<DeployedContract>,
-    ) {
-        let mut index_by_address: BTreeMap<ContractAddress, usize> =
-            target.iter().enumerate().map(|(idx, contract)| (contract.address, idx)).collect();
-
-        for contract in incoming {
-            if let Some(idx) = index_by_address.get(&contract.address).copied() {
-                target[idx] = contract;
-            } else {
-                index_by_address.insert(contract.address, target.len());
-                target.push(contract);
-            }
-        }
-    }
-
-    fn merge_declared_classes(target: &mut Vec<DeclaredContract>, incoming: Vec<DeclaredContract>) {
-        let mut index_by_hash: BTreeMap<ClassHash, usize> =
-            target.iter().enumerate().map(|(idx, contract)| (contract.class_hash, idx)).collect();
-
-        for declared in incoming {
-            if let Some(idx) = index_by_hash.get(&declared.class_hash).copied() {
-                target[idx] = declared;
-            } else {
-                index_by_hash.insert(declared.class_hash, target.len());
-                target.push(declared);
-            }
-        }
-    }
-
-    fn merge_old_declared_contracts(target: &mut Vec<Felt>, incoming: Vec<Felt>) {
-        let mut seen: BTreeSet<Felt> = target.iter().copied().collect();
-
-        for class_hash in incoming {
-            if seen.insert(class_hash) {
-                target.push(class_hash);
-            }
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for StateUpdate {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct __Visitor;
-
-        impl<'de> serde::de::Visitor<'de> for __Visitor {
-            type Value = StateUpdate;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("a state update response")
-            }
-
-            fn visit_map<A: serde::de::MapAccess<'de>>(
-                self,
-                mut map: A,
-            ) -> Result<Self::Value, A::Error> {
-                let mut block_hash: Option<BlockHash> = None;
-                let mut new_root: Option<Felt> = None;
-                let mut old_root: Option<Felt> = None;
-                let mut state_diff: Option<StateDiff> = None;
-
-                while let Some(key) = map.next_key::<String>()? {
-                    match key.as_str() {
-                        "block_hash" => {
-                            if block_hash.is_some() {
-                                return Err(serde::de::Error::duplicate_field("block_hash"));
-                            }
-                            block_hash = Some(map.next_value()?);
-                        }
-
-                        "new_root" => {
-                            if new_root.is_some() {
-                                return Err(serde::de::Error::duplicate_field("new_root"));
-                            }
-                            new_root = Some(map.next_value()?);
-                        }
-
-                        "old_root" => {
-                            if old_root.is_some() {
-                                return Err(serde::de::Error::duplicate_field("old_root"));
-                            }
-                            old_root = Some(map.next_value()?);
-                        }
-
-                        "state_diff" => {
-                            if state_diff.is_some() {
-                                return Err(serde::de::Error::duplicate_field("state_diff"));
-                            }
-                            state_diff = Some(map.next_value()?);
-                        }
-
-                        _ => {
-                            let _ = map.next_value::<serde::de::IgnoredAny>()?;
-                        }
-                    }
-                }
-
-                let old_root =
-                    old_root.ok_or_else(|| serde::de::Error::missing_field("old_root"))?;
-                let state_diff =
-                    state_diff.ok_or_else(|| serde::de::Error::missing_field("state_diff"))?;
-
-                // If block_hash and new_root are not present, deserialize as
-                // PreConfirmedStateUpdate
-                match (block_hash, new_root) {
-                    (None, None) => Ok(StateUpdate::PreConfirmed(PreConfirmedStateUpdate {
-                        old_root,
-                        state_diff,
-                    })),
-
-                    (Some(block_hash), Some(new_root)) => {
-                        Ok(StateUpdate::Confirmed(ConfirmedStateUpdate {
-                            block_hash,
-                            new_root,
-                            old_root,
-                            state_diff,
-                        }))
-                    }
-
-                    (None, Some(_)) => Err(serde::de::Error::missing_field("block_hash")),
-                    (Some(_), None) => Err(serde::de::Error::missing_field("new_root")),
-                }
-            }
-        }
-
-        deserializer.deserialize_map(__Visitor)
-    }
 }

--- a/crates/gateway/gateway-types/src/lib.rs
+++ b/crates/gateway/gateway-types/src/lib.rs
@@ -211,6 +211,7 @@ pub struct StateDiff {
     pub declared_classes: Vec<DeclaredContract>,
     pub nonces: BTreeMap<ContractAddress, Nonce>,
     pub replaced_classes: Vec<DeployedContract>,
+    pub migrated_compiled_classes: Vec<DeclaredContract>,
 }
 
 impl StateDiff {
@@ -224,12 +225,17 @@ impl StateDiff {
             declared_classes,
             nonces,
             replaced_classes,
+            migrated_compiled_classes,
         } = other;
 
         Self::merge_storage_diffs(&mut self.storage_diffs, storage_diffs);
         Self::merge_deployed_contracts(&mut self.deployed_contracts, deployed_contracts);
         Self::merge_deployed_contracts(&mut self.replaced_classes, replaced_classes);
         Self::merge_declared_classes(&mut self.declared_classes, declared_classes);
+        Self::merge_declared_classes(
+            &mut self.migrated_compiled_classes,
+            migrated_compiled_classes,
+        );
         Self::merge_old_declared_contracts(
             &mut self.old_declared_contracts,
             old_declared_contracts,

--- a/crates/gateway/gateway-types/src/state_update.rs
+++ b/crates/gateway/gateway-types/src/state_update.rs
@@ -1,0 +1,305 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use katana_primitives::block::BlockHash;
+use katana_primitives::class::{ClassHash, CompiledClassHash};
+use katana_primitives::contract::{Nonce, StorageKey, StorageValue};
+use katana_primitives::{ContractAddress, Felt};
+use serde::{Deserialize, Serialize};
+
+use crate::Block;
+
+/// The state update type returns by `/get_state_update` endpoint, with `includeBlock=true`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateUpdateWithBlock {
+    pub state_update: StateUpdate,
+    pub block: Block,
+}
+
+// The main reason why aren't using the state update RPC types is because the state diff
+// serialization is different.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum StateUpdate {
+    Confirmed(ConfirmedStateUpdate),
+    PreConfirmed(PreConfirmedStateUpdate),
+}
+
+/// State update of a pre-confirmed block.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreConfirmedStateUpdate {
+    /// The previous global state root
+    pub old_root: Felt,
+    /// State diff
+    pub state_diff: StateDiff,
+}
+
+/// State update of a confirmed block.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfirmedStateUpdate {
+    /// Block hash
+    pub block_hash: BlockHash,
+    /// The new global state root
+    pub new_root: Felt,
+    /// The previous global state root
+    pub old_root: Felt,
+    /// State diff
+    pub state_diff: StateDiff,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageDiff {
+    pub key: StorageKey,
+    pub value: StorageValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeployedContract {
+    pub address: ContractAddress,
+    pub class_hash: ClassHash,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeclaredContract {
+    pub class_hash: ClassHash,
+    pub compiled_class_hash: CompiledClassHash,
+}
+
+/// State diff returned by the feeder gateway API.
+///
+/// This type has a different serialization format compared to the JSON-RPC
+/// [`StateDiff`](katana_rpc_types::state_update::StateDiff).
+///
+/// ## Serialization Differences from the RPC Format
+///
+/// - **`nonces`**
+///
+///  Serialized as a map object `{ "0x123": "0x1" }`, whereas RPC uses an array `[ {
+///  "contract_address": "0x123", "nonce": "0x1" } ]`.
+///
+/// - **`storage_diffs`**
+///
+/// Serialized as a map with contract address as key `{ "0x123": [ { "key": "0x1", "value": "0x2" }
+/// ] }`, whereas RPC uses an array `[ { "address": "0x123", "storage_entries": [...] } ]`.
+///
+/// - **`replaced_classes`**
+///
+/// Uses `"address"` field name, whereas RPC uses `"contract_address"`.
+///
+/// - **`old_declared_contracts`**
+///
+/// This field name differs from RPC which uses `"deprecated_declared_classes"`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateDiff {
+    pub storage_diffs: BTreeMap<ContractAddress, Vec<StorageDiff>>,
+    pub deployed_contracts: Vec<DeployedContract>,
+    pub old_declared_contracts: Vec<Felt>,
+    pub declared_classes: Vec<DeclaredContract>,
+    pub nonces: BTreeMap<ContractAddress, Nonce>,
+    pub replaced_classes: Vec<DeployedContract>,
+    /// Classes whose compiled class hash (CASM hash) has been recomputed using the Blake2s hash
+    /// function.
+    ///
+    /// Introduced in [SNIP34] (Starknet 0.14.1) as part of the S-Two proving system optimization.
+    /// Blake2s hashes are ~3x cheaper to prove compared to Poseidon, significantly reducing the
+    /// cost of proving correct Cairo instruction execution within each block.
+    ///
+    /// [SNIP34]: https://community.starknet.io/t/snip-34-more-efficient-casm-hashes/115979
+    ///
+    /// ## Migration Mechanism
+    ///
+    /// Existing classes are migrated gradually - a class hash is migrated the first time SNOS
+    /// executes an instruction within a contract using that class. Specifically:
+    ///
+    /// - **Successful transactions**: All classes used throughout the transaction are migrated.
+    /// - **Reverted transactions**: Classes proven before the reversion point are migrated,
+    ///   including:
+    ///   - The account contract's class (since `validate` must run successfully)
+    ///   - Classes where a non-existent entry point invocation was proven
+    ///
+    /// The compiled class hash updates are applied at the end of each block. Since the execution
+    /// environment only references class hashes (never compiled class hashes directly), these
+    /// migrations do not affect execution - only the resulting state root.
+    #[serde(default)]
+    pub migrated_compiled_classes: Vec<DeclaredContract>,
+}
+
+impl StateDiff {
+    /// Returns a new [`StateDiff`] that contains all updates from `self` and `other`,
+    /// preferring the values from `other` when both diffs touch the same entry.
+    pub fn merge(mut self, other: StateDiff) -> StateDiff {
+        let StateDiff {
+            storage_diffs,
+            deployed_contracts,
+            old_declared_contracts,
+            declared_classes,
+            nonces,
+            replaced_classes,
+            migrated_compiled_classes,
+        } = other;
+
+        Self::merge_storage_diffs(&mut self.storage_diffs, storage_diffs);
+        Self::merge_deployed_contracts(&mut self.deployed_contracts, deployed_contracts);
+        Self::merge_deployed_contracts(&mut self.replaced_classes, replaced_classes);
+        Self::merge_declared_classes(&mut self.declared_classes, declared_classes);
+        Self::merge_declared_classes(
+            &mut self.migrated_compiled_classes,
+            migrated_compiled_classes,
+        );
+        Self::merge_old_declared_contracts(
+            &mut self.old_declared_contracts,
+            old_declared_contracts,
+        );
+        self.nonces.extend(nonces);
+
+        self
+    }
+
+    fn merge_storage_diffs(
+        target: &mut BTreeMap<ContractAddress, Vec<StorageDiff>>,
+        updates: BTreeMap<ContractAddress, Vec<StorageDiff>>,
+    ) {
+        for (address, diffs) in updates {
+            let entry = target.entry(address).or_default();
+            let mut index_by_key: BTreeMap<StorageKey, usize> =
+                entry.iter().enumerate().map(|(idx, diff)| (diff.key, idx)).collect();
+
+            for diff in diffs {
+                if let Some(idx) = index_by_key.get(&diff.key).copied() {
+                    entry[idx] = diff;
+                } else {
+                    index_by_key.insert(diff.key, entry.len());
+                    entry.push(diff);
+                }
+            }
+        }
+    }
+
+    fn merge_deployed_contracts(
+        target: &mut Vec<DeployedContract>,
+        incoming: Vec<DeployedContract>,
+    ) {
+        let mut index_by_address: BTreeMap<ContractAddress, usize> =
+            target.iter().enumerate().map(|(idx, contract)| (contract.address, idx)).collect();
+
+        for contract in incoming {
+            if let Some(idx) = index_by_address.get(&contract.address).copied() {
+                target[idx] = contract;
+            } else {
+                index_by_address.insert(contract.address, target.len());
+                target.push(contract);
+            }
+        }
+    }
+
+    fn merge_declared_classes(target: &mut Vec<DeclaredContract>, incoming: Vec<DeclaredContract>) {
+        let mut index_by_hash: BTreeMap<ClassHash, usize> =
+            target.iter().enumerate().map(|(idx, contract)| (contract.class_hash, idx)).collect();
+
+        for declared in incoming {
+            if let Some(idx) = index_by_hash.get(&declared.class_hash).copied() {
+                target[idx] = declared;
+            } else {
+                index_by_hash.insert(declared.class_hash, target.len());
+                target.push(declared);
+            }
+        }
+    }
+
+    fn merge_old_declared_contracts(target: &mut Vec<Felt>, incoming: Vec<Felt>) {
+        let mut seen: BTreeSet<Felt> = target.iter().copied().collect();
+
+        for class_hash in incoming {
+            if seen.insert(class_hash) {
+                target.push(class_hash);
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StateUpdate {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct __Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for __Visitor {
+            type Value = StateUpdate;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a state update response")
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut block_hash: Option<BlockHash> = None;
+                let mut new_root: Option<Felt> = None;
+                let mut old_root: Option<Felt> = None;
+                let mut state_diff: Option<StateDiff> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "block_hash" => {
+                            if block_hash.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block_hash"));
+                            }
+                            block_hash = Some(map.next_value()?);
+                        }
+
+                        "new_root" => {
+                            if new_root.is_some() {
+                                return Err(serde::de::Error::duplicate_field("new_root"));
+                            }
+                            new_root = Some(map.next_value()?);
+                        }
+
+                        "old_root" => {
+                            if old_root.is_some() {
+                                return Err(serde::de::Error::duplicate_field("old_root"));
+                            }
+                            old_root = Some(map.next_value()?);
+                        }
+
+                        "state_diff" => {
+                            if state_diff.is_some() {
+                                return Err(serde::de::Error::duplicate_field("state_diff"));
+                            }
+                            state_diff = Some(map.next_value()?);
+                        }
+
+                        _ => {
+                            let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                let old_root =
+                    old_root.ok_or_else(|| serde::de::Error::missing_field("old_root"))?;
+                let state_diff =
+                    state_diff.ok_or_else(|| serde::de::Error::missing_field("state_diff"))?;
+
+                // If block_hash and new_root are not present, deserialize as
+                // PreConfirmedStateUpdate
+                match (block_hash, new_root) {
+                    (None, None) => Ok(StateUpdate::PreConfirmed(PreConfirmedStateUpdate {
+                        old_root,
+                        state_diff,
+                    })),
+
+                    (Some(block_hash), Some(new_root)) => {
+                        Ok(StateUpdate::Confirmed(ConfirmedStateUpdate {
+                            block_hash,
+                            new_root,
+                            old_root,
+                            state_diff,
+                        }))
+                    }
+
+                    (None, Some(_)) => Err(serde::de::Error::missing_field("block_hash")),
+                    (Some(_), None) => Err(serde::de::Error::missing_field("new_root")),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(__Visitor)
+    }
+}

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -28,6 +28,8 @@ pub struct StateUpdates {
     /// A mapping of replaced contract addresses to their new class hashes ie using `replace_class`
     /// syscall.
     pub replaced_classes: BTreeMap<ContractAddress, ClassHash>,
+    /// A list of classes whose compiled class hashes have been migrated.
+    pub migrated_compiled_classes: BTreeMap<ClassHash, CompiledClassHash>,
 }
 
 impl StateUpdates {
@@ -40,6 +42,7 @@ impl StateUpdates {
         len += self.declared_classes.len();
         len += self.deprecated_declared_classes.len();
         len += self.nonce_updates.len();
+        len += self.migrated_compiled_classes.len();
 
         for updates in self.storage_updates.values() {
             len += updates.len();

--- a/crates/rpc/rpc-types/src/state_update.rs
+++ b/crates/rpc/rpc-types/src/state_update.rs
@@ -259,7 +259,7 @@ impl Serialize for StateDiff {
         /// [
         ///   {
         ///     "class_hash": "0x123",
-        ///     "compiled_hash": "0x456"
+        ///     "compiled_class_hash": "0x456"
         ///   },
         ///   ...
         /// ]
@@ -271,14 +271,14 @@ impl Serialize for StateDiff {
                 #[derive(Debug, Serialize)]
                 struct MigratedCompiledClass {
                     class_hash: ClassHash,
-                    compiled_hash: CompiledClassHash,
+                    compiled_class_hash: CompiledClassHash,
                 }
 
                 let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-                for (class_hash, compiled_hash) in self.0 {
+                for (class_hash, compiled_class_hash) in self.0 {
                     seq.serialize_element(&MigratedCompiledClass {
                         class_hash: *class_hash,
-                        compiled_hash: *compiled_hash,
+                        compiled_class_hash: *compiled_class_hash,
                     })?;
                 }
                 seq.end()
@@ -383,6 +383,17 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes nonces from an array of objects with the following structure:
+        ///
+        /// ```json
+        /// [
+        ///   {
+        ///     "contract_address": "0x123",
+        ///     "nonce": "0x123"
+        ///   },
+        ///   ...
+        /// ]
+        /// ```
         struct NoncesDe;
 
         impl<'de> DeserializeSeed<'de> for NoncesDe {
@@ -426,6 +437,23 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes storage diffs from an array of objects with the following structure:
+        ///
+        /// ```json
+        /// [
+        ///   {
+        ///     "address": "0x123",
+        ///     "storage_entries": [
+        ///       {
+        ///         "key": "0x123",
+        ///         "value": "0x456"
+        ///       },
+        ///       ...
+        ///     ]
+        ///   },
+        ///   ...
+        /// ]
+        /// ```
         struct StorageDiffsDe;
 
         impl<'de> DeserializeSeed<'de> for StorageDiffsDe {
@@ -479,6 +507,17 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes deployed contracts from an array of objects with the following structure:
+        ///
+        /// ```json
+        /// [
+        ///   {
+        ///     "address": "0x123",
+        ///     "class_hash": "0x456"
+        ///   },
+        ///   ...
+        /// ]
+        /// ```
         struct DeployedContractsDe;
 
         impl<'de> DeserializeSeed<'de> for DeployedContractsDe {
@@ -522,6 +561,17 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes declared classes from an array of objects with the following structure:
+        ///
+        /// ```json
+        /// [
+        ///   {
+        ///     "class_hash": "0x123",
+        ///     "compiled_class_hash": "0x456"
+        ///   },
+        ///   ...
+        /// ]
+        /// ```
         struct DeclaredClassesDe;
 
         impl<'de> DeserializeSeed<'de> for DeclaredClassesDe {
@@ -565,6 +615,11 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes deprecated declared classes from an array of class hashes:
+        ///
+        /// ```json
+        /// ["0x123", "0x456", ...]
+        /// ```
         struct DepDeclaredClassesDe;
 
         impl<'de> DeserializeSeed<'de> for DepDeclaredClassesDe {
@@ -602,6 +657,17 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes `replaced_classes` from an array of objects with the following structure:
+        ///
+        /// ```json
+        /// [
+        ///   {
+        ///     "contract_address": "0x123",
+        ///     "class_hash": "0x123"
+        ///   },
+        ///   ...
+        /// ]
+        /// ```
         struct ReplacedClassesDe;
 
         impl<'de> DeserializeSeed<'de> for ReplacedClassesDe {
@@ -645,6 +711,18 @@ impl<'de> Deserialize<'de> for StateDiff {
             }
         }
 
+        /// Deserializes `migrated_compiled_classes` from an array of objects with the following
+        /// structure:
+        ///
+        /// ```json
+        /// [
+        ///   {
+        ///     "class_hash": "0x123",
+        ///     "compiled_class_hash": "0x456"
+        ///   },
+        ///   ...
+        /// ]
+        /// ```
         struct MigratedCompiledClassesDe;
 
         impl<'de> DeserializeSeed<'de> for MigratedCompiledClassesDe {
@@ -673,13 +751,13 @@ impl<'de> Deserialize<'de> for StateDiff {
                         #[derive(Debug, Deserialize)]
                         struct MigratedCompiledClass {
                             class_hash: ClassHash,
-                            compiled_hash: CompiledClassHash,
+                            compiled_class_hash: CompiledClassHash,
                         }
 
                         let mut migrated_compiled_classes = BTreeMap::new();
                         while let Some(migrated) = seq.next_element::<MigratedCompiledClass>()? {
                             migrated_compiled_classes
-                                .insert(migrated.class_hash, migrated.compiled_hash);
+                                .insert(migrated.class_hash, migrated.compiled_class_hash);
                         }
                         Ok(migrated_compiled_classes)
                     }

--- a/crates/rpc/rpc-types/src/state_update.rs
+++ b/crates/rpc/rpc-types/src/state_update.rs
@@ -48,7 +48,7 @@ pub struct StateDiff {
     pub declared_classes: BTreeMap<ClassHash, CompiledClassHash>,
     pub deprecated_declared_classes: BTreeSet<ClassHash>,
     pub replaced_classes: BTreeMap<ContractAddress, ClassHash>,
-    pub migrated_compiled_classes: BTreeMap<ClassHash, CompiledClassHash>,
+    pub migrated_compiled_classes: Option<BTreeMap<ClassHash, CompiledClassHash>>,
 }
 
 impl Serialize for StateDiff {
@@ -291,16 +291,23 @@ impl Serialize for StateDiff {
         let declared_classes = DeclaredClassesSer(&self.declared_classes);
         let deployed_contracts = DeployedContractsSer(&self.deployed_contracts);
         let deprecated_declared_classes = DepDeclaredClassesSer(&self.deprecated_declared_classes);
-        let migrated_compiled_classes = MigratedCompiledClassesSer(&self.migrated_compiled_classes);
 
-        let mut map = serializer.serialize_map(Some(7))?;
+        let len = 6 + self.migrated_compiled_classes.is_some() as usize;
+        let mut map = serializer.serialize_map(Some(len))?;
+
         map.serialize_entry("nonces", &nonces)?;
         map.serialize_entry("storage_diffs", &storage_diffs)?;
         map.serialize_entry("declared_classes", &declared_classes)?;
         map.serialize_entry("replaced_classes", &replaced_classes)?;
         map.serialize_entry("deployed_contracts", &deployed_contracts)?;
         map.serialize_entry("deprecated_declared_classes", &deprecated_declared_classes)?;
-        map.serialize_entry("migrated_compiled_classes", &migrated_compiled_classes)?;
+        if let Some(ref migrated) = self.migrated_compiled_classes {
+            map.serialize_entry(
+                "migrated_compiled_classes",
+                &MigratedCompiledClassesSer(migrated),
+            )?;
+        }
+
         map.end()
     }
 }
@@ -371,9 +378,7 @@ impl<'de> Deserialize<'de> for StateDiff {
                     })?,
                     replaced_classes: replaced_classes
                         .ok_or_else(|| serde::de::Error::missing_field("replaced_classes"))?,
-                    migrated_compiled_classes: migrated_compiled_classes.ok_or_else(|| {
-                        serde::de::Error::missing_field("migrated_compiled_classes")
-                    })?,
+                    migrated_compiled_classes,
                 })
             }
         }
@@ -690,6 +695,12 @@ impl<'de> Deserialize<'de> for StateDiff {
 
 impl From<katana_primitives::state::StateUpdates> for StateDiff {
     fn from(value: katana_primitives::state::StateUpdates) -> Self {
+        let migrated_compiled_classes = if value.migrated_compiled_classes.is_empty() {
+            None
+        } else {
+            Some(value.migrated_compiled_classes)
+        };
+
         Self {
             nonces: value.nonce_updates,
             storage_diffs: value.storage_updates,
@@ -697,7 +708,7 @@ impl From<katana_primitives::state::StateUpdates> for StateDiff {
             declared_classes: value.declared_classes,
             deployed_contracts: value.deployed_contracts,
             deprecated_declared_classes: value.deprecated_declared_classes,
-            migrated_compiled_classes: value.migrated_compiled_classes,
+            migrated_compiled_classes,
         }
     }
 }
@@ -711,7 +722,7 @@ impl From<StateDiff> for katana_primitives::state::StateUpdates {
             declared_classes: value.declared_classes,
             deployed_contracts: value.deployed_contracts,
             deprecated_declared_classes: value.deprecated_declared_classes,
-            migrated_compiled_classes: value.migrated_compiled_classes,
+            migrated_compiled_classes: value.migrated_compiled_classes.unwrap_or_default(),
         }
     }
 }

--- a/crates/rpc/rpc-types/tests/fixtures/v0.10/state-updates/confirmed_state_update.json
+++ b/crates/rpc/rpc-types/tests/fixtures/v0.10/state-updates/confirmed_state_update.json
@@ -1,0 +1,47 @@
+{
+  "block_hash": "0x1935ec0e5c7758fdc11a78ed9d4cadd4225eab826aabd98fe2d04b45ca4c150",
+  "new_root": "0x7e72ca880e4fa1f4987257d90b2642860a4574a03b79ac830f6fb5968520977",
+  "old_root": "0x484d8010568613b1878e03085989536d9112d89e2979297f0fbd741a3f73138",
+  "state_diff": {
+    "declared_classes": [],
+    "deployed_contracts": [],
+    "deprecated_declared_classes": [],
+    "migrated_compiled_classes": [
+      {
+        "class_hash": "0x4ac055f14361bb6f7bf4b9af6e96ca68825e6037e9bdf87ea0b2c641dea73ae",
+        "compiled_class_hash": "0x17f3b8f7225a160ec0542ea5c44ee876f2b132e7dee00ec36f2422d8155a4e4"
+      }
+    ],
+    "nonces": [
+      {
+        "contract_address": "0x662776dac110a170767d83da4f1d8fae022df7aa8a78252eb9c501c68d49604",
+        "nonce": "0x1bb63"
+      }
+    ],
+    "replaced_classes": [],
+    "storage_diffs": [
+      {
+        "address": "0x18469ed2d40a016a602371173c7287e25f85cb6abb6fc0866d3c444e2837603",
+        "storage_entries": [
+          {
+            "key": "0x6d410d47be5497b0dafef14e24c8767731a6e50126ff8fa99f25a0d0ee02788",
+            "value": "0x1"
+          }
+        ]
+      },
+      {
+        "address": "0x377c2d65debb3978ea81904e7d59740da1f07412e30d01c5ded1c5d6f1ddc43",
+        "storage_entries": [
+          {
+            "key": "0x3ee4ba0f59886159d92a35f96ded219dd7f69c30953f9b68d333f10a27e312b",
+            "value": "0x18469ed2d40a016a602371173c7287e25f85cb6abb6fc0866d3c444e2837603"
+          },
+          {
+            "key": "0x484b46148d37383593029fa3b4c09a5e0e3cb66bbcf5fc66529fa452ccc6e34",
+            "value": "0x8"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/crates/rpc/rpc-types/tests/state_update.rs
+++ b/crates/rpc/rpc-types/tests/state_update.rs
@@ -63,6 +63,7 @@ fn preconfirmed_state_update() {
             }
         }
     );
+    assert!(state_diff.migrated_compiled_classes.is_none());
 
     let serialized = serde_json::to_value(&state_update).unwrap();
     similar_asserts::assert_eq!(serialized, json);
@@ -130,6 +131,62 @@ fn confirmed_state_update() {
                 felt!("0x1c8ba1"), felt!("0x6d33bd9dc2f9c1f96a91314a3198d190a33431b425db0db8b71db14eee333e7"),
             }
         }
+    );
+
+    let serialized = serde_json::to_value(&state_update).unwrap();
+    similar_asserts::assert_eq!(serialized, json);
+}
+
+#[test]
+fn v0_10_0_confirmed_state_update() {
+    let json = fixtures::test_data::<Value>("v0.10/state-updates/confirmed_state_update.json");
+
+    let state_update: ConfirmedStateUpdate = serde_json::from_value(json.clone()).unwrap();
+    let as_enum: StateUpdate = serde_json::from_value(json.clone()).unwrap();
+    assert_matches!(as_enum, StateUpdate::Update(as_enum_update) => {
+        similar_asserts::assert_eq!(as_enum_update, state_update);
+    });
+
+    let ConfirmedStateUpdate { block_hash, new_root, old_root, ref state_diff } = state_update;
+    assert_eq!(
+        block_hash,
+        felt!("0x1935ec0e5c7758fdc11a78ed9d4cadd4225eab826aabd98fe2d04b45ca4c150")
+    );
+    assert_eq!(
+        old_root,
+        felt!("0x484d8010568613b1878e03085989536d9112d89e2979297f0fbd741a3f73138")
+    );
+    assert_eq!(
+        new_root,
+        felt!("0x7e72ca880e4fa1f4987257d90b2642860a4574a03b79ac830f6fb5968520977")
+    );
+    assert!(state_diff.deprecated_declared_classes.is_empty());
+    assert!(state_diff.replaced_classes.is_empty());
+    assert!(state_diff.declared_classes.is_empty());
+    assert!(state_diff.deployed_contracts.is_empty());
+    assert_eq!(
+        state_diff.nonces,
+        map! {
+            address!("0x662776dac110a170767d83da4f1d8fae022df7aa8a78252eb9c501c68d49604"), felt!("0x1bb63"),
+        }
+    );
+    assert_eq!(
+        state_diff.storage_diffs,
+        map! {
+            address!("0x18469ed2d40a016a602371173c7287e25f85cb6abb6fc0866d3c444e2837603"), map! {
+                felt!("0x6d410d47be5497b0dafef14e24c8767731a6e50126ff8fa99f25a0d0ee02788"), felt!("0x1"),
+            },
+            address!("0x377c2d65debb3978ea81904e7d59740da1f07412e30d01c5ded1c5d6f1ddc43"), map! {
+                felt!("0x484b46148d37383593029fa3b4c09a5e0e3cb66bbcf5fc66529fa452ccc6e34"), felt!("0x8"),
+                felt!("0x3ee4ba0f59886159d92a35f96ded219dd7f69c30953f9b68d333f10a27e312b"), felt!("0x18469ed2d40a016a602371173c7287e25f85cb6abb6fc0866d3c444e2837603"),
+            }
+        }
+    );
+    assert_eq!(
+        state_diff.migrated_compiled_classes,
+        Some(map! {
+            felt!("0x4ac055f14361bb6f7bf4b9af6e96ca68825e6037e9bdf87ea0b2c641dea73ae"), felt!("0x17f3b8f7225a160ec0542ea5c44ee876f2b132e7dee00ec36f2422d8155a4e4"),
+        })
     );
 
     let serialized = serde_json::to_value(&state_update).unwrap();

--- a/crates/rpc/rpc-types/tests/trace.rs
+++ b/crates/rpc/rpc-types/tests/trace.rs
@@ -531,7 +531,7 @@ fn tx_trace_with_state_diff() {
         replaced_classes,
         declared_classes,
         deprecated_declared_classes: BTreeSet::new(),
-        migrated_compiled_classes: BTreeMap::new(),
+        migrated_compiled_classes: None,
     };
 
     let trace = InvokeTxTrace {

--- a/crates/rpc/rpc-types/tests/trace.rs
+++ b/crates/rpc/rpc-types/tests/trace.rs
@@ -531,6 +531,7 @@ fn tx_trace_with_state_diff() {
         replaced_classes,
         declared_classes,
         deprecated_declared_classes: BTreeSet::new(),
+        migrated_compiled_classes: BTreeMap::new(),
     };
 
     let trace = InvokeTxTrace {

--- a/crates/storage/db/src/models/class.rs
+++ b/crates/storage/db/src/models/class.rs
@@ -1,7 +1,36 @@
-use katana_primitives::class::CompiledClass;
+use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
+use serde::{Deserialize, Serialize};
 
 use crate::codecs::{Compress, Decompress};
 use crate::error::CodecError;
+
+/// The value for the [MigratedCompiledClassHashes](crate::tables::MigratedCompiledClassHashes)
+/// table.
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct MigratedCompiledClassHash {
+    pub class_hash: ClassHash,
+    pub compiled_class_hash: CompiledClassHash,
+}
+
+impl Compress for MigratedCompiledClassHash {
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&self.class_hash.compress()?);
+        buf.extend_from_slice(&self.compiled_class_hash.compress()?);
+        Ok(buf)
+    }
+}
+
+impl Decompress for MigratedCompiledClassHash {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+        let class_hash = ClassHash::decompress(&bytes[0..32])?;
+        let compiled_class_hash = ClassHash::decompress(&bytes[32..])?;
+        Ok(Self { class_hash, compiled_class_hash })
+    }
+}
 
 impl Compress for CompiledClass {
     type Compressed = Vec<u8>;

--- a/crates/storage/db/src/models/class.rs
+++ b/crates/storage/db/src/models/class.rs
@@ -1,7 +1,7 @@
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
 use serde::{Deserialize, Serialize};
 
-use crate::codecs::{Compress, Decompress};
+use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::error::CodecError;
 
 /// The value for the [MigratedCompiledClassHashes](crate::tables::MigratedCompiledClassHashes)
@@ -17,7 +17,7 @@ impl Compress for MigratedCompiledClassHash {
 
     fn compress(self) -> Result<Self::Compressed, CodecError> {
         let mut buf = Vec::new();
-        buf.extend_from_slice(&self.class_hash.compress()?);
+        buf.extend_from_slice(&self.class_hash.encode());
         buf.extend_from_slice(&self.compiled_class_hash.compress()?);
         Ok(buf)
     }
@@ -26,7 +26,7 @@ impl Compress for MigratedCompiledClassHash {
 impl Decompress for MigratedCompiledClassHash {
     fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
         let bytes = bytes.as_ref();
-        let class_hash = ClassHash::decompress(&bytes[0..32])?;
+        let class_hash = ClassHash::decode(&bytes[0..32])?;
         let compiled_class_hash = ClassHash::decompress(&bytes[32..])?;
         Ok(Self { class_hash, compiled_class_hash })
     }

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -7,6 +7,7 @@ use katana_primitives::transaction::{TxHash, TxNumber};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::models::block::StoredBlockBodyIndices;
+use crate::models::class::MigratedCompiledClassHash;
 use crate::models::contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange};
 use crate::models::list::BlockList;
 use crate::models::stage::{ExecutionCheckpoint, PruningCheckpoint, StageId};
@@ -54,7 +55,7 @@ pub enum TableType {
     DupSort,
 }
 
-pub const NUM_TABLES: usize = 33;
+pub const NUM_TABLES: usize = 34;
 
 /// Macro to declare `libmdbx` tables.
 #[macro_export]
@@ -172,6 +173,7 @@ define_tables_enum! {[
     (ContractStorage, TableType::DupSort),
     (ClassDeclarationBlock, TableType::Table),
     (ClassDeclarations, TableType::DupSort),
+    (MigratedCompiledClassHashes, TableType::DupSort),
     (ContractInfoChangeSet, TableType::Table),
     (NonceChangeHistory, TableType::DupSort),
     (ClassChangeHistory, TableType::DupSort),
@@ -233,6 +235,8 @@ tables! {
     ClassDeclarationBlock: (ClassHash) => BlockNumber,
     /// Stores the list of class hashes according to the block number it was declared in.
     ClassDeclarations: (BlockNumber, ClassHash) => ClassHash,
+    /// Stores the list of class hashes according to the block number it was declared in.
+    MigratedCompiledClassHashes: (BlockNumber, ClassHash) => MigratedCompiledClassHash,
 
     /// Generic contract info change set.
     ///
@@ -309,22 +313,23 @@ mod tests {
         assert_eq!(Tables::ALL[14].name(), ContractStorage::NAME);
         assert_eq!(Tables::ALL[15].name(), ClassDeclarationBlock::NAME);
         assert_eq!(Tables::ALL[16].name(), ClassDeclarations::NAME);
-        assert_eq!(Tables::ALL[17].name(), ContractInfoChangeSet::NAME);
-        assert_eq!(Tables::ALL[18].name(), NonceChangeHistory::NAME);
-        assert_eq!(Tables::ALL[19].name(), ClassChangeHistory::NAME);
-        assert_eq!(Tables::ALL[20].name(), StorageChangeHistory::NAME);
-        assert_eq!(Tables::ALL[21].name(), StorageChangeSet::NAME);
-        assert_eq!(Tables::ALL[22].name(), StageExecutionCheckpoints::NAME);
-        assert_eq!(Tables::ALL[23].name(), StagePruningCheckpoints::NAME);
-        assert_eq!(Tables::ALL[24].name(), ClassesTrie::NAME);
-        assert_eq!(Tables::ALL[25].name(), ContractsTrie::NAME);
-        assert_eq!(Tables::ALL[26].name(), StoragesTrie::NAME);
-        assert_eq!(Tables::ALL[27].name(), ClassesTrieHistory::NAME);
-        assert_eq!(Tables::ALL[28].name(), ContractsTrieHistory::NAME);
-        assert_eq!(Tables::ALL[29].name(), StoragesTrieHistory::NAME);
-        assert_eq!(Tables::ALL[30].name(), ClassesTrieChangeSet::NAME);
-        assert_eq!(Tables::ALL[31].name(), ContractsTrieChangeSet::NAME);
-        assert_eq!(Tables::ALL[32].name(), StoragesTrieChangeSet::NAME);
+        assert_eq!(Tables::ALL[17].name(), MigratedCompiledClassHashes::NAME);
+        assert_eq!(Tables::ALL[18].name(), ContractInfoChangeSet::NAME);
+        assert_eq!(Tables::ALL[19].name(), NonceChangeHistory::NAME);
+        assert_eq!(Tables::ALL[20].name(), ClassChangeHistory::NAME);
+        assert_eq!(Tables::ALL[21].name(), StorageChangeHistory::NAME);
+        assert_eq!(Tables::ALL[22].name(), StorageChangeSet::NAME);
+        assert_eq!(Tables::ALL[23].name(), StageExecutionCheckpoints::NAME);
+        assert_eq!(Tables::ALL[24].name(), StagePruningCheckpoints::NAME);
+        assert_eq!(Tables::ALL[25].name(), ClassesTrie::NAME);
+        assert_eq!(Tables::ALL[26].name(), ContractsTrie::NAME);
+        assert_eq!(Tables::ALL[27].name(), StoragesTrie::NAME);
+        assert_eq!(Tables::ALL[28].name(), ClassesTrieHistory::NAME);
+        assert_eq!(Tables::ALL[29].name(), ContractsTrieHistory::NAME);
+        assert_eq!(Tables::ALL[30].name(), StoragesTrieHistory::NAME);
+        assert_eq!(Tables::ALL[31].name(), ClassesTrieChangeSet::NAME);
+        assert_eq!(Tables::ALL[32].name(), ContractsTrieChangeSet::NAME);
+        assert_eq!(Tables::ALL[33].name(), StoragesTrieChangeSet::NAME);
 
         assert_eq!(Tables::Headers.table_type(), TableType::Table);
         assert_eq!(Tables::BlockHashes.table_type(), TableType::Table);
@@ -343,6 +348,7 @@ mod tests {
         assert_eq!(Tables::ContractStorage.table_type(), TableType::DupSort);
         assert_eq!(Tables::ClassDeclarationBlock.table_type(), TableType::Table);
         assert_eq!(Tables::ClassDeclarations.table_type(), TableType::DupSort);
+        assert_eq!(Tables::MigratedCompiledClassHashes.table_type(), TableType::DupSort);
         assert_eq!(Tables::ContractInfoChangeSet.table_type(), TableType::Table);
         assert_eq!(Tables::NonceChangeHistory.table_type(), TableType::DupSort);
         assert_eq!(Tables::ClassChangeHistory.table_type(), TableType::DupSort);
@@ -372,6 +378,7 @@ mod tests {
 
     use crate::codecs::{Compress, Decode, Decompress, Encode};
     use crate::models::block::StoredBlockBodyIndices;
+    use crate::models::class::MigratedCompiledClassHash;
     use crate::models::contract::{
         ContractClassChange, ContractInfoChangeList, ContractNonceChange,
     };
@@ -441,6 +448,7 @@ mod tests {
             (CompiledClassHash, felt!("211")),
             (CompiledClass, CompiledClass::Legacy(Default::default())),
             (GenericContractInfo, GenericContractInfo::default()),
+            (MigratedCompiledClassHash, MigratedCompiledClassHash::default()),
             (StorageEntry, StorageEntry::default()),
             (ContractInfoChangeList, ContractInfoChangeList::default()),
             (ContractNonceChange, ContractNonceChange::default()),

--- a/crates/storage/provider/provider-api/src/trie.rs
+++ b/crates/storage/provider/provider-api/src/trie.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use katana_primitives::block::BlockNumber;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::state::StateUpdates;
@@ -12,7 +10,7 @@ pub trait TrieWriter: Send + Sync {
     fn trie_insert_declared_classes(
         &self,
         block_number: BlockNumber,
-        updates: &BTreeMap<ClassHash, CompiledClassHash>,
+        updates: impl Iterator<Item = (ClassHash, CompiledClassHash)>,
     ) -> ProviderResult<Felt>;
 
     fn trie_insert_contract_updates(

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -700,6 +700,7 @@ impl<Tx: DbTxMut> BlockWriter for DbProvider<Tx> {
             self.0.put::<tables::ClassDeclarations>(block_number, class_hash)?;
         }
 
+        // insert migrated class hashes
         for (class_hash, compiled_class_hash) in states.state_updates.migrated_compiled_classes {
             let entry = MigratedCompiledClassHash { class_hash, compiled_class_hash };
             self.0.put::<tables::MigratedCompiledClassHashes>(block_number, entry)?;

--- a/crates/storage/provider/provider/src/providers/db/trie.rs
+++ b/crates/storage/provider/provider/src/providers/db/trie.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use katana_db::abstraction::DbTxMut;
 use katana_db::tables;
@@ -21,12 +21,12 @@ impl<Tx: DbTxMut> TrieWriter for DbProvider<Tx> {
     fn trie_insert_declared_classes(
         &self,
         block_number: BlockNumber,
-        updates: &BTreeMap<ClassHash, CompiledClassHash>,
+        updates: impl Iterator<Item = (ClassHash, CompiledClassHash)>,
     ) -> ProviderResult<Felt> {
         let mut trie = ClassesTrie::new(TrieDbMut::<tables::ClassesTrie, _>::new(self.0.clone()));
 
         for (class_hash, compiled_hash) in updates {
-            trie.insert(*class_hash, *compiled_hash);
+            trie.insert(class_hash, compiled_hash);
         }
 
         trie.commit(block_number);

--- a/crates/storage/provider/provider/src/providers/fork/trie.rs
+++ b/crates/storage/provider/provider/src/providers/fork/trie.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use katana_db::abstraction::DbTxMut;
 use katana_primitives::block::BlockNumber;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
@@ -24,7 +22,7 @@ impl<Tx1: DbTxMut> TrieWriter for ForkedProvider<Tx1> {
     fn trie_insert_declared_classes(
         &self,
         block_number: BlockNumber,
-        updates: &BTreeMap<ClassHash, CompiledClassHash>,
+        updates: impl Iterator<Item = (ClassHash, CompiledClassHash)>,
     ) -> ProviderResult<Felt> {
         let _ = block_number;
         let _ = updates;

--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -353,7 +353,8 @@ impl Pipeline {
 
                 result = self.run_loop() => {
                     if let Err(error) = result {
-                        error!(target: "pipeline", %error, "Pipeline returned an error.");
+                        error!(target: "pipeline", %error, "Pipeline finished due to error.");
+                        break;
                     }
                 }
             }
@@ -543,13 +544,17 @@ impl Pipeline {
                 }
             } else {
                 info!(target: "pipeline", "Waiting to receive new tip.");
-                self.cmd_rx.changed().await.map_err(|_| Error::CommandChannelClosed)?;
+            }
 
-                if let Some(PipelineCommand::SetTip(new_tip)) = *self.cmd_rx.borrow_and_update() {
-                    info!(target: "pipeline", tip = %new_tip, "A new tip has been set.");
-                    self.tip = Some(new_tip);
-                    self.metrics.set_sync_target(new_tip);
-                }
+            if let Some(PipelineCommand::SetTip(new_tip)) = *self
+                .cmd_rx
+                .wait_for(|c| matches!(c, &Some(PipelineCommand::SetTip(_))))
+                .await
+                .map_err(|_| Error::CommandChannelClosed)?
+            {
+                info!(target: "pipeline", tip = %new_tip, "A new tip has been set.");
+                self.tip = Some(new_tip);
+                self.metrics.set_sync_target(new_tip);
             }
 
             yield_now().await;

--- a/crates/sync/stage/src/trie.rs
+++ b/crates/sync/stage/src/trie.rs
@@ -150,17 +150,12 @@ impl Stage for StateTrie {
 
                     // Remove trie snapshots for blocks in the prune range
                     for block_number in range {
-                        let span = debug_span!("state_trie.prune", %block_number);
-                        let _enter = span.enter();
-
                         // Remove snapshot from classes trie
                         let mut classes_trie_db =
                             TrieDbMut::<tables::ClassesTrie, _>::new(tx.clone());
                         classes_trie_db
                             .remove_snapshot(block_number)
                             .map_err(|e| Error::Database(e.into_inner()))?;
-
-                        debug!(target: "stage", "Classes trie snapshot removed.");
 
                         // Remove snapshot from contracts trie
                         let mut contracts_trie_db =
@@ -169,16 +164,12 @@ impl Stage for StateTrie {
                             .remove_snapshot(block_number)
                             .map_err(|e| Error::Database(e.into_inner()))?;
 
-                        debug!(target: "stage", "Contracts trie snapshot removed.");
-
                         // Remove snapshot from storages trie
                         let mut storages_trie_db =
                             TrieDbMut::<tables::StoragesTrie, _>::new(tx.clone());
                         storages_trie_db
                             .remove_snapshot(block_number)
                             .map_err(|e| Error::Database(e.into_inner()))?;
-
-                        debug!(target: "stage", "Storage trie snapshot removed.");
 
                         pruned_count += 1;
                     }


### PR DESCRIPTION
Adds a new field to the state diff types for class hashes whose CASM hash has been migrated to the new hash function. This changes are part of the RPC v0.10.0 and Starknet 0.14.1 update. 

## Database Changes

Introduces a new table, `MigratedCompiledClassHash` - a dupsort table for indexing the list of migrated class hashes according to the block number where the migration occurred.

This change doesn't require bumping the database version as it is backward compatible. Queries performed on the table would not fail and simply return an empty result. Which is still the expected behaviour considering that this table only make sense for Katana with 0.14.1 support which versions prior to this PR have no support for.

## References

* Starknet 0.14.1 pre-release notes. https://community.starknet.io/t/starknet-v0-14-1-prerelease-notes/116032
* SNIP34 proposal for CASM hash change. https://community.starknet.io/t/snip-34-more-efficient-casm-hashes/115979