### PR TITLE
fix: system contract no class hash 

### DIFF
--- a/crates/rpc/rpc-server/src/starknet/mod.rs
+++ b/crates/rpc/rpc-server/src/starknet/mod.rs
@@ -369,9 +369,12 @@ where
         contract_address: ContractAddress,
     ) -> StarknetApiResult<ClassHash> {
         self.on_io_blocking_task(move |this| {
-            // Contract address 0x1 is special system contract and does not
-            // have a class. See https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#address_0x1.
-            if contract_address.0 == Felt::ONE {
+            // Contract address 0x1 and 0x2 are special system contracts and does not
+            // have a class.
+            //
+            // See https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#address_0x1.
+            if contract_address == ContractAddress::ONE || contract_address == ContractAddress::TWO
+            {
                 return Ok(ClassHash::ZERO);
             }
 
@@ -422,9 +425,12 @@ where
         let state = self.state(&block_id)?;
 
         // Check that contract exist by checking the class hash of the contract,
-        // unless its address 0x1 which is special system contract and does not
-        // have a class. See https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#address_0x1.
-        if contract_address.0 != Felt::ONE
+        // unless its address 0x1 or 0x2 which are special system contracts and does not
+        // have a class.
+        //
+        // See https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#address_0x1.
+        if contract_address != ContractAddress::ONE
+            && contract_address != ContractAddress::TWO
             && state.class_hash_of_contract(contract_address)?.is_none()
         {
             return Err(StarknetApiError::ContractNotFound);

--- a/crates/rpc/rpc-server/tests/starknet.rs
+++ b/crates/rpc/rpc-server/tests/starknet.rs
@@ -1340,3 +1340,45 @@ async fn simulate_should_skip_strict_nonce_check(#[case] nonce: Felt, #[case] sh
     let res = contract.transfer(&recipient, &amount).nonce(nonce).simulate(false, false).await;
     assert_eq!(res.is_ok(), should_ok)
 }
+
+/// Test that special system contract addresses (0x1 and 0x2) return ClassHash::ZERO
+/// for `get_class_hash_at` calls, as they don't have an associated class.
+///
+/// See https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#address_0x1
+#[tokio::test]
+async fn special_system_contract_class_hash() {
+    let sequencer = TestNode::new().await;
+    let provider = sequencer.starknet_rpc_client();
+
+    // Address 0x1 should return ClassHash::ZERO
+    let class_hash =
+        provider.get_class_hash_at(BlockIdOrTag::PreConfirmed, felt!("0x1").into()).await.unwrap();
+    assert_eq!(class_hash, Felt::ZERO, "Address 0x1 should return ClassHash::ZERO");
+
+    // Address 0x2 should return ClassHash::ZERO
+    let class_hash =
+        provider.get_class_hash_at(BlockIdOrTag::PreConfirmed, felt!("0x2").into()).await.unwrap();
+    assert_eq!(class_hash, Felt::ZERO, "Address 0x2 should return ClassHash::ZERO");
+}
+
+/// Test that `get_storage_at` works for special system contract addresses (0x1 and 0x2)
+/// without returning ContractNotFound error.
+///
+/// See https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#address_0x1
+#[tokio::test]
+async fn special_system_contract_storage() {
+    let sequencer = TestNode::new().await;
+    let provider = sequencer.starknet_rpc_client();
+
+    let storage_key = felt!("0x0");
+
+    // Address 0x1 should not return ContractNotFound
+    let result =
+        provider.get_storage_at(felt!("0x1").into(), storage_key, BlockIdOrTag::PreConfirmed).await;
+    assert!(result.is_ok(), "get_storage_at for address 0x1 should not fail");
+
+    // Address 0x2 should not return ContractNotFound
+    let result =
+        provider.get_storage_at(felt!("0x2").into(), storage_key, BlockIdOrTag::PreConfirmed).await;
+    assert!(result.is_ok(), "get_storage_at for address 0x2 should not fail");
+}


### PR DESCRIPTION
this is just a quick patch but we should probably find a more robust way of handling this ie this case shouldn't be handled on the rpc level.