### PR TITLE
chore: bump `blockifier` to `v0.16.0-rc.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   db-compatibility-check:
     needs: [fmt, clippy, build-katana-binary]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project 1.1.10",
- "reqwest 0.12.22",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -430,7 +430,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project 1.1.10",
- "reqwest 0.12.22",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -631,7 +631,7 @@ checksum = "0d3615ec64d775fec840f4e9d5c8e1f739eb1854d8d28db093fb3d4805e0cb53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.22",
+ "reqwest",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -745,232 +745,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "apollo_config"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+name = "apollo_compilation_utils"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "clap",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_config"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "clap",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tracing",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_metrics 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "async-trait",
- "hyper 0.14.32",
- "rstest 0.17.0",
- "serde",
- "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "tracing-subscriber",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_metrics 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "async-trait",
- "hyper 0.14.32",
- "rstest 0.17.0",
- "serde",
- "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "tracing-subscriber",
- "validator",
-]
-
-[[package]]
-name = "apollo_infra_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "assert-json-diff",
- "cached",
- "colored 3.0.0",
- "serde",
- "serde_json",
- "socket2 0.5.10",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "apollo_infra_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "assert-json-diff",
- "cached",
- "colored 3.0.0",
- "serde",
- "serde_json",
- "socket2 0.5.10",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "apollo_metrics"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "indexmap 2.10.0",
- "metrics 0.24.2",
- "num-traits",
- "paste",
- "regex",
-]
-
-[[package]]
-name = "apollo_metrics"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "indexmap 2.10.0",
- "metrics 0.24.2",
- "num-traits",
- "paste",
- "regex",
-]
-
-[[package]]
-name = "apollo_proc_macros"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "apollo_proc_macros"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "apollo_sierra_multicompile"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
-dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_sierra_multicompile_types 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "async-trait",
+ "apollo_infra_utils",
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "rlimit",
  "serde",
  "serde_json",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "starknet-types-core 0.2.3",
+ "starknet_api",
  "tempfile",
  "thiserror 1.0.69",
- "tracing",
- "validator",
 ]
 
 [[package]]
-name = "apollo_sierra_multicompile"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
+name = "apollo_compile_to_native"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_sierra_multicompile_types 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "async-trait",
- "cairo-lang-sierra",
+ "apollo_compilation_utils",
+ "apollo_compile_to_native_types",
+ "apollo_infra_utils",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils",
  "cairo-native",
- "rlimit",
- "serde",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
  "tempfile",
- "thiserror 1.0.69",
- "tracing",
+]
+
+[[package]]
+name = "apollo_compile_to_native_types"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+dependencies = [
+ "apollo_config",
+ "serde",
  "validator",
 ]
 
 [[package]]
-name = "apollo_sierra_multicompile_types"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+name = "apollo_config"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_proc_macros 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "async-trait",
+ "apollo_infra_utils",
+ "clap",
+ "const_format",
+ "itertools 0.12.1",
  "serde",
  "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "strum_macros 0.25.3",
  "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "validator",
 ]
 
 [[package]]
-name = "apollo_sierra_multicompile_types"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
+name = "apollo_infra_utils"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
- "apollo_infra 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_proc_macros 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "async-trait",
+ "apollo_proc_macros",
+ "assert-json-diff",
+ "colored 3.0.0",
+ "num_enum",
  "serde",
  "serde_json",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "socket2 0.5.10",
+ "tempfile",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "apollo_metrics"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+dependencies = [
+ "indexmap 2.10.0",
+ "metrics 0.24.2",
+ "num-traits",
+ "paste",
+ "regex",
+]
+
+[[package]]
+name = "apollo_proc_macros"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1689,21 +1560,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
  "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -1838,9 +1710,17 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
- "serde",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1854,69 +1734,29 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
  "anyhow",
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "apollo_sierra_multicompile 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "apollo_compilation_utils",
+ "apollo_compile_to_native",
+ "apollo_compile_to_native_types",
+ "apollo_config",
+ "apollo_infra_utils",
+ "apollo_metrics",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-secp256k1 0.4.0",
  "ark-secp256r1 0.4.0",
- "blockifier_test_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "blockifier_test_utils",
  "cached",
  "cairo-lang-casm",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.99.20",
- "indexmap 2.10.0",
- "itertools 0.12.1",
- "keccak",
- "log",
- "mockall",
- "num-bigint",
- "num-integer",
- "num-rational",
- "num-traits",
- "paste",
- "phf",
- "rand 0.8.5",
- "rstest 0.17.0",
- "rstest_reuse 0.7.0",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "sha2",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "blockifier"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "anyhow",
- "apollo_config 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "apollo_sierra_multicompile 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-secp256k1 0.4.0",
- "ark-secp256r1 0.4.0",
- "blockifier_test_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "cached",
- "cairo-lang-casm",
- "cairo-lang-runner",
- "cairo-lang-starknet-classes",
+ "cairo-lang-utils",
  "cairo-native",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
+ "dashmap",
  "derive_more 0.99.20",
  "indexmap 2.10.0",
  "itertools 0.12.1",
@@ -1936,8 +1776,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet-types-core 0.2.3",
+ "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -1945,38 +1785,17 @@ dependencies = [
 
 [[package]]
 name = "blockifier_test_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
+ "apollo_infra_utils",
  "cairo-lang-starknet-classes",
- "itertools 0.12.1",
+ "expect-test",
  "pretty_assertions",
  "rstest 0.17.0",
  "serde_json",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-test",
-]
-
-[[package]]
-name = "blockifier_test_utils"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
-dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
- "cairo-lang-starknet-classes",
- "itertools 0.12.1",
- "pretty_assertions",
- "rstest 0.17.0",
- "serde_json",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet-types-core 0.2.3",
+ "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tempfile",
@@ -2012,7 +1831,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
- "starknet-types-core",
+ "starknet-types-core 0.1.8",
  "thiserror 2.0.12",
 ]
 
@@ -2118,16 +1937,6 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
@@ -2215,7 +2024,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.1.8",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
@@ -2296,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b3c953c0321df1d7ce9101c7a94e2d4007aa8c3362ee96be54bbe77916ef60"
+checksum = "7d1d84a85b59c753aa4a7f0c455a5c815e0aebb89faf0c8ab366b0d87c0bb934"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -2310,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cd5bec42d0c4e9f1ac6c373c177c98c73a760fabb4066757edd32ef9db467e"
+checksum = "3a5cbeb4e134cf29c63d18a235beae3f124bef2824ec45d09d6e18a0c334e509"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -2321,6 +2130,7 @@ dependencies = [
  "cairo-lang-lowering",
  "cairo-lang-parser",
  "cairo-lang-project",
+ "cairo-lang-runnable-utils",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
  "cairo-lang-sierra-generator",
@@ -2336,19 +2146,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea55d64b6e7aa9186bb65ca32f50f386d6518d467930e53fcf47658dec74a2e"
+checksum = "fa5311e1c31d413f3fa34e40e48b662c19151f0fb4b10467d627a52c93eae918"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093146c748e95400230a40dc6171ac192399484addd96c6ac70ec36b0a2e45b0"
+checksum = "872feccf7b8f70ed5d74c40548bf974fbcc5069b2ea1ae15a9b8f1ab911c536b"
 dependencies = [
+ "bincode",
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -2357,14 +2168,17 @@ dependencies = [
  "cairo-lang-utils",
  "itertools 0.14.0",
  "rust-analyzer-salsa",
+ "serde",
  "smol_str",
+ "typetag",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c85890af7f0d0b6e0d15686e0a5169d3396e2861cb3adac3c594f82ae5ed42c"
+checksum = "5d0e7c551a634708366af3003176f2f9cdea56fd4a91c834ddd802030366f6a5"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -2374,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a54937f1baca684547159af847ba5332ec8015de442878b8e4d6dbbaeec714c"
+checksum = "ed04fc3f52d68157f359257c477e30f68dec36bbf568c85d567812583cd5f9c8"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -2384,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e07492644cfa43e50cfc334a80c12c9e4d8e2a4248b3d2240301c99a025010a"
+checksum = "ca1835a43a00a90d5cd4ca3f6bb9178ec450d55458e8b56ac34ca1d6d0ccf58f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -2400,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26c988d6b522c45b5f70add3808fcae13c921822d1c48724c394b450adcf7f9"
+checksum = "3bd0736456004f1d334bad5b366c6933c4b856a23a5dfade96cfe0a1c5eb3ddb"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -2413,18 +2227,18 @@ dependencies = [
  "diffy",
  "ignore",
  "itertools 0.14.0",
- "rust-analyzer-salsa",
  "serde",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90577e4dc391e2384041763120618ed2017a8f709f20dfcaa2c1246f908dd374"
+checksum = "fd2e1d66c241fba4f3dc43e42956001940298fb4ea5970acfc8b2db8bf4b6629"
 dependencies = [
- "bincode 1.3.3",
+ "assert_matches",
+ "bincode",
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -2442,14 +2256,13 @@ dependencies = [
  "num-traits",
  "rust-analyzer-salsa",
  "serde",
- "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b7985c0ee345ead0e0f713474ec6490e3fac80c3c3889ab9e67b1588d30337"
+checksum = "15c3ab263d4afd34a002dc0e37f9bacca734aa133dbbb8540651d28308977a68"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -2468,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697772ca0b096e36cb98cfc9b1231b115a15eebf8ac7295f7b50252f5a1e6aea"
+checksum = "566059584384c12fa598ae0e0509fd3d12b3985a25872de22e37245c4bc5762c"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -2493,9 +2306,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a956924e4f53cb1b69a7cee4758f0bcf50e23bbb8769f632625956a574f736"
+checksum = "61599d8cac760505d1913fa5d7dddcf019f22d47f0748ff66b1b58afe1858b62"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -2504,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088f29ca8d06722bd92001d098b619a25979dcbfa5face7a6de5d8c7232f0454"
+checksum = "99635e2569cebc31583110b417e6a410990a494c7d56998f2be0a169a1158456"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -2517,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b63a8fe2e8f2ae6280392bcc8ab98b981db75832b16c98974b81978d3d1b26"
+checksum = "f747c3d433ec5e82576e59852fd8c86a802fefe55e7bdbb9c0db61adb1a40e7b"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -2528,16 +2341,16 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "itertools 0.14.0",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db16efd33b13cecb1ca5b843a65f1e8e3eab4e18abf0c39522b04d741e51e7"
+checksum = "40a9ab4bb286d641463b2253070c145c53ff7e71f29cda2a49915f79ff7db927"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-secp256k1 0.5.0",
@@ -2550,7 +2363,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet",
  "cairo-lang-utils",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "itertools 0.14.0",
  "keccak",
  "num-bigint",
@@ -2559,15 +2372,15 @@ dependencies = [
  "rand 0.9.2",
  "sha2",
  "smol_str",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3d35463c096f1e3ab6830e28c762b22a7b5c3fbf0df5c2e9a265d290d22ee5"
+checksum = "bf1e01333b127fa3733f2f93b3febc45219ef55b807d196f298cadea6ad8fe44"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -2592,14 +2405,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e02d4df410965f122b67967936b722352eddbfde550883b054e019dc54beeef"
+checksum = "300655046f505cf806a918918e5397b20c22b579d78c2ef09bc7d4d59fd733be"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
  "const-fnv1a-hash",
- "convert_case 0.7.1",
+ "convert_case 0.8.0",
  "derivative",
  "itertools 0.14.0",
  "lalrpop",
@@ -2613,15 +2426,15 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0d3be06212edb4d79be1296cd999b246d22e1541b49432db74dca16fe0c523"
+checksum = "0c51190f463ac9f7d4a2ce0e0345cfc92334589811a7114eeeec84029999d7f1"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -2635,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7f246adb40ac69242231642cdf2571c83463068086a00b5ae9131f7dfc74b5"
+checksum = "bb0d0f038acd79aedcadad4ad2ad928b0881c4e96a2d9ad0e0b3173a6111f313"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -2651,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ca1fbf8d29528d5fdf6a7e3b2ccdd4f3e9b57066057c30f9bc2c3118867571"
+checksum = "8bc8d2a89273ba24529319982a4a7833f2a6c4a87752baea2bc70ceb4b3285b7"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -2675,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb42e872cff7d050d2348978e2f12a94b4b29aee6f5ba5a7eca76a5294c900"
+checksum = "7c852277442b2d8ca9741cdc8ccb737c6ad381d300ab4e2d982a98ba40e5f5b6"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -2690,15 +2503,15 @@ dependencies = [
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8217d84f5434c36c68f54b5bbac9c91ff981a3738f2e6bc51b102f5beae3fd8"
+checksum = "265aa8daaa94cc4d5e135a82c0bbe7d28d2c0fbc612332903dbf1a68ed15978f"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -2706,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70aca831fef1f41b29c5e62a464a8ddd7964ed2414d3dafb6e1530bff1ae3cbd"
+checksum = "deb8bf3ccf8fe1f910291d388a2351b6f40ad32be07bdbd3a628e103387b1a48"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -2716,6 +2529,7 @@ dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
+ "cairo-lang-parser",
  "cairo-lang-plugins",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
@@ -2730,21 +2544,22 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 2.0.12",
+ "typetag",
 ]
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e9b59bb3d46e68730266b27e3f0ad524c076eebab1bcc9352256a8957d6b88"
+checksum = "4839b63927954a7c3d018fd012ce0bea256db205b85ee45df27fb1e90cb10e02"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-utils",
- "convert_case 0.7.1",
+ "convert_case 0.8.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-integer",
@@ -2753,15 +2568,15 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686aea0cd9730af809010a74c0a8583b3acb99a08e5f97a07ed205f37b9e75ae"
+checksum = "a1f83d5b0213ddab04090f4a10d009ff3428a0d6e289f4fea31798210d60d5cb"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -2777,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.11.4"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c69eb6919b69a9a7bb92f79d73c568d09ef77efa0b5d265efb763234ec979d4"
+checksum = "0d00ae64466774b6e34a91c4a66202778b17ef5a844a6f668436e28d71ccb9b2"
 dependencies = [
  "genco",
  "xshell",
@@ -2787,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a6f34df0f3929bf8166c5a6d143c22ad28fd73937cfb5d7a994d56ca4a86c4"
+checksum = "e1e90cf75528c423cd6b6faaab2dde0c1b23efe36103e1e57f338293552ee16f"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -2797,6 +2612,7 @@ dependencies = [
  "cairo-lang-defs",
  "cairo-lang-filesystem",
  "cairo-lang-lowering",
+ "cairo-lang-parser",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
  "cairo-lang-sierra-generator",
@@ -2809,14 +2625,14 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "serde",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
 ]
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199eb0e7ac78ba7dfbf6551ab7eab14dd45fdcf21675fd5472ca695dc6da96f1"
+checksum = "ebbd4ebcd82ab07fba3d376a6aa992aa552fcb7f051736f6b5a2122381754bdb"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -2827,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.11.2"
+version = "2.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e621368454b62603ae035d04864770a70952e6ca8341b78c1ac50a0088939e3f"
+checksum = "cca315cce0937801a772bee5fe92cca28b8172421bdd2f67c96e8288a0dcfb9f"
 dependencies = [
  "hashbrown 0.15.4",
  "indexmap 2.10.0",
@@ -2839,13 +2655,14 @@ dependencies = [
  "parity-scale-codec",
  "schemars 0.8.22",
  "serde",
+ "smol_str",
 ]
 
 [[package]]
 name = "cairo-native"
-version = "0.4.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67542e31b00b8f015088c06b04095aaed96b3e35b50d396289390e9fb9c9a778"
+checksum = "ff8751057242ee2f1414b27079188bd750aeed8191c9a49429be8526214bf507"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2862,7 +2679,6 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
  "cairo-lang-sierra-gas",
- "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
@@ -2887,8 +2703,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "starknet-curve 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
+ "starknet-curve 0.6.0",
+ "starknet-types-core 0.2.3",
  "stats_alloc",
  "tempfile",
  "thiserror 2.0.12",
@@ -2898,28 +2714,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cairo-type-derive"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "cairo-vm"
-version = "1.0.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa8b4b56ee66cebcade4d85128e55b2bfdf046502187aeaa8c2768a427684dc"
+checksum = "c21cacdf4e290ab5f0018f24d6bf97f8d3a8809bd09568550669270e7f9ed534"
 dependencies = [
  "anyhow",
  "arbitrary",
- "bincode 2.0.1",
+ "bincode",
  "bitvec",
  "generic-array",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
  "hex",
+ "indoc",
  "keccak",
  "lazy_static",
  "nom",
@@ -2933,45 +2740,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "starknet-crypto 0.6.2",
- "starknet-types-core",
- "thiserror-no-std",
- "zip 0.6.6",
-]
-
-[[package]]
-name = "cairo-vm"
-version = "1.0.2"
-source = "git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell#0881dafa5440b304fb000578b6f17c0a6e5f0595"
-dependencies = [
- "anyhow",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bincode 2.0.1",
- "bitvec",
- "cairo-lang-casm",
- "cairo-lang-starknet",
- "cairo-lang-starknet-classes",
- "generic-array",
- "hashbrown 0.14.5",
- "hex",
- "keccak",
- "lazy_static",
- "nom",
- "num-bigint",
- "num-integer",
- "num-prime",
- "num-traits",
- "rand 0.8.5",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha2",
- "sha3",
- "starknet-crypto 0.6.2",
- "starknet-types-core",
- "thiserror-no-std",
- "wasm-bindgen",
+ "starknet-crypto 0.8.1",
+ "starknet-types-core 0.2.3",
+ "thiserror 2.0.12",
  "zip 0.6.6",
 ]
 
@@ -3017,7 +2788,7 @@ dependencies = [
  "katana-primitives",
  "lazy_static",
  "num-bigint",
- "reqwest 0.12.22",
+ "reqwest",
  "serde",
  "serde_json",
  "stark-vrf",
@@ -3337,12 +3108,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -3923,6 +3688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,18 +3704,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "dummy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac124e13ae9aa56acc4241f8c8207501d93afdd8d8e62f0c1f2e12f6508c65"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
 
 [[package]]
 name = "dunce"
@@ -4054,15 +3813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,39 +3845,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -4189,15 +3927,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake"
-version = "2.10.0"
+name = "expect-test"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
- "deunicode",
- "dummy",
- "rand 0.8.5",
- "serde_json",
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -4281,7 +4017,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -4462,7 +4197,7 @@ dependencies = [
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest 0.12.22",
+ "reqwest",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -4489,10 +4224,10 @@ dependencies = [
  "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "ring",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4752,7 +4487,6 @@ dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
  "rayon",
- "serde",
 ]
 
 [[package]]
@@ -4790,7 +4524,7 @@ dependencies = [
  "url",
  "walkdir",
  "which 7.0.3",
- "winreg 0.55.0",
+ "winreg",
  "zip 2.4.2",
 ]
 
@@ -4959,20 +4693,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -5313,7 +5033,7 @@ checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
- "portable-atomic 1.11.1",
+ "portable-atomic",
  "unicode-width 0.2.1",
  "web-time",
 ]
@@ -5375,6 +5095,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5492,30 +5221,6 @@ checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
  "libc",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic 1.11.1",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -5640,7 +5345,7 @@ dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5804,7 +5509,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "vergen 9.0.6",
+ "vergen",
  "vergen-gitcl",
 ]
 
@@ -5902,8 +5607,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
+ "starknet-crypto 0.7.4",
+ "starknet-types-core 0.1.8",
  "syn 2.0.104",
 ]
 
@@ -5937,7 +5642,7 @@ dependencies = [
  "rayon",
  "rstest 0.18.2",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -5971,7 +5676,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -5981,10 +5686,10 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "assert_matches",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-native",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "criterion",
  "katana-chain-spec",
  "katana-contracts",
@@ -6004,7 +5709,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "starknet",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6019,7 +5724,7 @@ dependencies = [
  "http-body 1.0.1",
  "jsonrpsee",
  "katana-runner",
- "reqwest 0.12.22",
+ "reqwest",
  "rust-embed",
  "serde",
  "serde_json",
@@ -6070,7 +5775,7 @@ dependencies = [
  "katana-utils",
  "num-traits",
  "parking_lot",
- "reqwest 0.12.22",
+ "reqwest",
  "starknet",
  "thiserror 1.0.69",
  "tokio",
@@ -6086,7 +5791,7 @@ dependencies = [
  "clap",
  "katana-gateway-types",
  "katana-primitives",
- "reqwest 0.12.22",
+ "reqwest",
  "rstest 0.18.2",
  "serde",
  "serde_json",
@@ -6153,7 +5858,7 @@ version = "1.7.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "derive_more 0.99.20",
  "katana-contracts",
  "katana-primitives",
@@ -6191,7 +5896,7 @@ dependencies = [
  "katana-chain-spec",
  "katana-pool",
  "katana-primitives",
- "reqwest 0.12.22",
+ "reqwest",
  "serde",
  "serde_json",
  "starknet",
@@ -6270,7 +5975,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6334,12 +6039,12 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "assert_matches",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "blockifier",
  "cainome-cairo-serde",
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-vm",
  "criterion",
  "derive_more 0.99.20",
  "katana-primitives-macro",
@@ -6354,8 +6059,8 @@ dependencies = [
  "serde_json_pythonic",
  "similar-asserts",
  "starknet",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet-types-core 0.2.3",
+ "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -6367,7 +6072,7 @@ version = "1.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "syn 2.0.104",
 ]
 
@@ -6400,7 +6105,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6417,7 +6122,7 @@ dependencies = [
  "katana-primitives",
  "katana-trie",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 1.0.69",
 ]
 
@@ -6529,7 +6234,7 @@ dependencies = [
  "serde_with",
  "similar-asserts",
  "starknet",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "starknet_api",
  "thiserror 1.0.69",
 ]
 
@@ -6597,7 +6302,7 @@ dependencies = [
  "rayon",
  "rstest 0.18.2",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6615,7 +6320,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "anyhow",
- "reqwest 0.12.22",
+ "reqwest",
 ]
 
 [[package]]
@@ -6669,7 +6374,7 @@ dependencies = [
  "serde",
  "slab",
  "starknet",
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
  "thiserror 1.0.69",
 ]
 
@@ -6768,7 +6473,21 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
 dependencies = [
- "lambdaworks-math",
+ "lambdaworks-math 0.10.0",
+ "serde",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "lambdaworks-crypto"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
+dependencies = [
+ "lambdaworks-math 0.13.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "sha2",
  "sha3",
@@ -6780,6 +6499,20 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lambdaworks-math"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018a95aa873eb49896a858dee0d925c33f3978d073c64b08dd4f2c9b35a017c6"
+dependencies = [
+ "getrandom 0.2.16",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
  "serde",
  "serde_json",
 ]
@@ -6840,17 +6573,6 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -7046,23 +6768,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
-dependencies = [
- "ahash 0.7.8",
- "metrics-macros",
- "portable-atomic 0.3.20",
-]
-
-[[package]]
-name = "metrics"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
 dependencies = [
  "ahash 0.8.12",
- "portable-atomic 1.11.1",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -7072,7 +6783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
 dependencies = [
  "ahash 0.8.12",
- "portable-atomic 1.11.1",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -7096,7 +6807,7 @@ dependencies = [
  "base64 0.22.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "indexmap 2.10.0",
  "ipnet",
@@ -7106,17 +6817,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7270,7 +6970,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
- "portable-atomic 1.11.1",
+ "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
 ]
@@ -7481,6 +7181,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -7616,7 +7317,7 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "opentelemetry",
- "reqwest 0.12.22",
+ "reqwest",
 ]
 
 [[package]]
@@ -7631,7 +7332,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
- "reqwest 0.12.22",
+ "reqwest",
  "thiserror 2.0.12",
  "tokio",
  "tonic 0.13.1",
@@ -7778,17 +7479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7801,65 +7491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
-name = "pathfinder-common"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "anyhow",
- "bitvec",
- "fake",
- "metrics 0.20.1",
- "num-bigint",
- "paste",
- "pathfinder-crypto",
- "primitive-types",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "tagged",
- "tagged-debug-derive",
- "thiserror 1.0.69",
- "vergen 8.3.2",
-]
-
-[[package]]
-name = "pathfinder-crypto"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "bitvec",
- "fake",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "pathfinder-serde"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "anyhow",
- "num-bigint",
- "pathfinder-common",
- "pathfinder-crypto",
- "primitive-types",
- "serde",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -8080,15 +7717,6 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
-dependencies = [
- "portable-atomic 1.11.1",
-]
-
-[[package]]
-name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
@@ -8099,7 +7727,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
- "portable-atomic 1.11.1",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -8458,39 +8086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost 0.14.1",
-]
-
-[[package]]
-name = "prove_block"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "anyhow",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cairo-lang-starknet-classes",
- "cairo-lang-utils",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "clap",
- "env_logger",
- "futures-core",
- "log",
- "num-bigint",
- "pathfinder-common",
- "pathfinder-crypto",
- "pathfinder-serde",
- "reqwest 0.11.27",
- "rpc-client",
- "rpc-replay",
- "serde",
- "serde_json",
- "serde_with",
- "starknet",
- "starknet-os",
- "starknet-os-types",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
@@ -8854,47 +8449,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
@@ -8902,20 +8456,17 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
@@ -8973,7 +8524,7 @@ dependencies = [
  "anyhow",
  "headless_chrome",
  "nix 0.30.1",
- "reqwest 0.12.22",
+ "reqwest",
  "tokio",
 ]
 
@@ -9074,39 +8625,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rpc-client"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "log",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-os",
- "starknet-types-core",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rpc-replay"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cairo-lang-starknet-classes",
- "rpc-client",
- "serde",
- "serde_json",
- "starknet",
- "starknet-os-types",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "rsb_derive"
@@ -9380,18 +8898,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -9427,7 +8933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -9443,15 +8949,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.3.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -9499,16 +8996,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -9672,16 +9159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9807,10 +9284,11 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -9823,10 +9301,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9928,19 +9415,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.10.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -10171,30 +9645,12 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "3498b0a27f93ef1402f20eefacfaa1691272ac4eca1cdc8c596cb0a245d6cbf5"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "snos-integration-test"
-version = "1.7.0"
-dependencies = [
- "anyhow",
- "c-kzg",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "either",
- "katana-chain-spec",
- "katana-messaging",
- "katana-node",
- "katana-primitives",
- "katana-provider",
- "prove_block",
- "starknet",
- "starknet-os",
- "tokio",
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -10303,14 +9759,15 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.17.0-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ed01c14136e56dcdf21385d20c4a6fdd3509947cb56cca45fc765ef5809add"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
  "starknet-core-derive",
- "starknet-crypto 0.7.4 (git+https://github.com/kariy/starknet-rs?rev=2ef3088)",
+ "starknet-crypto 0.8.1",
  "starknet-macros",
  "starknet-providers",
  "starknet-signers",
@@ -10318,13 +9775,14 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7c118729bcdcfa1610844047cbdb23090fb1d4172a36bb97a663be8d022d1a"
 dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core",
- "starknet-crypto 0.7.4 (git+https://github.com/kariy/starknet-rs?rev=2ef3088)",
+ "starknet-crypto 0.8.1",
  "starknet-providers",
  "starknet-signers",
  "thiserror 1.0.69",
@@ -10332,8 +9790,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb64331b72caf51c0d8b684b62012f9a771015b4cf5e52cba9bf61be8384ad3"
 dependencies = [
  "serde",
  "serde_json",
@@ -10346,8 +9805,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb7212226769766c1c7d79b70f9242ffbd213290a41604ecc7e78faa0ed0deb"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
@@ -10362,14 +9822,15 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-core-derive",
- "starknet-crypto 0.7.4 (git+https://github.com/kariy/starknet-rs?rev=2ef3088)",
- "starknet-types-core",
+ "starknet-crypto 0.8.1",
+ "starknet-types-core 0.2.3",
 ]
 
 [[package]]
 name = "starknet-core-derive"
 version = "0.1.0"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10410,15 +9871,16 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-curve 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
+ "starknet-curve 0.5.1",
+ "starknet-types-core 0.1.8",
  "zeroize",
 ]
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.4"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a16c25dc6113c19d4f9d0c19ff97d85804829894bba22c0d0e9e7b249812"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -10428,8 +9890,8 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-curve 0.5.1 (git+https://github.com/kariy/starknet-rs?rev=2ef3088)",
- "starknet-types-core",
+ "starknet-curve 0.6.0",
+ "starknet-types-core 0.2.3",
  "zeroize",
 ]
 
@@ -10459,15 +9921,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
 dependencies = [
- "starknet-types-core",
+ "starknet-types-core 0.1.8",
 ]
 
 [[package]]
 name = "starknet-curve"
-version = "0.5.1"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
 dependencies = [
- "starknet-types-core",
+ "starknet-types-core 0.2.3",
 ]
 
 [[package]]
@@ -10485,113 +9948,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-gateway-types"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "anyhow",
- "fake",
- "pathfinder-common",
- "pathfinder-crypto",
- "pathfinder-serde",
- "primitive-types",
- "rand 0.8.5",
- "reqwest 0.12.22",
- "rstest 0.18.2",
- "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "starknet-macros"
-version = "0.2.5-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d59e1eb22f4366385b132ba7016faa5a6457f1f23f896f737a06da626455e7b"
 dependencies = [
  "starknet-core",
  "syn 2.0.104",
 ]
 
 [[package]]
-name = "starknet-os"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "anyhow",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-secp256k1 0.4.0",
- "ark-secp256r1 0.4.0",
- "base64 0.21.7",
- "bitvec",
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "c-kzg",
- "cairo-lang-casm",
- "cairo-lang-starknet",
- "cairo-lang-starknet-classes",
- "cairo-type-derive",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "futures",
- "futures-util",
- "heck 0.4.1",
- "hex",
- "indexmap 2.10.0",
- "indoc",
- "keccak",
- "lazy_static",
- "log",
- "num-bigint",
- "num-integer",
- "num-traits",
- "pathfinder-common",
- "pathfinder-crypto",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml",
- "sha2",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-gateway-types",
- "starknet-os-types",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
- "uuid 1.17.0",
- "zip 0.6.6",
-]
-
-[[package]]
-name = "starknet-os-types"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/snos?rev=c96eb9e#c96eb9e433c89da1a12a8a8474a30e6590431662"
-dependencies = [
- "blockifier 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "cairo-lang-starknet-classes",
- "cairo-vm 1.0.2 (git+https://github.com/kariy/cairo-vm?branch=kariy%2F1.0.2_clear-cell)",
- "flate2",
- "num-bigint",
- "once_cell",
- "serde",
- "serde_json",
- "serde_with",
- "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-gateway-types",
- "starknet-types-core",
- "starknet_api 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "starknet-providers"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fc3d94cc008cea64e291b261e8349065424ee7491e5dd0fa9bd688818bece1"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -10599,7 +9969,7 @@ dependencies = [
  "flate2",
  "getrandom 0.2.16",
  "log",
- "reqwest 0.12.22",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",
@@ -10610,8 +9980,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.14.0-rc.2"
-source = "git+https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887a2be68b6aa4514d6b56ba12fcb3988be"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d839b06d899ef3a0de11b1e9a91a14c118b1ed36830ec8e59d9fbc9a1e51976b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -10620,7 +9991,7 @@ dependencies = [
  "getrandom 0.2.16",
  "rand 0.8.5",
  "starknet-core",
- "starknet-crypto 0.7.4 (git+https://github.com/kariy/starknet-rs?rev=2ef3088)",
+ "starknet-crypto 0.8.1",
  "thiserror 1.0.69",
 ]
 
@@ -10629,10 +10000,8 @@ name = "starknet-types-core"
 version = "0.1.8"
 source = "git+https://github.com/kariy/types-rs?rev=0f6ae31#0f6ae31a5a19352cc99b74604fab15cd9d1bb76e"
 dependencies = [
- "arbitrary",
- "lambdaworks-crypto",
- "lambdaworks-math",
- "lazy_static",
+ "lambdaworks-crypto 0.10.0",
+ "lambdaworks-math 0.10.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -10643,49 +10012,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet_api"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=4b1587c5e#4b1587c5e3effc4cfbbb8551cdcab6454a2dbe30"
+name = "starknet-types-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab92594a86ac627dd4c8d3350362cc8035e55c548c27c71dfa4c9fc6b3b6ab1a"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=4b1587c5e)",
- "base64 0.13.1",
- "bitvec",
- "cached",
- "cairo-lang-runner",
- "cairo-lang-starknet-classes",
- "derive_more 0.99.20",
- "flate2",
- "hex",
- "indexmap 2.10.0",
- "itertools 0.12.1",
+ "arbitrary",
+ "blake2",
+ "digest 0.10.7",
+ "lambdaworks-crypto 0.13.0",
+ "lambdaworks-math 0.13.0",
+ "lazy_static",
  "num-bigint",
+ "num-integer",
  "num-traits",
- "pretty_assertions",
- "primitive-types",
- "rand 0.8.5",
- "semver 1.0.26",
+ "rand 0.9.2",
  "serde",
- "serde_json",
- "sha3",
  "size-of",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
 name = "starknet_api"
-version = "0.0.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=5d737b9c9#5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2"
+version = "0.16.0-rc.0"
+source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
 dependencies = [
- "apollo_infra_utils 0.0.0 (git+https://github.com/dojoengine/sequencer?rev=5d737b9c9)",
+ "apollo_infra_utils",
  "base64 0.13.1",
  "bitvec",
  "cached",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
+ "cairo-lang-utils",
  "derive_more 0.99.20",
  "flate2",
  "hex",
@@ -10701,11 +10059,12 @@ dependencies = [
  "serde_json",
  "sha3",
  "size-of",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
+ "starknet-crypto 0.8.1",
+ "starknet-types-core 0.2.3",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]
@@ -10910,45 +10269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tagged"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "fake",
-]
-
-[[package]]
-name = "tagged-debug-derive"
-version = "0.14.3"
-source = "git+https://github.com/Moonsong-Labs/pathfinder?rev=9c19d9a37be8f447ec4548456c440ccbd0e44260#9c19d9a37be8f447ec4548456c440ccbd0e44260"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11032,26 +10352,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
 ]
 
 [[package]]
@@ -11192,16 +10492,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
@@ -11310,7 +10600,7 @@ dependencies = [
  "pin-project 1.1.10",
  "prost 0.12.6",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -11642,10 +10932,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -11744,12 +11064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11800,7 +11114,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "rustls 0.23.31",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
@@ -11871,9 +11185,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.3",
  "js-sys",
- "serde",
  "wasm-bindgen",
 ]
 
@@ -11923,24 +11235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "8.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
-dependencies = [
- "anyhow",
- "cfg-if",
- "rustversion",
- "time",
-]
-
-[[package]]
 name = "vergen"
 version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11967,7 +11261,7 @@ dependencies = [
  "derive_builder",
  "rustversion",
  "time",
- "vergen 9.0.6",
+ "vergen",
  "vergen-lib",
 ]
 
@@ -11987,6 +11281,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -12166,12 +11466,6 @@ checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -12773,16 +12067,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -12859,6 +12143,12 @@ name = "xshell-macros"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "xz2"
@@ -12999,18 +12289,10 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2 0.4.4",
- "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -13021,8 +12303,8 @@ checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
  "arbitrary",
- "bzip2 0.5.2",
- "constant_time_eq 0.3.1",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
@@ -13040,7 +12322,7 @@ dependencies = [
  "xz2",
  "zeroize",
  "zopfli",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -13057,30 +12339,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda689f7287f15bd3582daba6be8d1545bad3740fd1fb778f629a1fe866bb43b"
+checksum = "f3dcd2b4e208ce5477de90ccdcbd4bde2c8fb06af49a443974e92bb8f2c5e93f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -91,6 +91,7 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -99,15 +100,16 @@ dependencies = [
  "rand 0.8.5",
  "secp256k1",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5659581e41e8fe350ecc3593cb5c9dcffddfd550896390f2b78a07af67b0fa"
+checksum = "ee5655f234985f5ab1e31bef7e02ed11f0a899468cf3300e061e1b96e9e11de0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -119,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.23"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28074a21cd4f7c3a7ab218c4f38fae6be73944e1feae3b670c68b60bf85ca40"
+checksum = "7f01b6d8e5b4f3222aaf7f18613a7292e2fbc9163fe120649cd1b078ca534349"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -141,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e8a436f0aad7df8bb47f144095fba61202265d9f5f09a70b0e3227881a668e"
+checksum = "369f5707b958927176265e8a58627fc6195e5dfa5c55689396e68b241b3a72e6"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -170,32 +172,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35887da30b5fc50267109a3c61cd63e6ca1f45967983641053a40ee83468c1"
+checksum = "6847d641141b92a1557094aa6c236cbe49c06fb24144d4a21fe6acb970c15888"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -204,18 +208,21 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
  "serde",
+ "serde_with",
  "sha2",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d4009efea6f403b3a80531f9c6f70fc242399498ff71196a1688cc1c901f44"
+checksum = "fe3192fca2eb0b0c4b122b3c2d8254496b88a4e810558dddd3ea2f30ad9469df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -239,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
+checksum = "84e3cf01219c966f95a460c95f1d4c30e12f6c18150c21a30b768af2a2a29142"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -251,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883dee3b4020fcb5667ee627b4f401e899dad82bf37b246620339dd980720ed9"
+checksum = "d4ab3330e491053e9608b2a315f147357bb8acb9377a988c1203f2e8e2b296c9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -266,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6e5b8ac1654a05c224390008e43634a2bdc74e181e02cf8ed591d8b3d4ad08"
+checksum = "c1e22ff194b1e34b4defd1e257e3fe4dce0eee37451c7757a1510d6b23e7379a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -292,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7980333dd9391719756ac28bc2afa9baa705fc70ffd11dc86ab078dd64477"
+checksum = "b8a6cbb9f431bdad294eebb5af9b293d6979e633bfe5468d1e87c1421a858265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -305,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984c20af8aee7d123bb4bf40cf758b362b38cb9ff7160d986b6face604a1e6a9"
+checksum = "7e9e5dae7d2be44904dba55bb8b538e5de89fdb9e50b3f0f163277b729285011"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -326,19 +333,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfebde8c581a5d37b678d0a48a32decb51efd7a63a08ce2517ddec26db705c8"
+checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_arbitrary",
  "derive_more 2.0.1",
- "foldhash",
- "hashbrown 0.15.4",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
  "indexmap 2.10.0",
  "itoa",
  "k256",
@@ -347,6 +353,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.9.2",
+ "rapidhash",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -356,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.23"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59879a772ebdcde9dc4eb38b2535d32e8503d3175687cc09e763a625c5fcf32"
+checksum = "3f5dde1abc3d582e53d139904fcdd8b2103f0bd03e8f2acb4292edbbaeaa7e6e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -382,7 +389,6 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "http 1.3.1",
  "lru 0.13.0",
  "parking_lot",
  "pin-project 1.1.10",
@@ -420,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.23"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f060e3bb9f319eb01867a2d6d1ff9e0114e8877f5ca8f5db447724136106cae"
+checksum = "5a94bdef2710322c6770be08689fee0878c2ad75615b8fc40e05d7f3c9618c0b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -443,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10493fa300a2757d8134f584800fef545c15905c95122bed1f6dde0b0d9dae27"
+checksum = "838ca94be532a929f27961851000ec8bbbaeb06e2a2bcca44fac7855a2fe0f6f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -455,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7eb22670a972ad6c222a6c6dac3eef905579acffe9d63ab42be24c7d158535"
+checksum = "12df0b34551ca2eab8ec83b56cb709ee5da991737282180d354a659b907f00dc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -466,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b777b98526bbe5b7892ca22a7fd5f18ed624ff664a79f40d0f9f2bf94ba79a84"
+checksum = "b7f9f130511b8632686dfe6f9909b38d7ae4c68de3ce17d28991400646a39b25"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -487,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8d2c52adebf3e6494976c8542fbdf12f10123b26e11ad56f77274c16a2a039"
+checksum = "067b718d2e6ac1bb889341fcc7a250cfa49bcd3ba4f23923f1c1eb1f2b10cb7c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -498,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0494d1e0f802716480aabbe25549c7f6bc2a25ff33b08fd332bbb4b7d06894"
+checksum = "acff6b251740ef473932386d3b71657d3825daebf2217fb41a7ef676229225d4"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -513,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c2435eb8979a020763ced3fb478932071c56e5f75ea86db41f320915d325ba"
+checksum = "c9129ef31975d987114c27c9930ee817cf3952355834d47f2fdf4596404507e8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -529,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
+checksum = "09eb18ce0df92b4277291bbaa0ed70545d78b02948df756bbd3d6214bf39a218"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -543,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
+checksum = "95d9fa2daf21f59aa546d549943f10b5cce1ae59986774019fbedae834ffe01b"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -562,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
+checksum = "9396007fe69c26ee118a19f4dee1f5d1d6be186ea75b3881adf16d87f8444686"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -580,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
+checksum = "af67a0b0dcebe14244fc92002cd8d96ecbf65db4639d479f5fcd5805755a4c27"
 dependencies = [
  "serde",
  "winnow",
@@ -590,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
+checksum = "09aeea64f09a7483bdcd4193634c7e5cf9fd7775ee767585270cd8ce2d69dc95"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -602,12 +608,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.23"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89bec2f59a41c0e259b6fe92f78dfc49862c17d10f938db9c33150d5a7f42b6"
+checksum = "bec1fb08ee484e615f24867c0b154fff5722bb00176102a16868c6532b7c3623"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "auto_impl",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -625,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.23"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3615ec64d775fec840f4e9d5c8e1f739eb1854d8d28db093fb3d4805e0cb53"
+checksum = "64b722073c76f2de7e118d546ee1921c50710f97feb32aed50db94cfa5b663e1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -656,12 +662,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acb36318dfa50817154064fea7932adf2eec3f51c86680e2b37d7e8906c66bb"
+checksum = "04950a13cc4209d8e9b78f306e87782466bad8538c94324702d061ff03e211c9"
 dependencies = [
- "alloy-primitives",
- "darling 0.20.11",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3373,6 +3378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +3416,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim 0.11.1",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,6 +3448,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.104",
 ]
@@ -4033,6 +4074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,8 +4544,19 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7962,9 +8020,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8305,6 +8363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2988730ee014541157f48ce4dcc603940e00915edc3c7f9a8d78092256bb2493"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -9812,7 +9879,7 @@ dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
  "flate2",
- "foldhash",
+ "foldhash 0.1.5",
  "hex",
  "indexmap 2.10.0",
  "num-traits",
@@ -10205,9 +10272,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
+checksum = "5f92d01b5de07eaf324f7fca61cc6bd3d82bbc1de5b6c963e6fe79e86f36580d"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "bonsai-trie"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/bonsai-trie/?rev=95de4c6#95de4c600f20cec326650364dea841d23cf93718"
+source = "git+https://github.com/dojoengine/bonsai-trie/?rev=351d5be#351d5be7918b1d9b7e6057f7903fd9eb571cfbcf"
 dependencies = [
  "bitvec",
  "derive_more 0.99.20",
@@ -1836,7 +1836,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
- "starknet-types-core 0.1.8",
+ "starknet-types-core 0.2.3",
  "thiserror 2.0.12",
 ]
 
@@ -10072,7 +10072,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "parity-scale-codec",
  "serde",
  "size-of",
  "zeroize",
@@ -10093,6 +10092,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "parity-scale-codec",
  "rand 0.9.2",
  "serde",
  "size-of",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ members = [
 	"crates/utils",
 	"tests/db-compat",
 	"tests/reverse-proxy",
-	"tests/snos",
+	# "tests/snos",
 ]
 
 [workspace.package]
@@ -113,13 +113,13 @@ katana-trie = { path = "crates/trie" }
 katana-utils = { path = "crates/utils" }
 
 # cairo-lang
-cairo-lang-casm = "2.11.2"
-cairo-lang-runner = "2.11.2"
-cairo-lang-sierra = "2.11.2"
-cairo-lang-sierra-to-casm = "2.11.2"
-cairo-lang-starknet = "2.11.2"
-cairo-lang-starknet-classes = "2.11.2"
-cairo-lang-utils = "2.11.2"
+cairo-lang-casm = "2.12.3"
+cairo-lang-runner = "2.12.3"
+cairo-lang-sierra = "2.12.3"
+cairo-lang-sierra-to-casm = "2.12.3"
+cairo-lang-starknet = "2.12.3"
+cairo-lang-starknet-classes = "2.12.3"
+cairo-lang-utils = "2.12.3"
 
 anyhow = "1.0.89"
 arbitrary = { version = "1.3.2", features = [ "derive" ] }
@@ -226,21 +226,20 @@ opentelemetry-http = "0.30.0"
 opentelemetry-stackdriver = { version = "0.27.0", features = [ "propagator" ] }
 
 # starknet
-starknet = "0.17.0-rc.2"
-starknet-types-core = { version = "0.1.8", features = [ "arbitrary", "hash" ] }
+starknet = "0.17.0"
+starknet-types-core = { version = "0.2", features = [ "arbitrary", "hash" ] }
 # Some types that we used from cairo-vm implements the `Arbitrary` trait,
 # only under the `test_utils` feature.
-cairo-vm = { version = "1.0.2", features = [ "test_utils" ] }
+cairo-vm = { version = "2.5.0", features = [ "test_utils" ] }
 
-blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "5d737b9c9", default-features = false }
-starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "5d737b9c9" }
+blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb", default-features = false }
+starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb" }
 
 cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1", features = [ "abigen-rs" ] }
 cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1" }
 piltover = { git = "https://github.com/kariy/piltover.git", branch = "feat/rpc0.9" }
 
 [patch.crates-io]
-starknet = { git = "https://github.com/kariy/starknet-rs", rev = "2ef3088" }
 # NOTE: remove this patch once this PR is merged <https://github.com/starknet-io/types-rs/pull/132>
 #
 # This patch fixes an issue where we're unable to correctly evaluate the accurate size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ starknet-types-core = { version = "0.2", features = [ "arbitrary", "hash" ] }
 # only under the `test_utils` feature.
 cairo-vm = { version = "2.5.0", features = [ "test_utils" ] }
 
+# branch: blockifier/v0.16.0-rc.0
 blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb", default-features = false }
 starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,15 +196,15 @@ criterion = "0.5.1"
 pprof = { version = "0.13.0", features = [ "criterion", "flamegraph" ] }
 
 # alloys
-alloy-contract = { version = "1.0", default-features = false }
-alloy-network = { version = "1.0", default-features = false }
-alloy-primitives = { version = "1.0", default-features = false }
-alloy-provider = { version = "1.0", default-features = false }
-alloy-rpc-types-eth = { version = "1.0", default-features = false }
-alloy-signer = { version = "1.0", default-features = false }
-alloy-sol-types = { version = "1.0", default-features = false }
-alloy-transport = { version = "1.0", default-features = false }
-alloy-transport-http = { version = "1.0", default-features = false }
+alloy-contract = { version = "1.2", default-features = false }
+alloy-network = { version = "1.2", default-features = false }
+alloy-primitives = { version = "1.2", default-features = false }
+alloy-provider = { version = "1.2", default-features = false }
+alloy-rpc-types-eth = { version = "1.2", default-features = false }
+alloy-signer = { version = "1.2", default-features = false }
+alloy-sol-types = { version = "1.2", default-features = false }
+alloy-transport = { version = "1.2", default-features = false }
+alloy-transport-http = { version = "1.2", default-features = false }
 
 # macro
 proc-macro2 = "1.0"

--- a/bin/katana/src/cli/db/prune.rs
+++ b/bin/katana/src/cli/db/prune.rs
@@ -108,8 +108,8 @@ fn prune_database(db_path: &str, mode: PruneMode) -> Result<()> {
 
             if blocks > latest_block {
                 eprintln!(
-                    "Warning: Requested to keep {} blocks, but only {} blocks exist",
-                    blocks, latest_block
+                    "Warning: Requested to keep {blocks} blocks, but only {latest_block} blocks \
+                     exist"
                 );
                 return Ok(());
             }
@@ -123,7 +123,7 @@ fn prune_database(db_path: &str, mode: PruneMode) -> Result<()> {
             }
 
             prune_keep_last_n(&tx, cutoff_block)?;
-            println!("Pruned historical data for blocks 0 to {}", cutoff_block);
+            println!("Pruned historical data for blocks 0 to {cutoff_block}");
         }
     }
 
@@ -456,7 +456,7 @@ fn show_confirmation_prompt(stats: &PruningStats, mode: &PruneMode) -> Result<bo
             println!("- Action: Remove ALL historical data, keeping only the latest state");
         }
         PruneMode::KeepLastN { blocks } => {
-            println!("- Action: Keep only the last {} blocks of historical data", blocks);
+            println!("- Action: Keep only the last {blocks} blocks of historical data");
         }
     }
 

--- a/bin/katana/src/cli/init/deployment.rs
+++ b/bin/katana/src/cli/init/deployment.rs
@@ -126,6 +126,8 @@ pub async fn deploy_settlement_contract(
         sp.update_text("Deploying contract...");
 
         let salt = Felt::from(rand::random::<u64>());
+
+        #[allow(deprecated)]
         let factory = ContractFactory::new(class_hash, &account);
 
         const INITIAL_STATE_ROOT: Felt = Felt::ZERO;

--- a/bin/katana/src/cli/init/prompt.rs
+++ b/bin/katana/src/cli/init/prompt.rs
@@ -199,7 +199,7 @@ fn prompt_slot_paymasters() -> Result<Option<Vec<slot::PaymasterAccountArgs>>> {
 
     // Prompt for slot paymaster accounts
     while Confirm::new("Add Slot paymaster account?").with_default(true).prompt()? {
-        let pubkey_prompt_text = format!("Paymaster #{} public key", paymaster_count);
+        let pubkey_prompt_text = format!("Paymaster #{paymaster_count} public key");
         let public_key = CustomType::<Felt>::new(&pubkey_prompt_text)
             .with_formatter(&|input: Felt| format!("{input:#x}"))
             .prompt()?;
@@ -223,7 +223,7 @@ fn prompt_slot_paymasters() -> Result<Option<Vec<slot::PaymasterAccountArgs>>> {
             }
         };
 
-        let salt_prompt_text = format!("Paymaster #{} salt", paymaster_count);
+        let salt_prompt_text = format!("Paymaster #{paymaster_count} salt");
         let salt = CustomType::<Felt>::new(&salt_prompt_text)
             .with_formatter(&|input: Felt| format!("{input:#x}"))
             .with_validator(unique_salt_validator)

--- a/bin/katana/src/cli/rpc/starknet.rs
+++ b/bin/katana/src/cli/rpc/starknet.rs
@@ -478,7 +478,7 @@ impl StarknetCommands {
                             .enumerate()
                             .map(|(i, s)| {
                                 s.trim().parse::<ClassHash>().with_context(|| {
-                                    format!("Invalid class hash at position {}: '{}'", i, s)
+                                    format!("Invalid class hash at position {i}: '{s}'")
                                 })
                             })
                             .collect::<Result<Vec<_>>>()?,
@@ -498,7 +498,7 @@ impl StarknetCommands {
                             .enumerate()
                             .map(|(i, s)| {
                                 s.trim().parse::<ContractAddress>().with_context(|| {
-                                    format!("Invalid contract address at position {}: '{}'", i, s)
+                                    format!("Invalid contract address at position {i}: '{s}'")
                                 })
                             })
                             .collect::<Result<Vec<_>>>()?,
@@ -613,7 +613,7 @@ fn parse_event_keys(keys: &[String]) -> Result<Vec<Vec<Felt>>> {
                 .map(|s| {
                     s.trim()
                         .parse::<Felt>()
-                        .with_context(|| format!("invalid felt in key group {}: '{}'", i, s))
+                        .with_context(|| format!("invalid felt in key group {i}: '{s}'"))
                 })
                 .collect::<Result<Vec<Felt>>>()
         })

--- a/bin/katana/src/cli/version.rs
+++ b/bin/katana/src/cli/version.rs
@@ -28,7 +28,7 @@ pub fn generate_long() -> String {
     writeln!(out, "{}", generate_short()).unwrap();
     writeln!(out).unwrap();
     writeln!(out, "features: {}", features().join(",")).unwrap();
-    write!(out, "built on: {}", VERGEN_BUILD_TIMESTAMP).unwrap();
+    write!(out, "built on: {VERGEN_BUILD_TIMESTAMP}").unwrap();
     out
 }
 

--- a/crates/cartridge/build.rs
+++ b/crates/cartridge/build.rs
@@ -56,9 +56,9 @@ fn main() {
             let struct_name = filename_to_struct_name(&file_name);
 
             generated_code.push_str(&format!(
-                "::katana_contracts::contract!(\n    {},\n    \
-                 \"{{CARGO_MANIFEST_DIR}}/controller/account_sdk/artifacts/classes/{}.json\"\n);\n",
-                struct_name, file_name
+                "::katana_contracts::contract!(\n    {struct_name},\n    \
+                 \"{{CARGO_MANIFEST_DIR}}/controller/account_sdk/artifacts/classes/{file_name}.\
+                 json\"\n);\n"
             ));
         }
     }

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -807,6 +807,6 @@ fn parse_pruning_mode(s: &str) -> Result<PruningMode, String> {
                 })?;
             Ok(PruningMode::Full(n))
         }
-        _ => Err(format!("Invalid pruning mode '{}'. Valid modes are: 'archive', 'full:N'", s)),
+        _ => Err(format!("Invalid pruning mode '{s}'. Valid modes are: 'archive', 'full:N'")),
     }
 }

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -138,9 +138,8 @@ PREDEPLOYED CONTRACTS
     println!(
         r"
 | Contract        | Universal Deployer
-| Address         | {}
-| Class Hash      | {:#064x}",
-        DEFAULT_UDC_ADDRESS, DEFAULT_LEGACY_UDC_CLASS_HASH
+| Address         | {DEFAULT_UDC_ADDRESS}
+| Class Hash      | {DEFAULT_LEGACY_UDC_CLASS_HASH:#064x}"
     );
 
     if let Some(hash) = account_class_hash {

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -57,20 +57,19 @@ fn main() {
 
         panic!(
             "Contract compilation build script failed. Below are the last 50 lines of `scarb \
-             build` output:\n\n{}",
-            last_n_lines
+             build` output:\n\n{last_n_lines}"
         );
     }
 
     // Create build directory if it doesn't exist
     if let Err(e) = fs::create_dir_all(build_dir) {
-        panic!("Failed to create build directory: {}", e);
+        panic!("Failed to create build directory: {e}");
     }
 
     // Copy artifacts from target/dev to build directory
     if target_dir.exists() {
         if let Err(e) = copy_dir_contents(&target_dir, build_dir) {
-            panic!("Failed to copy contract artifacts: {}", e);
+            panic!("Failed to copy contract artifacts: {e}");
         }
         println!("cargo:warning=Contract artifacts copied to build directory");
     } else {

--- a/crates/contracts/macro/src/lib.rs
+++ b/crates/contracts/macro/src/lib.rs
@@ -111,14 +111,14 @@ fn generate_contract_impl(input: &ContractInput) -> Result<proc_macro2::TokenStr
 
     // Compute class hash
     let class_hash =
-        contract_class.class_hash().map_err(|e| format!("failed to compute class hash: {}", e))?;
+        contract_class.class_hash().map_err(|e| format!("failed to compute class hash: {e}"))?;
 
     // Compile and compute compiled class hash
     let compiled_class =
-        contract_class.compile().map_err(|e| format!("failed to compile contract class: {}", e))?;
+        contract_class.compile().map_err(|e| format!("failed to compile contract class: {e}"))?;
 
     let compiled_class_hash =
-        compiled_class.class_hash().map_err(|e| format!("failed to compute casm hash: {}", e))?;
+        compiled_class.class_hash().map_err(|e| format!("failed to compute casm hash: {e}"))?;
 
     // Convert Felt values to string representation for const generation
     let class_hash_str = format!("{class_hash:#x}",);

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -19,7 +19,7 @@ tracing.workspace = true
 
 # cairo-native
 cairo-lang-starknet-classes = { workspace = true, optional = true }
-cairo-native = { version = "0.4.1", optional = true }
+cairo-native = { version = "0.6.2", optional = true }
 cairo-vm.workspace = true
 parking_lot.workspace = true
 rayon = { workspace = true, optional = true }

--- a/crates/executor/src/implementation/blockifier/cache.rs
+++ b/crates/executor/src/implementation/blockifier/cache.rs
@@ -277,7 +277,7 @@ impl ClassCache {
                         let _span = span.enter();
 
                         let executor =
-                            AotContractExecutor::new(&program, &entry_points, version.into(), OptLevel::Default)
+                            AotContractExecutor::new(&program, &entry_points, version.into(), OptLevel::Default, None)
                                 .inspect_err(|error| tracing::error!(target: "class_cache", %error, "Failed to compile native class"))
                                 .unwrap();
 

--- a/crates/executor/src/implementation/blockifier/call.rs
+++ b/crates/executor/src/implementation/blockifier/call.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use blockifier::blockifier_versioned_constants::VersionedConstants;
-use blockifier::bouncer::n_steps_to_sierra_gas;
+use blockifier::bouncer::n_steps_to_gas;
 use blockifier::context::{BlockContext, TransactionContext};
 use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::entry_point::{
@@ -138,9 +138,7 @@ pub fn get_call_sierra_gas_consumed(
         // steps to sierra gas.
         //
         // https://github.com/dojoengine/sequencer/blob/5d737b9c90a14bdf4483d759d1a1d4ce64aa9fd2/crates/blockifier/src/execution/entry_point_execution.rs#L475-L479
-        TrackedResource::CairoSteps => {
-            n_steps_to_sierra_gas(info.resources.n_steps, versioned_constant).0
-        }
+        TrackedResource::CairoSteps => n_steps_to_gas(info.resources.n_steps, versioned_constant).0,
 
         TrackedResource::SierraGas => info.execution.gas_consumed,
     }

--- a/crates/executor/src/implementation/blockifier/error.rs
+++ b/crates/executor/src/implementation/blockifier/error.rs
@@ -46,6 +46,12 @@ impl From<EntryPointExecutionError> for ExecutionError {
     }
 }
 
+impl From<Box<EntryPointExecutionError>> for ExecutionError {
+    fn from(error: Box<EntryPointExecutionError>) -> Self {
+        Self::from(*error)
+    }
+}
+
 impl From<PreExecutionError> for ExecutionError {
     fn from(error: PreExecutionError) -> Self {
         match error {
@@ -77,6 +83,12 @@ impl From<TransactionPreValidationError> for ExecutionError {
     }
 }
 
+impl From<Box<TransactionPreValidationError>> for ExecutionError {
+    fn from(error: Box<TransactionPreValidationError>) -> Self {
+        Self::from(*error)
+    }
+}
+
 impl From<TransactionFeeError> for ExecutionError {
     fn from(error: TransactionFeeError) -> Self {
         match error {
@@ -89,6 +101,12 @@ impl From<TransactionFeeError> for ExecutionError {
             TransactionFeeError::StateError(e) => Self::from(e),
             e => Self::Other(e.to_string()),
         }
+    }
+}
+
+impl From<Box<TransactionFeeError>> for ExecutionError {
+    fn from(error: Box<TransactionFeeError>) -> Self {
+        Self::from(*error)
     }
 }
 

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 // Re-export the blockifier crate.
 pub use blockifier;
 use blockifier::blockifier_versioned_constants::VersionedConstants;
-use blockifier::bouncer::{n_steps_to_sierra_gas, Bouncer, BouncerConfig, BouncerWeights};
+use blockifier::bouncer::{n_steps_to_gas, Bouncer, BouncerConfig, BouncerWeights};
 
 pub mod cache;
 pub mod call;
@@ -144,9 +144,9 @@ impl<'a> StarknetVMProcessor<'a> {
         //
         // To learn more about the L2 gas, refer to <https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257>.
         block_max_capacity.sierra_gas =
-            n_steps_to_sierra_gas(limits.cairo_steps as usize, block_context.versioned_constants());
+            n_steps_to_gas(limits.cairo_steps as usize, block_context.versioned_constants());
 
-        let bouncer = Bouncer::new(BouncerConfig { block_max_capacity });
+        let bouncer = Bouncer::new(BouncerConfig { block_max_capacity, ..Default::default() });
 
         Self {
             cfg_env,

--- a/crates/executor/src/implementation/blockifier/utils.rs
+++ b/crates/executor/src/implementation/blockifier/utils.rs
@@ -141,6 +141,7 @@ pub fn transact<S: StateReader>(
                     &tx_state,
                     &tx_state_changes_keys,
                     &info.summarize(versioned_constants),
+                    &info.summarize_builtins(),
                     &info.receipt.resources,
                     versioned_constants,
                 )?;
@@ -205,7 +206,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     tx: ApiInvokeTransaction::V0(starknet_api::transaction::InvokeTransactionV0 {
                         entry_point_selector: EntryPointSelector(tx.entry_point_selector),
                         contract_address: to_blk_address(tx.contract_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         calldata: Calldata(Arc::new(calldata)),
                         max_fee: Fee(tx.max_fee),
                     }),
@@ -227,7 +228,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         max_fee: Fee(tx.max_fee),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         calldata: Calldata(Arc::new(calldata)),
                     }),
                     tx_hash: TransactionHash(hash),
@@ -253,7 +254,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         tip: Tip(tx.tip),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         calldata: Calldata(Arc::new(calldata)),
                         paymaster_data: PaymasterData(paymaster_data),
                         account_deployment_data: AccountDeploymentData(account_deploy_data),
@@ -283,7 +284,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     tx: ApiDeployAccountTransaction::V1(DeployAccountTransactionV1 {
                         max_fee: Fee(tx.max_fee),
                         nonce: Nonce(tx.nonce),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         constructor_calldata: Calldata(Arc::new(calldata)),
                         contract_address_salt: salt,
@@ -311,7 +312,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     tx: ApiDeployAccountTransaction::V3(DeployAccountTransactionV3 {
                         tip: Tip(tx.tip),
                         nonce: Nonce(tx.nonce),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         constructor_calldata: Calldata(Arc::new(calldata)),
                         contract_address_salt: salt,
@@ -338,7 +339,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     max_fee: Fee(tx.max_fee),
                     nonce: Nonce::default(),
                     sender_address: to_blk_address(tx.sender_address),
-                    signature: TransactionSignature(tx.signature),
+                    signature: TransactionSignature(tx.signature.into()),
                     class_hash: ClassHash(tx.class_hash),
                 }),
 
@@ -346,7 +347,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                     max_fee: Fee(tx.max_fee),
                     nonce: Nonce(tx.nonce),
                     sender_address: to_blk_address(tx.sender_address),
-                    signature: TransactionSignature(tx.signature),
+                    signature: TransactionSignature(tx.signature.into()),
                     class_hash: ClassHash(tx.class_hash),
                 }),
 
@@ -357,7 +358,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         max_fee: Fee(tx.max_fee),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         compiled_class_hash: CompiledClassHash(tx.compiled_class_hash),
                     })
@@ -376,7 +377,7 @@ pub fn to_executor_tx(mut tx: ExecutableTxWithHash, mut flags: ExecutionFlags) -
                         tip: Tip(tx.tip),
                         nonce: Nonce(tx.nonce),
                         sender_address: to_blk_address(tx.sender_address),
-                        signature: TransactionSignature(signature),
+                        signature: TransactionSignature(signature.into()),
                         class_hash: ClassHash(tx.class_hash),
                         account_deployment_data: AccountDeploymentData(account_deploy_data),
                         compiled_class_hash: CompiledClassHash(tx.compiled_class_hash),
@@ -481,7 +482,8 @@ pub fn block_context_from_envs(
         use_kzg_da: false,
     };
 
-    let chain_info = ChainInfo { fee_token_addresses, chain_id: to_blk_chain_id(chain_spec.id()) };
+    let chain_info =
+        ChainInfo { fee_token_addresses, chain_id: to_blk_chain_id(chain_spec.id()), is_l3: false };
 
     // IMPORTANT:
     //

--- a/crates/executor/src/utils.rs
+++ b/crates/executor/src/utils.rs
@@ -13,15 +13,17 @@ pub(crate) const LOG_TARGET: &str = "executor";
 pub fn log_resources(resources: &TransactionResources) {
     let mut mapped_strings = Vec::new();
 
-    for (builtin, count) in &resources.computation.vm_resources.builtin_instance_counter {
+    for (builtin, count) in &resources.computation.tx_vm_resources.builtin_instance_counter {
         mapped_strings.push(format!("{builtin}: {count}"));
     }
 
     // Sort the strings alphabetically
     mapped_strings.sort();
-    mapped_strings.insert(0, format!("steps: {}", resources.computation.vm_resources.n_steps));
-    mapped_strings
-        .insert(1, format!("memory holes: {}", resources.computation.vm_resources.n_memory_holes));
+    mapped_strings.insert(0, format!("steps: {}", resources.computation.tx_vm_resources.n_steps));
+    mapped_strings.insert(
+        1,
+        format!("memory holes: {}", resources.computation.tx_vm_resources.n_memory_holes),
+    );
 
     trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Transaction resource usage.");
 }
@@ -74,7 +76,7 @@ pub(crate) fn build_receipt(
 }
 
 fn get_receipt_resources(receipt: &TransactionReceipt) -> receipt::ExecutionResources {
-    let computation_resources = receipt.resources.computation.vm_resources.clone();
+    let computation_resources = receipt.resources.computation.tx_vm_resources.clone();
 
     let gas = GasUsed {
         l2_gas: receipt.gas.l2_gas.0,

--- a/crates/explorer/build.rs
+++ b/crates/explorer/build.rs
@@ -84,7 +84,7 @@ fn build_ui_assets(ui_dir: &Path) {
             return;
         }
         Err(e) => {
-            eprintln!("Warning: Failed to run bun install: {}", e);
+            eprintln!("Warning: Failed to run bun install: {e}");
             return;
         }
     }
@@ -105,7 +105,7 @@ fn build_ui_assets(ui_dir: &Path) {
             eprintln!("Warning: Failed to build UI in {}", ui_dir.display());
         }
         Err(e) => {
-            eprintln!("Warning: Failed to run bun build: {}", e);
+            eprintln!("Warning: Failed to run bun build: {e}");
         }
     }
 }

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -564,7 +564,7 @@ impl<S> ExplorerService<S> {
         };
 
         if let Some(asset) = EmbeddedAssets::get(asset_path) {
-            let content_type = Self::get_content_type(&format!("/{}", asset_path));
+            let content_type = Self::get_content_type(&format!("/{asset_path}"));
             let content = if content_type == "text/html" {
                 let html = String::from_utf8_lossy(&asset.data);
                 let injected = Self::inject_environment(config, &html);
@@ -640,9 +640,9 @@ impl<S> ExplorerService<S> {
 
         if let Some(head_pos) = html.find("<head>") {
             let (start, end) = html.split_at(head_pos + 6);
-            format!("{}{}{}", start, script, end)
+            format!("{start}{script}{end}")
         } else {
-            format!("{}\n{}", script, html)
+            format!("{script}\n{html}")
         }
     }
 

--- a/crates/gateway/gateway-server/src/handlers.rs
+++ b/crates/gateway/gateway-server/src/handlers.rs
@@ -195,7 +195,7 @@ where
 }
 
 /// The state update type returns by `/get_state_update` endpoint.
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names, clippy::large_enum_variant)]
 #[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum GetStateUpdateResponse {

--- a/crates/messaging/src/ethereum.rs
+++ b/crates/messaging/src/ethereum.rs
@@ -207,7 +207,7 @@ fn parse_messages(messages: &[MessageToL1]) -> Vec<U256> {
 }
 
 fn felt_from_u256(v: U256) -> Felt {
-    Felt::from_str(format!("{:#064x}", v).as_str()).unwrap()
+    Felt::from_str(format!("{v:#064x}").as_str()).unwrap()
 }
 
 #[cfg(test)]

--- a/crates/messaging/src/lib.rs
+++ b/crates/messaging/src/lib.rs
@@ -170,6 +170,7 @@ pub trait Messenger {
     ) -> MessengerResult<(u64, Vec<Self::MessageTransaction>)>;
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum MessengerMode {
     Ethereum(EthereumMessaging),

--- a/crates/pool/pool/src/validation/stateful.rs
+++ b/crates/pool/pool/src/validation/stateful.rs
@@ -286,9 +286,9 @@ fn map_executor_err(
 ) -> Result<InvalidTransactionError, Box<dyn std::error::Error + Send>> {
     match err {
         TransactionExecutorError::TransactionExecutionError(e) => match e {
-            TransactionExecutionError::TransactionFeeError(e) => map_fee_err(e),
+            TransactionExecutionError::TransactionFeeError(e) => map_fee_err(*e),
             TransactionExecutionError::TransactionPreValidationError(e) => {
-                map_pre_validation_err(e)
+                map_pre_validation_err(*e)
             }
 
             _ => Err(Box::new(e)),
@@ -330,7 +330,7 @@ fn map_pre_validation_err(
     err: TransactionPreValidationError,
 ) -> Result<InvalidTransactionError, Box<dyn std::error::Error + Send>> {
     match err {
-        TransactionPreValidationError::TransactionFeeError(err) => map_fee_err(err),
+        TransactionPreValidationError::TransactionFeeError(err) => map_fee_err(*err),
         TransactionPreValidationError::StateError(err) => Err(Box::new(err)),
         TransactionPreValidationError::InvalidNonce {
             address,

--- a/crates/pool/pool/src/validation/stateful.rs
+++ b/crates/pool/pool/src/validation/stateful.rs
@@ -271,7 +271,7 @@ fn map_fee_err(
         }
 
         TransactionFeeError::InsufficientResourceBounds { errors } => {
-            let error = errors.iter().map(|e| format!("{}", e)).collect::<Vec<_>>().join("\n");
+            let error = errors.iter().map(|e| format!("{e}")).collect::<Vec<_>>().join("\n");
             Ok(InvalidTransactionError::InsufficientIntrinsicFee(
                 InsufficientIntrinsicFeeError::InsufficientResourceBounds { error },
             ))

--- a/crates/primitives/src/class.rs
+++ b/crates/primitives/src/class.rs
@@ -39,9 +39,9 @@ impl std::fmt::Display for MaybeInvalidSierraContractAbi {
         match self {
             MaybeInvalidSierraContractAbi::Valid(abi) => {
                 let s = to_string_pythonic(abi).expect("failed to serialize abi");
-                write!(f, "{}", s)
+                write!(f, "{s}")
             }
-            MaybeInvalidSierraContractAbi::Invalid(abi) => write!(f, "{}", abi),
+            MaybeInvalidSierraContractAbi::Invalid(abi) => write!(f, "{abi}"),
         }
     }
 }

--- a/crates/primitives/src/da/blob.rs
+++ b/crates/primitives/src/da/blob.rs
@@ -19,7 +19,7 @@ use super::math::{fft, ifft};
 pub fn recover(data: Vec<BigUint>) -> Vec<BigUint> {
     let xs: Vec<BigUint> = (0..BLOB_LEN)
         .map(|i| {
-            let bin = format!("{:012b}", i);
+            let bin = format!("{i:012b}");
             let bin_rev = bin.chars().rev().collect::<String>();
             GENERATOR.modpow(&BigUint::from_str_radix(&bin_rev, 2).unwrap(), &BLS_MODULUS)
         })
@@ -31,7 +31,7 @@ pub fn recover(data: Vec<BigUint>) -> Vec<BigUint> {
 pub fn transform(data: Vec<BigUint>) -> Vec<BigUint> {
     let xs: Vec<BigUint> = (0..BLOB_LEN)
         .map(|i| {
-            let bin = format!("{:012b}", i);
+            let bin = format!("{i:012b}");
             let bin_rev = bin.chars().rev().collect::<String>();
             GENERATOR.modpow(&BigUint::from_str_radix(&bin_rev, 2).unwrap(), &BLS_MODULUS)
         })

--- a/crates/rpc/rpc-server/src/cors.rs
+++ b/crates/rpc/rpc-server/src/cors.rs
@@ -94,7 +94,7 @@ impl AllowOrigins {
         I: IntoIterator<Item = HeaderValue>,
     {
         let origins = origins.into_iter().collect::<Vec<_>>();
-        if origins.iter().any(|o| o == WILDCARD) {
+        if origins.contains(&WILDCARD) {
             Self(cors::AllowOrigin::any())
         } else {
             Self(cors::AllowOrigin::list(origins))

--- a/crates/rpc/rpc-server/tests/messaging.rs
+++ b/crates/rpc/rpc-server/tests/messaging.rs
@@ -95,6 +95,7 @@ async fn test_messaging() {
         let address = get_contract_address(Felt::ZERO, class_hash, &[], Felt::ZERO);
 
         // Deploy the contract using UDC
+        #[allow(deprecated)]
         let res = ContractFactory::new(class_hash, &katana_account)
             .deploy_v3(Vec::new(), Felt::ZERO, false)
             .send()
@@ -239,6 +240,7 @@ async fn estimate_message_fee() -> Result<()> {
     TxWaiter::new(res.transaction_hash, &rpc_client).await?;
 
     // Deploy the contract using UDC
+    #[allow(deprecated)]
     let res = ContractFactory::new(class_hash, &account)
         .deploy_v3(Vec::new(), Felt::ZERO, false)
         .send()

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -148,7 +148,7 @@ impl<'de> Deserialize<'de> for SyncingResponse {
         impl<'de> Visitor<'de> for SyncingResponseVisitor {
             type Value = SyncingResponse;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str(
                     "either `false` or an object with fields: starting_block_hash, \
                      starting_block_num, current_block_hash, current_block_num, \

--- a/crates/rpc/rpc-types/src/trace.rs
+++ b/crates/rpc/rpc-types/src/trace.rs
@@ -39,6 +39,7 @@ pub struct TxTraceWithHash {
 }
 
 /// Execution trace of a Starknet transaction.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum TxTrace {

--- a/crates/storage/db/src/codecs/mod.rs
+++ b/crates/storage/db/src/codecs/mod.rs
@@ -68,8 +68,28 @@ macro_rules! impl_encode_and_decode_for_felts {
     }
 }
 
+macro_rules! impl_compress_and_decompress_for_felts {
+    ($($ty:ty),*) => {
+        $(
+            impl Compress for $ty {
+	            type Compressed = <$ty as Encode>::Encoded;
+                fn compress(self) -> Result<Self::Compressed, CodecError> {
+                	Ok(Encode::encode(self))
+                }
+            }
+
+            impl Decompress for $ty {
+                fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, crate::error::CodecError> {
+                	Decode::decode(bytes)
+                }
+            }
+        )*
+    }
+}
+
 impl_encode_and_decode_for_uints!(u64);
 impl_encode_and_decode_for_felts!(Felt, ContractAddress);
+impl_compress_and_decompress_for_felts!(Felt, ContractAddress);
 
 impl Encode for String {
     type Encoded = Vec<u8>;

--- a/crates/storage/db/src/codecs/mod.rs
+++ b/crates/storage/db/src/codecs/mod.rs
@@ -68,28 +68,8 @@ macro_rules! impl_encode_and_decode_for_felts {
     }
 }
 
-macro_rules! impl_compress_and_decompress_for_felts {
-    ($($ty:ty),*) => {
-        $(
-            impl Compress for $ty {
-	            type Compressed = <$ty as Encode>::Encoded;
-                fn compress(self) -> Result<Self::Compressed, CodecError> {
-                	Ok(Encode::encode(self))
-                }
-            }
-
-            impl Decompress for $ty {
-                fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, crate::error::CodecError> {
-                	Decode::decode(bytes)
-                }
-            }
-        )*
-    }
-}
-
 impl_encode_and_decode_for_uints!(u64);
 impl_encode_and_decode_for_felts!(Felt, ContractAddress);
-impl_compress_and_decompress_for_felts!(Felt, ContractAddress);
 
 impl Encode for String {
     type Encoded = Vec<u8>;

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,10 +1,51 @@
 use katana_primitives::contract::GenericContractInfo;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
+use katana_primitives::Felt;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use {postcard, zstd};
 
 use super::{Compress, Decompress};
 use crate::error::CodecError;
+
+/// A wrapper type for `Felt` that serializes/deserializes as a 32-byte big-endian array.
+///
+/// This exists for backward compatibility - older versions of `Felt` used to serialize as
+/// a 32-byte array, but newer versions have changed this behavior. This wrapper ensures
+/// consistent serialization format for database storage.
+///
+/// See <https://github.com/starknet-io/types-rs/pull/155> for the breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Felt32(Felt);
+
+impl Serialize for Felt32 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.to_bytes_be().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Felt32 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes = <[u8; 32]>::deserialize(deserializer)?;
+        Ok(Felt32(Felt::from_bytes_be(&bytes)))
+    }
+}
+
+impl Compress for Felt {
+    type Compressed = Vec<u8>;
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
+        postcard::to_stdvec(&Felt32(self)).map_err(|e| CodecError::Compress(e.to_string()))
+    }
+}
+
+impl Decompress for Felt {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let wrapper: Felt32 = postcard::from_bytes(bytes.as_ref())
+            .map_err(|e| CodecError::Decompress(e.to_string()))?;
+        Ok(wrapper.0)
+    }
+}
+
 use crate::models::block::StoredBlockBodyIndices;
 use crate::models::contract::ContractInfoChangeList;
 use crate::models::list::BlockList;

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -10,11 +10,14 @@ use crate::error::CodecError;
 
 /// A wrapper type for `Felt` that serializes/deserializes as a 32-byte big-endian array.
 ///
-/// This exists for backward compatibility - older versions of `Felt` used to serialize as
+/// This exists for backward compatibility - older versions of `Felt` used to always serialize as
 /// a 32-byte array, but newer versions have changed this behavior. This wrapper ensures
-/// consistent serialization format for database storage.
+/// consistent serialization format for database storage. However, deserialization is still backward
+/// compatible.
 ///
 /// See <https://github.com/starknet-io/types-rs/pull/155> for the breaking change.
+///
+/// This is temporary and may change in the future.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Felt32(Felt);
 
@@ -26,8 +29,7 @@ impl Serialize for Felt32 {
 
 impl<'de> Deserialize<'de> for Felt32 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let bytes = <[u8; 32]>::deserialize(deserializer)?;
-        Ok(Felt32(Felt::from_bytes_be(&bytes)))
+        Ok(Felt32(Felt::deserialize(deserializer)?))
     }
 }
 

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -20,7 +20,7 @@ struct Felt32(Felt);
 
 impl Serialize for Felt32 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.to_bytes_be().serialize(serializer)
+        serializer.serialize_bytes(&self.0.to_bytes_be())
     }
 }
 

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,7 +1,6 @@
-use katana_primitives::contract::{ContractAddress, GenericContractInfo};
+use katana_primitives::contract::GenericContractInfo;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::Felt;
 use {postcard, zstd};
 
 use super::{Compress, Decompress};
@@ -52,9 +51,7 @@ impl Decompress for TypedTransactionExecutionInfo {
 impl_compress_and_decompress_for_table_values!(
     u64,
     Receipt,
-    Felt,
     TrieDatabaseValue,
-    ContractAddress,
     BlockList,
     ExecutionCheckpoint,
     PruningCheckpoint,

--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -17,7 +17,7 @@ starknet-types-core.workspace = true
 thiserror.workspace = true
 
 [dependencies.bonsai-trie]
-rev = "95de4c6"
+rev = "351d5be"
 default-features = false
 features = [ "std" ]
 git = "https://github.com/dojoengine/bonsai-trie/"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.89.0"


### PR DESCRIPTION
Related #393, #388, #198, #209, #211, #256, #268.

When running `cargo vendor`, we're stuck with this error:

```
λ cargo vendor
error: failed to sync

Caused by:
  found duplicate version of package `starknet-crypto v0.7.4` vendored from two sources:

  	source 1: registry `crates-io`
  	source 2: https://github.com/kariy/starknet-rs?rev=2ef3088#2ef30887
```

The dependencies bump is required because we are removing the `starknet` crate patch:

```toml
[patch.crates-io]
starknet = { git = "https://github.com/kariy/starknet-rs", rev = "2ef3088" }
```

The initial reason for the patch is for this PR https://github.com/xJonathanLEI/starknet-rs/pull/773 but it's no longer needed since #256.

The dependency updates were originally meant to only make the project compile after removing the patch. Given the tight integration with `blockifier` and the breaking database format change introduced in `v0.16.0-rc.0`, this PR is now primarily about updating `blockifier`, with patch removal as a side effect.

## Database Backward Compatibility

### TransactionExecutionInfo

`blockifier` v0.16.0-rc.0 has a breaking change in the `TransactionExecutionInfo` struct. In order to maintain backward-compatibility, if database can't deserialize the `TransactionExecutionInfo` it'd simply return nothing instead of failing.

This is still temporary for now and may change once we find a better solution that doesn't require dropping old data.

### Felt Serialization

The `starknet-types-core` crate has a breaking change in `Felt` serialization (see https://github.com/starknet-io/types-rs/pull/155). To maintain backward compatibility with existing databases, a `Felt32` wrapper type is used to ensure `Felt` values are always serialized as 32-byte big-endian arrays when stored in the database.

---

The reason to vendor the Cargo dependencies is to make the Katana binary build hermetic in order to achieve reproducible build process.
