### PR TITLE
feat(primitives): deploy tx receipt

### DIFF
--- a/crates/gateway/gateway-types/src/conversion.rs
+++ b/crates/gateway/gateway-types/src/conversion.rs
@@ -265,6 +265,19 @@ impl From<katana_primitives::receipt::Receipt> for ReceiptBody {
         };
 
         match receipt {
+            katana_primitives::receipt::Receipt::Deploy(receipt) => {
+                Self {
+                    execution_resources: Some(receipt.execution_resources.into()),
+                    // This would need to be populated from transaction context
+                    l1_to_l2_consumed_message: None,
+                    l2_to_l1_messages: receipt.messages_sent,
+                    events: receipt.events,
+                    actual_fee: receipt.fee.overall_fee.into(),
+                    execution_status,
+                    revert_error: receipt.revert_error,
+                }
+            }
+
             katana_primitives::receipt::Receipt::Invoke(receipt) => {
                 Self {
                     execution_resources: Some(receipt.execution_resources.into()),

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -107,6 +107,25 @@ pub struct DeployAccountTxReceipt {
     pub contract_address: ContractAddress,
 }
 
+/// Receipt for a `Deploy` transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DeployTxReceipt {
+    /// Information about the transaction fee.
+    pub fee: FeeInfo,
+    /// Events emitted by contracts.
+    pub events: Vec<Event>,
+    /// Messages sent to L1.
+    pub messages_sent: Vec<MessageToL1>,
+    /// Revert error message if the transaction execution failed.
+    pub revert_error: Option<String>,
+    /// The execution resources used by the transaction.
+    pub execution_resources: ExecutionResources,
+    /// Contract address of the deployed contract.
+    pub contract_address: ContractAddress,
+}
+
 /// The receipt of a transaction containing the outputs of its execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -116,6 +135,7 @@ pub enum Receipt {
     Declare(DeclareTxReceipt),
     L1Handler(L1HandlerTxReceipt),
     DeployAccount(DeployAccountTxReceipt),
+    Deploy(DeployTxReceipt),
 }
 
 impl Receipt {
@@ -129,6 +149,7 @@ impl Receipt {
     /// Returns the revert reason if the transaction is reverted.
     pub fn revert_reason(&self) -> Option<&str> {
         match self {
+            Receipt::Deploy(rct) => rct.revert_error.as_deref(),
             Receipt::Invoke(rct) => rct.revert_error.as_deref(),
             Receipt::Declare(rct) => rct.revert_error.as_deref(),
             Receipt::L1Handler(rct) => rct.revert_error.as_deref(),
@@ -139,6 +160,7 @@ impl Receipt {
     /// Returns the L1 messages sent.
     pub fn messages_sent(&self) -> &[MessageToL1] {
         match self {
+            Receipt::Deploy(rct) => &rct.messages_sent,
             Receipt::Invoke(rct) => &rct.messages_sent,
             Receipt::Declare(rct) => &rct.messages_sent,
             Receipt::L1Handler(rct) => &rct.messages_sent,
@@ -149,6 +171,7 @@ impl Receipt {
     /// Returns the events emitted.
     pub fn events(&self) -> &[Event] {
         match self {
+            Receipt::Deploy(rct) => &rct.events,
             Receipt::Invoke(rct) => &rct.events,
             Receipt::Declare(rct) => &rct.events,
             Receipt::L1Handler(rct) => &rct.events,
@@ -159,6 +182,7 @@ impl Receipt {
     /// Returns the execution resources used.
     pub fn resources_used(&self) -> &ExecutionResources {
         match self {
+            Receipt::Deploy(rct) => &rct.execution_resources,
             Receipt::Invoke(rct) => &rct.execution_resources,
             Receipt::Declare(rct) => &rct.execution_resources,
             Receipt::L1Handler(rct) => &rct.execution_resources,
@@ -168,6 +192,7 @@ impl Receipt {
 
     pub fn fee(&self) -> &FeeInfo {
         match self {
+            Receipt::Deploy(rct) => &rct.fee,
             Receipt::Invoke(rct) => &rct.fee,
             Receipt::Declare(rct) => &rct.fee,
             Receipt::L1Handler(rct) => &rct.fee,
@@ -178,6 +203,7 @@ impl Receipt {
     /// Returns the transaction tyoe of the receipt.
     pub fn r#type(&self) -> TxType {
         match self {
+            Receipt::Deploy(_) => TxType::Deploy,
             Receipt::Invoke(_) => TxType::Invoke,
             Receipt::Declare(_) => TxType::Declare,
             Receipt::L1Handler(_) => TxType::L1Handler,

--- a/crates/rpc/rpc-types/src/receipt.rs
+++ b/crates/rpc/rpc-types/src/receipt.rs
@@ -175,6 +175,25 @@ pub struct RpcDeployAccountTxReceipt {
 impl RpcTxReceipt {
     fn new(receipt: Receipt, finality_status: FinalityStatus) -> Self {
         match receipt {
+            Receipt::Deploy(rct) => {
+                let messages_sent = rct.messages_sent;
+                let events = rct.events;
+
+                RpcTxReceipt::Deploy(RpcDeployTxReceipt {
+                    events,
+                    messages_sent,
+                    finality_status,
+                    actual_fee: rct.fee.into(),
+                    contract_address: rct.contract_address,
+                    execution_resources: rct.execution_resources.into(),
+                    execution_result: if let Some(reason) = rct.revert_error {
+                        ExecutionResult::Reverted { reason }
+                    } else {
+                        ExecutionResult::Succeeded
+                    },
+                })
+            }
+
             Receipt::Invoke(rct) => {
                 let messages_sent = rct.messages_sent;
                 let events = rct.events;


### PR DESCRIPTION
Add support for the legacy **Deploy** transaction receipt. This is needed in order to sync Starknet Mainnet.

## Database Changes

Although we're adding a new variant to the `Receipt` enum, `Receipt::Deploy`, this doesn't break the `Receipts` database table as it doesn't affect the indices for the existing variants - only adding a new one.