### PR TITLE
fix(cli): merge explorer options from config file

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -525,6 +525,15 @@ impl SequencerNodeArgs {
             self.cartridge.merge(config.cartridge.as_ref());
         }
 
+        #[cfg(feature = "explorer")]
+        {
+            if !self.explorer.explorer {
+                if let Some(explorer) = &config.explorer {
+                    self.explorer.explorer = explorer.explorer;
+                }
+            }
+        }
+
         Ok(self)
     }
 
@@ -729,6 +738,9 @@ total_accounts = 20
 validate_max_steps = 500
 invoke_max_steps = 9988
 chain_id.Named = "Mainnet"
+
+[explorer]
+explorer = true
         "#;
         let path = std::env::temp_dir().join("katana-config.json");
         std::fs::write(&path, content).unwrap();
@@ -772,6 +784,9 @@ chain_id.Named = "Mainnet"
         assert_eq!(config.chain.genesis().gas_prices.eth.get(), 9999);
         assert_eq!(config.chain.genesis().gas_prices.strk.get(), 8888);
         assert_eq!(config.chain.id(), ChainId::Id(Felt::from_str("0x123").unwrap()));
+
+        #[cfg(feature = "explorer")]
+        assert!(config.rpc.explorer);
     }
 
     #[test]

--- a/crates/cli/src/file.rs
+++ b/crates/cli/src/file.rs
@@ -27,6 +27,8 @@ pub struct NodeArgsConfig {
     pub metrics: Option<MetricsOptions>,
     #[cfg(feature = "cartridge")]
     pub cartridge: Option<CartridgeOptions>,
+    #[cfg(feature = "explorer")]
+    pub explorer: Option<ExplorerOptions>,
 }
 
 impl NodeArgsConfig {
@@ -79,6 +81,15 @@ impl TryFrom<SequencerNodeArgs> for NodeArgsConfig {
                 None
             } else {
                 Some(args.cartridge)
+            };
+        }
+
+        #[cfg(feature = "explorer")]
+        {
+            node_config.explorer = if args.explorer == ExplorerOptions::default() {
+                None
+            } else {
+                Some(args.explorer)
             };
         }
 


### PR DESCRIPTION
The `[explorer]` section in `katana.toml` was being ignored because `NodeArgsConfig` was missing the explorer field and `with_config_file()` didn't merge it. This adds the missing field and merge logic so that `explorer = true` in the config file now works the same as the `--explorer` CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)