### PR TITLE
chore: bump Rust version in Dockerfile

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -14,8 +14,8 @@ on:
       - ".github/Dockerfile"
 
 env:
-  RUST_VERSION: 1.86.0
-  CLIPPY_VERSION: nightly-2025-02-20
+  RUST_VERSION: 1.89.0
+  CLIPPY_VERSION: nightly-2025-06-20
 
 jobs:
   # Docker tag determination based on workflow trigger:


### PR DESCRIPTION
Relied by #392 as the PR includes a Rust bump to 1.89