### PR TITLE
refactor(primitives): remove usages of `short_string!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,7 +3021,6 @@ dependencies = [
  "serde",
  "serde_json",
  "stark-vrf",
- "starknet",
  "thiserror 1.0.69",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4729,15 +4729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,17 +4795,6 @@ dependencies = [
  "which 7.0.3",
  "winreg 0.55.0",
  "zip 2.4.2",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "serde",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -6365,7 +6345,6 @@ dependencies = [
  "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion",
  "derive_more 0.99.20",
- "heapless",
  "katana-primitives-macro",
  "lazy_static",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,12 +3013,10 @@ version = "1.7.0"
 dependencies = [
  "anyhow",
  "ark-ec 0.4.2",
- "cainome",
  "katana-contracts",
  "katana-primitives",
  "lazy_static",
  "num-bigint",
- "parking_lot",
  "reqwest 0.12.22",
  "serde",
  "serde_json",

--- a/bin/katana/src/cli/config.rs
+++ b/bin/katana/src/cli/config.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Args;
 use katana_chain_spec::rollup::LocalChainConfigDir;
+use katana_primitives::cairo::ShortString;
 use katana_primitives::chain::ChainId;
-use starknet::core::utils::parse_cairo_short_string;
 
 #[derive(Debug, Args)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -30,7 +30,7 @@ impl ConfigArgs {
                     // returned by `list` will be of the `ChainId::Id` variant and thus
                     // will display in hex form. But for now, it's fine to assume that because we
                     // only limit valid ASCII string in the `katana init` flow.
-                    let name = parse_cairo_short_string(&chain.id())?;
+                    let name = ShortString::try_from(chain.id())?;
                     println!("{name}");
                 }
             }

--- a/bin/katana/src/cli/init/deployment.rs
+++ b/bin/katana/src/cli/init/deployment.rs
@@ -18,7 +18,6 @@ use starknet::accounts::{Account, AccountError, ConnectedAccount, SingleOwnerAcc
 use starknet::contract::ContractFactory;
 use starknet::core::crypto::compute_hash_on_elements;
 use starknet::core::types::{BlockId, BlockTag, FlattenedSierraClass, StarknetError};
-use starknet::macros::short_string;
 use starknet::providers::{Provider, ProviderError};
 use starknet::signers::LocalWallet;
 use thiserror::Error;

--- a/bin/katana/src/cli/init/deployment.rs
+++ b/bin/katana/src/cli/init/deployment.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Result};
 use cainome::cairo_serde;
 use katana_primitives::block::{BlockHash, BlockNumber};
+use katana_primitives::cairo::ShortString;
 use katana_primitives::class::{
     CompiledClassHash, ComputeClassHashError, ContractClass, ContractClassCompilationError,
     ContractClassFromStrError,
@@ -410,10 +411,10 @@ fn compute_starknet_os_config_hash(
     fee_token: Felt,
 ) -> Felt {
     // A constant representing the StarkNet OS config version.
-    const STARKNET_OS_CONFIG_VERSION: Felt = short_string!("StarknetOsConfig2");
+    const STARKNET_OS_CONFIG_VERSION: ShortString = ShortString::from_ascii("StarknetOsConfig2");
 
     compute_hash_on_elements(&[
-        STARKNET_OS_CONFIG_VERSION,
+        STARKNET_OS_CONFIG_VERSION.into(),
         chain_id,
         deprecated_fee_token,
         fee_token,

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -59,11 +59,11 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::Context;
-use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 use deployment::DeploymentOutcome;
 use katana_chain_spec::rollup::{ChainConfigDir, DEFAULT_APPCHAIN_FEE_TOKEN_ADDRESS};
 use katana_chain_spec::{rollup, FeeContracts, SettlementLayer};
+use katana_cli::utils::ShortStringValueParser;
 use katana_genesis::allocation::DevAllocationsGenerator;
 use katana_genesis::constant::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
 use katana_genesis::Genesis;
@@ -118,7 +118,7 @@ pub struct RollupArgs {
     /// An empty `Id` is not a allowed, since the chain id must be
     /// a valid ASCII string.
     #[arg(long)]
-    #[arg(value_parser = NonEmptyStringValueParser::new())]
+    #[arg(value_parser = ShortStringValueParser)]
     #[arg(requires_all = ["settlement_chain", "settlement_account", "settlement_account_private_key"])]
     id: Option<ShortString>,
 
@@ -193,7 +193,7 @@ pub struct SovereignArgs {
     /// An empty `Id` is not a allowed, since the chain id must be
     /// a valid ASCII string.
     #[arg(long)]
-    #[arg(value_parser = NonEmptyStringValueParser::new())]
+    #[arg(value_parser = ShortStringValueParser)]
     id: Option<ShortString>,
 
     /// Specify the path of the directory where the configuration files will be stored at.

--- a/crates/cartridge/Cargo.toml
+++ b/crates/cartridge/Cargo.toml
@@ -17,7 +17,6 @@ num-bigint.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-starknet.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/cartridge/Cargo.toml
+++ b/crates/cartridge/Cargo.toml
@@ -12,10 +12,8 @@ katana-primitives.workspace = true
 
 anyhow.workspace = true
 ark-ec = "0.4"
-cainome.workspace = true
 lazy_static.workspace = true
 num-bigint.workspace = true
-parking_lot.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cartridge/src/lib.rs
+++ b/crates/cartridge/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 pub mod client;
 pub mod vrf;
 

--- a/crates/cartridge/src/vrf.rs
+++ b/crates/cartridge/src/vrf.rs
@@ -23,10 +23,9 @@ use std::str::FromStr;
 use ark_ec::short_weierstrass::Affine;
 use katana_primitives::cairo::ShortString;
 use katana_primitives::utils::get_contract_address;
-use katana_primitives::{ContractAddress, Felt};
+use katana_primitives::{felt, ContractAddress, Felt};
 use num_bigint::BigInt;
 use stark_vrf::{generate_public_key, BaseField, StarkCurve, StarkVRF};
-use starknet::macros::felt;
 use tracing::trace;
 
 // Class hash of the VRF provider contract (fee estimation code commented, since currently Katana

--- a/crates/cartridge/src/vrf.rs
+++ b/crates/cartridge/src/vrf.rs
@@ -21,11 +21,12 @@
 use std::str::FromStr;
 
 use ark_ec::short_weierstrass::Affine;
+use katana_primitives::cairo::ShortString;
 use katana_primitives::utils::get_contract_address;
 use katana_primitives::{ContractAddress, Felt};
 use num_bigint::BigInt;
 use stark_vrf::{generate_public_key, BaseField, StarkCurve, StarkVRF};
-use starknet::macros::{felt, short_string};
+use starknet::macros::felt;
 use tracing::trace;
 
 // Class hash of the VRF provider contract (fee estimation code commented, since currently Katana
@@ -34,7 +35,7 @@ use tracing::trace;
 // `crates/controller/artifacts/cartridge_vrf_VrfProvider.contract_class.json`
 pub const CARTRIDGE_VRF_CLASS_HASH: Felt =
     felt!("0x07007ea60938ff539f1c0772a9e0f39b4314cfea276d2c22c29a8b64f2a87a58");
-pub const CARTRIDGE_VRF_SALT: Felt = short_string!("cartridge_vrf");
+pub const CARTRIDGE_VRF_SALT: ShortString = ShortString::from_ascii("cartridge_vrf");
 pub const CARTRIDGE_VRF_DEFAULT_PRIVATE_KEY: Felt = felt!("0x1");
 
 #[derive(Debug, Default, Clone)]
@@ -125,7 +126,7 @@ fn compute_vrf_address(
     public_key_y: Felt,
 ) -> ContractAddress {
     get_contract_address(
-        CARTRIDGE_VRF_SALT,
+        CARTRIDGE_VRF_SALT.into(),
         CARTRIDGE_VRF_CLASS_HASH,
         &[*provider_addrss, public_key_x, public_key_y],
         Felt::ZERO,

--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
 use alloy_primitives::U256;
 use katana_contracts::contracts;
@@ -11,6 +12,7 @@ use katana_genesis::constant::{
 };
 use katana_genesis::Genesis;
 use katana_primitives::block::{ExecutableBlock, GasPrices, PartialHeader};
+use katana_primitives::cairo::ShortString;
 use katana_primitives::chain::ChainId;
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::ContractAddress;
@@ -20,7 +22,6 @@ use katana_primitives::utils::split_u256;
 use katana_primitives::version::StarknetVersion;
 use katana_primitives::Felt;
 use lazy_static::lazy_static;
-use starknet::core::utils::cairo_short_string_to_felt;
 
 use crate::{FeeContracts, SettlementLayer};
 
@@ -206,13 +207,13 @@ fn add_fee_token(
 
     // --- ERC20 metadata
 
-    let name = cairo_short_string_to_felt(name).unwrap();
-    let symbol = cairo_short_string_to_felt(symbol).unwrap();
+    let name = ShortString::from_str(name).expect("valid ERC20 name");
+    let symbol = ShortString::from_str(symbol).expect("valid ERC20 symbol");
     let decimals = decimals.into();
     let (total_supply_low, total_supply_high) = split_u256(total_supply);
 
-    storage.insert(ERC20_NAME_STORAGE_SLOT, name);
-    storage.insert(ERC20_SYMBOL_STORAGE_SLOT, symbol);
+    storage.insert(ERC20_NAME_STORAGE_SLOT, name.into());
+    storage.insert(ERC20_SYMBOL_STORAGE_SLOT, symbol.into());
     storage.insert(ERC20_DECIMAL_STORAGE_SLOT, decimals);
     storage.insert(ERC20_TOTAL_SUPPLY_STORAGE_SLOT, total_supply_low);
     storage.insert(ERC20_TOTAL_SUPPLY_STORAGE_SLOT + Felt::ONE, total_supply_high);

--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -502,8 +502,8 @@ mod tests {
         let (total_supply_low, total_supply_high) =
             split_u256(U256::from_str("0x1a784379d99db42000000").unwrap());
 
-        let name = cairo_short_string_to_felt("Ether").unwrap();
-        let symbol = cairo_short_string_to_felt("ETH").unwrap();
+        let name = ShortString::from_ascii("Ether");
+        let symbol = ShortString::from_ascii("ETH");
         let decimals = Felt::from(18);
 
         let eth_fee_token_storage = actual_state_updates
@@ -512,8 +512,8 @@ mod tests {
             .get(&DEFAULT_ETH_FEE_TOKEN_ADDRESS)
             .unwrap();
 
-        assert_eq!(eth_fee_token_storage.get(&ERC20_NAME_STORAGE_SLOT), Some(&name));
-        assert_eq!(eth_fee_token_storage.get(&ERC20_SYMBOL_STORAGE_SLOT), Some(&symbol));
+        assert_eq!(eth_fee_token_storage.get(&ERC20_NAME_STORAGE_SLOT), Some(&name.into()));
+        assert_eq!(eth_fee_token_storage.get(&ERC20_SYMBOL_STORAGE_SLOT), Some(&symbol.into()));
         assert_eq!(eth_fee_token_storage.get(&ERC20_DECIMAL_STORAGE_SLOT), Some(&decimals));
         assert_eq!(
             eth_fee_token_storage.get(&ERC20_TOTAL_SUPPLY_STORAGE_SLOT),
@@ -526,8 +526,8 @@ mod tests {
 
         // check STRK fee token contract storage
 
-        let strk_name = cairo_short_string_to_felt("Starknet Token").unwrap();
-        let strk_symbol = cairo_short_string_to_felt("STRK").unwrap();
+        let strk_name = ShortString::from_ascii("Starknet Token");
+        let strk_symbol = ShortString::from_ascii("STRK");
         let strk_decimals = Felt::from(18);
 
         let strk_fee_token_storage = actual_state_updates
@@ -536,8 +536,11 @@ mod tests {
             .get(&DEFAULT_STRK_FEE_TOKEN_ADDRESS)
             .unwrap();
 
-        assert_eq!(strk_fee_token_storage.get(&ERC20_NAME_STORAGE_SLOT), Some(&strk_name));
-        assert_eq!(strk_fee_token_storage.get(&ERC20_SYMBOL_STORAGE_SLOT), Some(&strk_symbol));
+        assert_eq!(strk_fee_token_storage.get(&ERC20_NAME_STORAGE_SLOT), Some(&strk_name.into()));
+        assert_eq!(
+            strk_fee_token_storage.get(&ERC20_SYMBOL_STORAGE_SLOT),
+            Some(&strk_symbol.into())
+        );
         assert_eq!(strk_fee_token_storage.get(&ERC20_DECIMAL_STORAGE_SLOT), Some(&strk_decimals));
         assert_eq!(
             strk_fee_token_storage.get(&ERC20_TOTAL_SUPPLY_STORAGE_SLOT),

--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use alloy_primitives::U256;
 use katana_contracts::contracts;
 use katana_genesis::allocation::{DevGenesisAccount, GenesisAccountAlloc};
+use katana_primitives::cairo::ShortString;
 use katana_primitives::class::{ClassHash, ContractClass};
 use katana_primitives::contract::{ContractAddress, Nonce};
 use katana_primitives::transaction::{
@@ -16,7 +17,6 @@ use katana_primitives::utils::{get_contract_address, split_u256};
 use katana_primitives::{felt, Felt};
 use num_traits::FromPrimitive;
 use starknet::core::utils::get_selector_from_name;
-use starknet::macros::short_string;
 use starknet::signers::SigningKey;
 
 use crate::rollup::ChainSpec;
@@ -270,9 +270,9 @@ impl<'c> GenesisTransactionsBuilder<'c> {
 
         let master_address = *self.master_address.get().expect("must be initialized first");
 
-        let ctor_args = vec![
-            short_string!("Starknet Token"),
-            short_string!("STRK"),
+        let ctor_args: Vec<Felt> = vec![
+            ShortString::from_ascii("Starknet Token").into(),
+            ShortString::from_ascii("STRK").into(),
             felt!("0x12"),
             Felt::from_u128(u128::MAX).unwrap(),
             Felt::from_u128(u128::MAX).unwrap(),

--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -11,11 +11,11 @@ use katana_primitives::transaction::{
     DeclareTx, DeclareTxV0, DeclareTxV2, DeclareTxWithClass, DeployAccountTx, DeployAccountTxV1,
     ExecutableTx, ExecutableTxWithHash, InvokeTx, InvokeTxV1,
 };
-use katana_primitives::utils::split_u256;
 use katana_primitives::utils::transaction::compute_deploy_account_v1_tx_hash;
+use katana_primitives::utils::{get_contract_address, split_u256};
 use katana_primitives::{felt, Felt};
 use num_traits::FromPrimitive;
-use starknet::core::utils::{get_contract_address, get_selector_from_name};
+use starknet::core::utils::get_selector_from_name;
 use starknet::macros::short_string;
 use starknet::signers::SigningKey;
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -11,6 +11,7 @@ use katana_genesis::constant::{
 use katana_genesis::json::GenesisJson;
 use katana_genesis::Genesis;
 use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockNumber};
+use katana_primitives::cairo::ShortString;
 use katana_primitives::chain::ChainId;
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::ContractAddress;
@@ -226,6 +227,49 @@ pub fn parse_chain_config_dir(value: &str) -> Result<ChainConfigDir> {
     } else {
         let path = PathBuf::from(shellexpand::tilde(value).as_ref());
         Ok(ChainConfigDir::open(path)?)
+    }
+}
+
+/// A clap value parser for [`ShortString`] that ensures the string is non-empty.
+///
+/// This is the `ShortString` equivalent of clap's `NonEmptyStringValueParser`.
+#[derive(Clone, Debug)]
+pub struct ShortStringValueParser;
+
+impl clap::builder::TypedValueParser for ShortStringValueParser {
+    type Value = ShortString;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        use core::str::FromStr;
+
+        use clap::error::{ContextKind, ContextValue, ErrorKind};
+
+        let value =
+            value.to_str().ok_or_else(|| clap::Error::new(ErrorKind::InvalidUtf8).with_cmd(cmd))?;
+
+        if value.is_empty() {
+            let mut err = clap::Error::new(ErrorKind::InvalidValue).with_cmd(cmd);
+            if let Some(arg) = arg {
+                err.insert(ContextKind::InvalidArg, ContextValue::String(arg.to_string()));
+            }
+            err.insert(ContextKind::InvalidValue, ContextValue::String(value.to_string()));
+            return Err(err);
+        }
+
+        ShortString::from_str(value).map_err(|e| {
+            let mut err = clap::Error::new(ErrorKind::InvalidValue).with_cmd(cmd);
+            if let Some(arg) = arg {
+                err.insert(ContextKind::InvalidArg, ContextValue::String(arg.to_string()));
+            }
+            err.insert(ContextKind::InvalidValue, ContextValue::String(value.to_string()));
+            err.insert(ContextKind::Custom, ContextValue::String(e.to_string()));
+            err
+        })
     }
 }
 

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -9,6 +9,7 @@ use katana_primitives::block::{
     BlockHash, BlockNumber, FinalityStatus, Header, PartialHeader, SealedBlock,
     SealedBlockWithStatus,
 };
+use katana_primitives::cairo::ShortString;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::env::BlockEnv;
@@ -537,7 +538,7 @@ impl<'a, P: TrieWriter> UncommittedBlock<'a, P> {
             .expect("failed to update contract trie");
 
         hash::Poseidon::hash_array(&[
-            short_string!("STARKNET_STATE_V0"),
+            ShortString::from_ascii("STARKNET_STATE_V0").into(),
             contract_trie_root,
             class_trie_root,
         ])

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -30,7 +30,6 @@ use katana_trie::{
 };
 use parking_lot::RwLock;
 use rayon::prelude::*;
-use starknet::macros::short_string;
 use starknet_types_core::hash::{self, StarkHash};
 use tracing::info;
 

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -14,7 +14,6 @@ katana-provider.workspace = true
 blockifier = { workspace = true, features = [ "testing" ] }
 num-traits.workspace = true
 quick_cache = "0.6.10"
-starknet.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
@@ -34,6 +33,7 @@ katana-provider = { workspace = true, features = [ "test-utils" ] }
 katana-rpc-types.workspace = true
 katana-utils.workspace = true
 
+starknet.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 assert_matches.workspace = true

--- a/crates/executor/src/implementation/blockifier/utils.rs
+++ b/crates/executor/src/implementation/blockifier/utils.rs
@@ -20,6 +20,7 @@ use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::types::errors::program_errors::ProgramError;
 use katana_chain_spec::ChainSpec;
+use katana_primitives::cairo::ShortString;
 use katana_primitives::chain::NamedChainId;
 use katana_primitives::env::{BlockEnv, VersionedConstantsOverrides};
 use katana_primitives::fee::{FeeInfo, PriceUnit, ResourceBoundsMapping};
@@ -30,7 +31,6 @@ use katana_primitives::transaction::{
 use katana_primitives::{class, fee};
 use katana_provider::api::contract::ContractClassProvider;
 use num_traits::Zero;
-use starknet::core::utils::parse_cairo_short_string;
 use starknet_api::block::{
     BlockInfo, BlockNumber, BlockTimestamp, FeeType, GasPriceVector, GasPrices, NonzeroGasPrice,
     StarknetVersion,
@@ -653,8 +653,8 @@ pub fn to_blk_chain_id(chain_id: katana_primitives::chain::ChainId) -> ChainId {
         katana_primitives::chain::ChainId::Named(NamedChainId::Sepolia) => ChainId::Sepolia,
         katana_primitives::chain::ChainId::Named(named) => ChainId::Other(named.to_string()),
         katana_primitives::chain::ChainId::Id(id) => {
-            let id = parse_cairo_short_string(&id).expect("valid cairo string");
-            ChainId::Other(id)
+            let id = ShortString::try_from(id).expect("valid cairo string");
+            ChainId::Other(id.to_string())
         }
     }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -20,7 +20,6 @@ arbitrary = { workspace = true, optional = true }
 blockifier = { workspace = true, features = [ "testing" ] } # some Clone derives are gated behind 'testing' feature
 cainome-cairo-serde.workspace = true
 derive_more.workspace = true
-heapless = { version = "0.8.0", features = [ "serde" ] }
 lazy_static.workspace = true
 num-traits.workspace = true
 serde.workspace = true

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 use num_traits::ToPrimitive;
 use starknet::core::types::ResourcePrice;
 use starknet::core::utils::cairo_short_string_to_felt;
-use starknet::macros::short_string;
 
+use crate::cairo::ShortString;
 use crate::contract::ContractAddress;
 use crate::da::L1DataAvailabilityMode;
 use crate::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
@@ -327,6 +327,8 @@ impl Header {
     pub fn compute_hash(&self) -> Felt {
         use starknet_types_core::hash::{Poseidon, StarkHash};
 
+        const BLOCK_HASH_VERSION: ShortString = ShortString::from_ascii("STARKNET_BLOCK_HASH0");
+
         let concant = Self::concat_counts(
             self.transaction_count,
             self.events_count,
@@ -335,7 +337,7 @@ impl Header {
         );
 
         Poseidon::hash_array(&[
-            short_string!("STARKNET_BLOCK_HASH0"),
+            BLOCK_HASH_VERSION.into(),
             self.number.into(),
             self.state_root,
             self.sequencer_address.into(),

--- a/crates/primitives/src/cairo.rs
+++ b/crates/primitives/src/cairo.rs
@@ -134,6 +134,12 @@ impl AsRef<str> for ShortString {
     }
 }
 
+impl PartialEq<Felt> for ShortString {
+    fn eq(&self, other: &Felt) -> bool {
+        Felt::from(self) == *other
+    }
+}
+
 impl core::fmt::Debug for ShortString {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("ShortString").field(&self.as_str()).finish()
@@ -258,9 +264,9 @@ impl<'a> arbitrary::Arbitrary<'a> for ShortString {
         let length: u8 = u.int_in_range(0..=31)?;
         let mut data = [0u8; 31];
 
-        for i in 0..length as usize {
+        for item in data.iter_mut().take(length as usize) {
             // ASCII printable range (32-126) to avoid control characters
-            data[i] = u.int_in_range(32..=126)?;
+            *item = u.int_in_range(32..=126)?;
         }
 
         Ok(Self { data, len: length })
@@ -318,6 +324,15 @@ mod tests {
         let felt = Felt::from(original.clone());
         let converted = ShortString::try_from(felt).unwrap();
         assert_eq!(original, converted);
+    }
+
+    #[test]
+    fn eq_felt() {
+        let s = ShortString::from_str("hello").unwrap();
+        let felt = Felt::from(&s);
+
+        assert!(s == felt);
+        assert!(s != Felt::from(123u64));
     }
 
     #[test]

--- a/crates/primitives/src/cairo.rs
+++ b/crates/primitives/src/cairo.rs
@@ -1,81 +1,187 @@
 use crate::Felt;
 
 /// A Cairo short string.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ShortString(heapless::String<31>);
+///
+/// This is a stack-allocated string type that can hold up to 31 ASCII bytes,
+/// which is the maximum length for a Cairo short string.
+///
+/// It supports const construction via [`ShortString::from_ascii`].
+#[derive(Clone, PartialEq, Eq, Hash, Default, Copy)]
+pub struct ShortString {
+    data: [u8; 31],
+    len: u8,
+}
 
 impl ShortString {
     /// Creates a new empty short string.
     pub const fn new() -> Self {
-        Self(heapless::String::new())
+        Self { data: [0; 31], len: 0 }
     }
 
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
+    /// Creates a new short string from an ASCII string literal at compile time.
+    ///
+    /// # Panics
+    ///
+    /// Panics at compile time if the string is longer than 31 bytes or contains
+    /// non-ASCII characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use katana_primitives::cairo::ShortString;
+    ///
+    /// const HELLO: ShortString = ShortString::from_ascii("hello");
+    /// assert_eq!(HELLO.as_str(), "hello");
+    /// ```
+    pub const fn from_ascii(s: &str) -> Self {
+        let bytes = s.as_bytes();
+        let len = bytes.len();
+
+        assert!(len <= 31, "string is too long to be a Cairo short string");
+
+        let mut data = [0u8; 31];
+        let mut i = 0;
+        while i < len {
+            let b = bytes[i];
+            assert!(b.is_ascii(), "invalid ASCII character in string");
+            data[i] = b;
+            i += 1;
+        }
+
+        Self { data, len: len as u8 }
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
+    pub const fn as_str(&self) -> &str {
+        // SAFETY: We only store valid ASCII bytes, which are valid UTF-8
+        unsafe { core::str::from_utf8_unchecked(self.as_bytes()) }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+    /// Returns the bytes of the short string as a slice.
+    pub const fn as_bytes(&self) -> &[u8] {
+        // Use a manual slice since `&self.data[..self.len as usize]` is not const-stable
+        unsafe { core::slice::from_raw_parts(self.data.as_ptr(), self.len as usize) }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     #[inline]
-    fn push(&mut self, c: char) -> Result<(), ()> {
-        self.0.push(c)
+    fn push(&mut self, c: char) -> Result<(), ShortStringError> {
+        if !c.is_ascii() {
+            return Err(ShortStringError::InvalidAscii);
+        }
+
+        if self.len >= 31 {
+            return Err(ShortStringError::ExceedsCapacity);
+        }
+
+        self.data[self.len as usize] = c as u8;
+        self.len += 1;
+
+        Ok(())
     }
 
     #[inline]
-    fn push_str(&mut self, string: &str) -> Result<(), ()> {
-        self.0.push_str(string)
+    fn push_str(&mut self, string: &str) -> Result<(), ShortStringError> {
+        let bytes = string.as_bytes();
+
+        if bytes.len() + self.len as usize > 31 {
+            return Err(ShortStringError::ExceedsCapacity);
+        }
+
+        for &b in bytes {
+            if !b.is_ascii() {
+                return Err(ShortStringError::InvalidAscii);
+            }
+
+            self.data[self.len as usize] = b;
+            self.len += 1;
+        }
+
+        Ok(())
     }
 }
 
-impl Default for ShortString {
-    fn default() -> Self {
-        Self::new()
-    }
+/// Error returned when constructing or modifying a [`ShortString`] fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ShortStringError {
+    #[error("string is longer than 31 bytes")]
+    ExceedsCapacity,
+
+    #[error("invalid ASCII character")]
+    InvalidAscii,
+
+    #[error("unexpected null terminator")]
+    UnexpectedNullTerminator,
 }
 
 impl core::ops::Deref for ShortString {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_str()
+        self.as_str()
     }
 }
 
 impl AsRef<str> for ShortString {
     fn as_ref(&self) -> &str {
-        self.0.as_str()
+        self.as_str()
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ShortStringTryFromStrError {
-    #[error("String is too long to be a Cairo short string")]
-    StringTooLong,
-    #[error("Invalid ASCII character in string")]
-    InvalidAsciiString,
+impl core::fmt::Debug for ShortString {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("ShortString").field(&self.as_str()).finish()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ShortString {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ShortString {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ShortStringVisitor;
+
+        impl serde::de::Visitor<'_> for ShortStringVisitor {
+            type Value = ShortString;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a string up to 31 ASCII characters")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                v.parse().map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(ShortStringVisitor)
+    }
 }
 
 impl core::str::FromStr for ShortString {
-    type Err = ShortStringTryFromStrError;
+    type Err = ShortStringError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if !s.is_ascii() {
-            return Err(ShortStringTryFromStrError::InvalidAsciiString);
+            return Err(ShortStringError::InvalidAscii);
         }
 
         if s.len() > 31 {
-            return Err(ShortStringTryFromStrError::StringTooLong);
+            return Err(ShortStringError::ExceedsCapacity);
         }
 
         let mut string = Self::new();
-        string.push_str(s).expect("length already checked");
+        string.push_str(s).expect("qed; length already checked");
 
         Ok(string)
     }
@@ -83,7 +189,7 @@ impl core::str::FromStr for ShortString {
 
 impl From<ShortString> for String {
     fn from(string: ShortString) -> Self {
-        string.0.to_string()
+        string.as_str().to_string()
     }
 }
 
@@ -95,22 +201,12 @@ impl From<ShortString> for Felt {
 
 impl From<&ShortString> for Felt {
     fn from(string: &ShortString) -> Self {
-        Felt::from_bytes_be_slice(string.0.as_bytes())
+        Felt::from_bytes_be_slice(string.as_bytes())
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ShortStringFromFeltError {
-    #[error("Unexpected null terminator in string")]
-    UnexpectedNullTerminator,
-    #[error("String exceeds maximum length for Cairo short strings")]
-    StringTooLong,
-    #[error("Non-ASCII character found")]
-    NonAsciiCharacter,
-}
-
 impl TryFrom<Felt> for ShortString {
-    type Error = ShortStringFromFeltError;
+    type Error = ShortStringError;
 
     fn try_from(value: Felt) -> Result<Self, Self::Error> {
         if value == Felt::ZERO {
@@ -121,7 +217,7 @@ impl TryFrom<Felt> for ShortString {
 
         // First byte must be zero because the string must only be 31 bytes.
         if bytes[0] > 0 {
-            return Err(ShortStringFromFeltError::StringTooLong);
+            return Err(ShortStringError::ExceedsCapacity);
         }
 
         let mut string = ShortString::new();
@@ -129,12 +225,12 @@ impl TryFrom<Felt> for ShortString {
         for byte in bytes {
             if byte == 0u8 {
                 if !string.is_empty() {
-                    return Err(ShortStringFromFeltError::UnexpectedNullTerminator);
+                    return Err(ShortStringError::UnexpectedNullTerminator);
                 }
             } else if byte.is_ascii() {
                 string.push(byte as char).expect("qed; should fit");
             } else {
-                return Err(ShortStringFromFeltError::NonAsciiCharacter);
+                return Err(ShortStringError::InvalidAscii);
             }
         }
 
@@ -143,7 +239,7 @@ impl TryFrom<Felt> for ShortString {
 }
 
 impl TryFrom<&Felt> for ShortString {
-    type Error = ShortStringFromFeltError;
+    type Error = ShortStringError;
 
     fn try_from(value: &Felt) -> Result<Self, Self::Error> {
         Self::try_from(*value)
@@ -152,23 +248,22 @@ impl TryFrom<&Felt> for ShortString {
 
 impl core::fmt::Display for ShortString {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.as_str())
     }
 }
 
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for ShortString {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let mut raw_bytes = heapless::Vec::<u8, 31>::new();
-        let length = u.int_in_range(0..=31)?;
+        let length: u8 = u.int_in_range(0..=31)?;
+        let mut data = [0u8; 31];
 
-        for _ in 0..length {
-            let char = u.int_in_range(0..=127)?; // ASCII range
-            raw_bytes.push(char).expect("shouldn't be full");
+        for i in 0..length as usize {
+            // ASCII printable range (32-126) to avoid control characters
+            data[i] = u.int_in_range(32..=126)?;
         }
 
-        let str = heapless::String::<31>::from_utf8(raw_bytes).expect("should be valid utf8");
-        Ok(Self(str))
+        Ok(Self { data, len: length })
     }
 }
 
@@ -179,7 +274,7 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::ShortString;
-    use crate::cairo::{ShortStringFromFeltError, ShortStringTryFromStrError};
+    use crate::cairo::ShortStringError;
     use crate::Felt;
 
     #[test]
@@ -188,6 +283,19 @@ mod tests {
         assert!(s.is_empty());
         assert_eq!(s.len(), 0);
         assert_eq!(s.as_str(), "");
+    }
+
+    #[test]
+    fn const_from_ascii() {
+        const HELLO: ShortString = ShortString::from_ascii("hello");
+        assert_eq!(HELLO.as_str(), "hello");
+        assert_eq!(HELLO.len(), 5);
+
+        const EMPTY: ShortString = ShortString::from_ascii("");
+        assert!(EMPTY.is_empty());
+
+        const MAX_LEN: ShortString = ShortString::from_ascii("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_eq!(MAX_LEN.len(), 31);
     }
 
     #[test]
@@ -218,7 +326,7 @@ mod tests {
         let mut bytes = [0u8; 32];
         bytes[0] = 1;
         let felt = Felt::from_bytes_be(&bytes);
-        assert_matches!(ShortString::try_from(felt), Err(ShortStringFromFeltError::StringTooLong));
+        assert_matches!(ShortString::try_from(felt), Err(ShortStringError::ExceedsCapacity));
     }
 
     #[test]
@@ -274,16 +382,13 @@ mod tests {
         let felt = Felt::from_bytes_be(&bytes);
         assert!(matches!(
             ShortString::try_from(felt),
-            Err(ShortStringFromFeltError::UnexpectedNullTerminator)
+            Err(ShortStringError::UnexpectedNullTerminator)
         ));
     }
 
     #[test]
     fn try_from_non_ascii_str() {
-        assert_matches!(
-            ShortString::from_str("café"),
-            Err(ShortStringTryFromStrError::InvalidAsciiString)
-        );
+        assert_matches!(ShortString::from_str("café"), Err(ShortStringError::InvalidAscii));
     }
 
     #[cfg(feature = "arbitrary")]
@@ -297,7 +402,8 @@ mod tests {
         for _ in 0..100 {
             let s = ShortString::arbitrary(&mut u).unwrap();
             assert!(s.len() <= 31);
-            assert!(String::from(s).into_bytes().into_iter().all(|b| b <= 127));
+            // Verify all characters are ASCII printable (32-126)
+            assert!(s.as_bytes().iter().all(|&b| (32..=126).contains(&b)));
         }
     }
 }

--- a/crates/primitives/src/class.rs
+++ b/crates/primitives/src/class.rs
@@ -6,10 +6,10 @@ use cairo_lang_starknet_classes::contract_class::{
 };
 use cairo_lang_utils::bigint::BigUintAsHex;
 use serde_json_pythonic::to_string_pythonic;
-use starknet::macros::short_string;
 use starknet_api::contract_class::SierraVersion;
 use starknet_types_core::hash::{self, Poseidon, StarkHash};
 
+use crate::cairo::ShortString;
 use crate::utils::{normalize_address, starknet_keccak};
 use crate::Felt;
 
@@ -309,8 +309,10 @@ pub fn compute_sierra_class_hash(
     entry_points_by_type: &ContractEntryPoints,
     sierra_program: &[Felt],
 ) -> Felt {
+    const CONTRACT_CLASS_VERSION: ShortString = ShortString::from_ascii("CONTRACT_CLASS_V0.1.0");
+
     let hash = hash::Poseidon::hash_array(&[
-        short_string!("CONTRACT_CLASS_V0.1.0"),
+        CONTRACT_CLASS_VERSION.into(),
         // Hashes entry points
         entrypoints_hash(&entry_points_by_type.external),
         entrypoints_hash(&entry_points_by_type.l1_handler),

--- a/crates/primitives/src/da/encoding.rs
+++ b/crates/primitives/src/da/encoding.rs
@@ -305,10 +305,8 @@ impl ContractUpdate {
 mod tests {
     use std::str::FromStr;
 
-    use starknet::macros::felt;
-
     use super::*;
-    use crate::address;
+    use crate::{address, felt};
 
     macro_rules! biguint {
         ($s:expr) => {
@@ -318,7 +316,7 @@ mod tests {
 
     #[test]
     fn rt_metadata_encoding() {
-        let metadata = felt!("0x10000000000000001").to_biguint();
+        let metadata = felt!("0x10000000000000001", crate).to_biguint();
 
         let encoded = Metadata::decode(&metadata).unwrap();
         assert!(!encoded.class_information_flag);
@@ -362,12 +360,18 @@ mod tests {
 
         let storage_updates = state_updates.storage_updates.get(&address).unwrap();
         assert_eq!(storage_updates.len(), 1);
-        assert_eq!(storage_updates.get(&felt!("0x64")), Some(&felt!("0xc8")));
+        assert_eq!(storage_updates.get(&felt!("0x64", crate)), Some(&felt!("0xc8", crate)));
 
-        let class_hash =
-            felt!("1351148242645005540004162531550805076995747746087542030095186557536641755046");
-        let compiled_class_hash =
-            felt!("558404273560404778508455254030458021013656352466216690688595011803280448032");
+        let class_hash = felt!(
+            "1351148242645005540004162531550805076995747746087542030095186557536641755046",
+            crate
+        );
+
+        let compiled_class_hash = felt!(
+            "558404273560404778508455254030458021013656352466216690688595011803280448032",
+            crate
+        );
+
         assert_eq!(state_updates.declared_classes.get(&class_hash), Some(&compiled_class_hash));
 
         let encoded = encode_state_updates(state_updates);

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter;
 
-use starknet::macros::short_string;
 use starknet_types_core::hash::{self, StarkHash};
 
+use crate::cairo::ShortString;
 use crate::class::{ClassHash, CompiledClassHash, ContractClass};
 use crate::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
 use crate::Felt;
@@ -125,8 +125,8 @@ pub fn compute_state_diff_hash(states: StateUpdates) -> Felt {
     let nonces_len = Felt::from(nonce_updates.len());
     let nonce_updates = nonce_updates.into_iter().flat_map(|nonce| vec![nonce.0.into(), nonce.1]);
 
-    let magic = short_string!("STARKNET_STATE_DIFF0");
-    let elements: Vec<Felt> = iter::once(magic)
+    let magic = ShortString::from_ascii("STARKNET_STATE_DIFF0");
+    let elements: Vec<Felt> = iter::once(Felt::from(magic))
         .chain(iter::once(updated_contracts_len))
         .chain(updated_contracts)
         .chain(iter::once(declared_classes_len))

--- a/crates/primitives/src/utils/transaction.rs
+++ b/crates/primitives/src/utils/transaction.rs
@@ -423,6 +423,7 @@ mod tests {
 
     use super::*;
     use crate::address;
+    use crate::cairo::ShortString;
     use crate::chain::ChainId;
 
     #[test]
@@ -433,10 +434,10 @@ mod tests {
 
     #[test]
     fn test_prefix_constants() {
-        assert_eq!(PREFIX_INVOKE, short_string!("invoke"));
-        assert_eq!(PREFIX_DECLARE, short_string!("declare"));
-        assert_eq!(PREFIX_DEPLOY_ACCOUNT, short_string!("deploy_account"));
-        assert_eq!(PREFIX_L1_HANDLER, short_string!("l1_handler"));
+        assert_eq!(PREFIX_INVOKE, ShortString::from_ascii("invoke").into());
+        assert_eq!(PREFIX_DECLARE, ShortString::from_ascii("declare").into());
+        assert_eq!(PREFIX_DEPLOY_ACCOUNT, ShortString::from_ascii("deploy_account").into());
+        assert_eq!(PREFIX_L1_HANDLER, ShortString::from_ascii("l1_handler").into());
     }
 
     #[test]

--- a/crates/primitives/src/utils/transaction.rs
+++ b/crates/primitives/src/utils/transaction.rs
@@ -419,7 +419,7 @@ fn encode_da_mode(
 #[cfg(test)]
 mod tests {
     use num_traits::ToPrimitive;
-    use starknet::macros::{felt, short_string};
+    use starknet::macros::felt;
 
     use super::*;
     use crate::address;

--- a/crates/rpc/rpc-server/src/cartridge/mod.rs
+++ b/crates/rpc/rpc-server/src/cartridge/mod.rs
@@ -536,7 +536,7 @@ pub async fn craft_deploy_cartridge_vrf_tx(
 ) -> anyhow::Result<ExecutableTxWithHash> {
     let calldata = vec![
         CARTRIDGE_VRF_CLASS_HASH,
-        CARTRIDGE_VRF_SALT,
+        CARTRIDGE_VRF_SALT.into(),
         // from zero
         Felt::ZERO,
         // Calldata len

--- a/crates/rpc/rpc-server/tests/common/mod.rs
+++ b/crates/rpc/rpc-server/tests/common/mod.rs
@@ -8,8 +8,9 @@ use cainome::rs::abigen_legacy;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use katana_primitives::class::CompiledClass;
+use katana_primitives::Felt;
 use starknet::core::types::contract::SierraClass;
-use starknet::core::types::{Call, Felt, FlattenedSierraClass};
+use starknet::core::types::{Call, FlattenedSierraClass};
 use starknet::core::utils::get_selector_from_name;
 
 abigen_legacy!(Erc20Contract, "crates/contracts/build/legacy/erc20.json", derives(Clone));

--- a/crates/rpc/rpc-server/tests/estimate_fee_rate_limit.rs
+++ b/crates/rpc/rpc-server/tests/estimate_fee_rate_limit.rs
@@ -4,9 +4,8 @@ use std::time::Instant;
 use anyhow::Result;
 use cainome::rs::abigen_legacy;
 use katana_genesis::constant::DEFAULT_ETH_FEE_TOKEN_ADDRESS;
+use katana_primitives::{felt, Felt};
 use katana_utils::TestNode;
-use starknet::core::types::Felt;
-use starknet::macros::felt;
 use tokio::sync::Mutex;
 
 mod common;

--- a/crates/rpc/rpc-server/tests/forking.rs
+++ b/crates/rpc/rpc-server/tests/forking.rs
@@ -20,7 +20,6 @@ use url::Url;
 
 mod common;
 
-const SEPOLIA_CHAIN_ID: Felt = NamedChainId::SN_SEPOLIA;
 const SEPOLIA_URL: &str = "https://api.cartridge.gg/x/starknet/sepolia";
 const FORK_BLOCK_NUMBER: BlockNumber = 268_471;
 const FORK_BLOCK_HASH: BlockHash =
@@ -105,7 +104,7 @@ async fn can_fork() -> Result<()> {
     let BlockNumberResponse { block_number } = provider.block_number().await?;
     let chain = provider.chain_id().await?;
 
-    assert_eq!(chain, SEPOLIA_CHAIN_ID);
+    assert_eq!(NamedChainId::SN_SEPOLIA, chain);
     assert_eq!(block_number, FORK_BLOCK_NUMBER + 11); // fork block + genesis + 10 blocks
 
     Ok(())

--- a/crates/rpc/rpc-server/tests/messaging.rs
+++ b/crates/rpc/rpc-server/tests/messaging.rs
@@ -11,13 +11,13 @@ use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::utils::transaction::{
     compute_l1_handler_tx_hash, compute_l1_to_l2_message_hash,
 };
-use katana_primitives::{eth_address, felt, ContractAddress};
+use katana_primitives::{eth_address, felt, ContractAddress, Felt};
 use katana_rpc_types::{Class, MsgFromL1};
 use katana_utils::{TestNode, TxWaiter};
 use rand::Rng;
 use starknet::accounts::{Account, ConnectedAccount};
 use starknet::contract::ContractFactory;
-use starknet::core::types::{Felt, Hash256, ReceiptBlock, Transaction, TransactionReceipt};
+use starknet::core::types::{Hash256, ReceiptBlock, Transaction, TransactionReceipt};
 use starknet::core::utils::get_contract_address;
 use starknet::macros::selector;
 use starknet::providers::Provider;

--- a/crates/rpc/rpc-server/tests/simulate.rs
+++ b/crates/rpc/rpc-server/tests/simulate.rs
@@ -1,10 +1,9 @@
 use cainome::rs::abigen_legacy;
 use katana_genesis::constant::DEFAULT_ETH_FEE_TOKEN_ADDRESS;
 use katana_primitives::block::BlockIdOrTag;
+use katana_primitives::{felt, Felt};
 use katana_utils::TestNode;
 use starknet::accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
-use starknet::core::types::Felt;
-use starknet::macros::felt;
 use starknet::providers::Provider;
 use starknet::signers::{LocalWallet, SigningKey};
 

--- a/crates/rpc/rpc-server/tests/starknet.rs
+++ b/crates/rpc/rpc-server/tests/starknet.rs
@@ -13,7 +13,7 @@ use katana_genesis::constant::{
 };
 use katana_primitives::block::{BlockIdOrTag, ConfirmedBlockIdOrTag};
 use katana_primitives::event::ContinuationToken;
-use katana_primitives::Felt;
+use katana_primitives::{felt, Felt};
 use katana_rpc_api::dev::DevApiClient;
 use katana_rpc_types::state_update::StateUpdate;
 use katana_rpc_types::trace::TxTrace;
@@ -31,7 +31,7 @@ use starknet::accounts::{
 };
 use starknet::core::types::Call;
 use starknet::core::utils::get_contract_address;
-use starknet::macros::{felt, selector};
+use starknet::macros::selector;
 use starknet::providers::{Provider, ProviderError};
 use starknet::signers::{LocalWallet, SigningKey};
 use tokio::sync::Mutex;

--- a/crates/storage/db/src/trie/mod.rs
+++ b/crates/storage/db/src/trie/mod.rs
@@ -471,10 +471,10 @@ fn to_db_key(key: &DatabaseKey<'_>) -> models::trie::TrieDatabaseKey {
 
 #[cfg(test)]
 mod tests {
+    use katana_primitives::cairo::ShortString;
     use katana_primitives::hash::{Poseidon, StarkHash};
     use katana_primitives::{felt, hash};
     use katana_trie::{verify_proof, ClassesTrie, CommitId};
-    use starknet::macros::short_string;
 
     use super::TrieDbMut;
     use crate::abstraction::Database;
@@ -532,8 +532,10 @@ mod tests {
             let verify_result0 =
                 verify_proof::<Poseidon>(&proofs0, snapshot_root0, vec![felt!("0x9999")]);
 
-            let value =
-                hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0xdead"));
+            let value = hash::Poseidon::hash(
+                &ShortString::from_ascii("CONTRACT_CLASS_LEAF_V0").into(),
+                &felt!("0xdead"),
+            );
             assert_eq!(vec![value], verify_result0);
         }
 
@@ -549,8 +551,10 @@ mod tests {
             let verify_result1 =
                 verify_proof::<Poseidon>(&proofs1, snapshot_root1, vec![felt!("0x6969")]);
 
-            let value =
-                hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0x80085"));
+            let value = hash::Poseidon::hash(
+                &ShortString::from_ascii("CONTRACT_CLASS_LEAF_V0").into(),
+                &felt!("0x80085"),
+            );
             assert_eq!(vec![value], verify_result1);
         }
 
@@ -560,10 +564,14 @@ mod tests {
             let result =
                 verify_proof::<Poseidon>(&proofs, root, vec![felt!("0x6969"), felt!("0x9999")]);
 
-            let value0 =
-                hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0x80085"));
-            let value1 =
-                hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0xdead"));
+            let value0 = hash::Poseidon::hash(
+                &ShortString::from_ascii("CONTRACT_CLASS_LEAF_V0").into(),
+                &felt!("0x80085"),
+            );
+            let value1 = hash::Poseidon::hash(
+                &ShortString::from_ascii("CONTRACT_CLASS_LEAF_V0").into(),
+                &felt!("0xdead"),
+            );
 
             assert_eq!(vec![value0, value1], result);
         }

--- a/crates/storage/provider/provider-api/src/state.rs
+++ b/crates/storage/provider/provider-api/src/state.rs
@@ -1,9 +1,9 @@
 use katana_primitives::block::BlockHashOrNumber;
+use katana_primitives::cairo::ShortString;
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
 use katana_primitives::Felt;
 use katana_trie::MultiProof;
-use starknet::macros::short_string;
 use starknet_types_core::hash::StarkHash;
 
 use super::contract::ContractClassProvider;
@@ -16,7 +16,7 @@ pub trait StateRootProvider: Send + Sync {
     fn state_root(&self) -> ProviderResult<Felt> {
         // https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#state_commitment
         Ok(starknet_types_core::hash::Poseidon::hash_array(&[
-            short_string!("STARKNET_STATE_V0"),
+            ShortString::from_ascii("STARKNET_STATE_V0").into(),
             self.contracts_root()?,
             self.classes_root()?,
         ]))

--- a/crates/sync/stage/src/trie.rs
+++ b/crates/sync/stage/src/trie.rs
@@ -3,13 +3,13 @@ use katana_db::abstraction::{Database, DbTx};
 use katana_db::tables;
 use katana_db::trie::TrieDbMut;
 use katana_primitives::block::BlockNumber;
+use katana_primitives::cairo::ShortString;
 use katana_primitives::Felt;
 use katana_provider::api::block::HeaderProvider;
 use katana_provider::api::state_update::StateUpdateProvider;
 use katana_provider::api::trie::TrieWriter;
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderFactory};
 use katana_tasks::TaskSpawner;
-use starknet::macros::short_string;
 use starknet_types_core::hash::{Poseidon, StarkHash};
 use tracing::{debug, debug_span, error};
 
@@ -100,7 +100,7 @@ impl Stage for StateTrie {
                     computed_contract_trie_root
                 } else {
                     Poseidon::hash_array(&[
-                        short_string!("STARKNET_STATE_V0"),
+                        ShortString::from_ascii("STARKNET_STATE_V0").into(),
                         computed_contract_trie_root,
                         computed_class_trie_root,
                     ])

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -8,12 +8,9 @@ use katana_gateway_types::{
     StateUpdateWithBlock,
 };
 use katana_primitives::block::{
-    BlockHash, BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,
+    BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,
 };
 use katana_primitives::da::L1DataAvailabilityMode;
-use katana_primitives::execution::TypedTransactionExecutionInfo;
-use katana_primitives::receipt::Receipt;
-use katana_primitives::state::StateUpdatesWithClasses;
 use katana_primitives::{felt, ContractAddress, Felt};
 use katana_provider::api::block::{BlockHashProvider, BlockNumberProvider, BlockWriter};
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderFactory};

--- a/crates/trie/src/classes.rs
+++ b/crates/trie/src/classes.rs
@@ -1,9 +1,9 @@
 use bonsai_trie::{BonsaiDatabase, BonsaiPersistentDatabase, MultiProof};
 use katana_primitives::block::BlockNumber;
+use katana_primitives::cairo::ShortString;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::hash::{Poseidon, StarkHash};
 use katana_primitives::Felt;
-use starknet::macros::short_string;
 
 use crate::id::CommitId;
 
@@ -69,6 +69,6 @@ where
 
 pub fn compute_classes_trie_value(compiled_class_hash: CompiledClassHash) -> Felt {
     // https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#classes_trie
-    const CONTRACT_CLASS_LEAF_V0: Felt = short_string!("CONTRACT_CLASS_LEAF_V0");
-    Poseidon::hash(&CONTRACT_CLASS_LEAF_V0, &compiled_class_hash)
+    const CONTRACT_CLASS_LEAF_V0: ShortString = ShortString::from_ascii("CONTRACT_CLASS_LEAF_V0");
+    Poseidon::hash(&CONTRACT_CLASS_LEAF_V0.into(), &compiled_class_hash)
 }


### PR DESCRIPTION
Related #198, #209, #211, #256, #268

This change is part of the effort to remove the dependency on the `starknet` crate. The `short_string!` macro from that crate was previously used to construct `ShortString` values at compile time, but eliminating this dependency requires an alternative approach. The previous implementation using `heapless::String` did not support const construction of arbitrary strings, so it has been replaced with a custom stack-allocated data structure that enables compile-time construction via `ShortString::from_ascii`.
