### PR TITLE
ci: run in bigger storage runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
 
   db-compatibility-check:
     needs: [fmt, clippy, build-katana-binary]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     steps:


### PR DESCRIPTION
The db-compatibility-check job keeps failing recently due to space issue:

```
 = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld: final link failed: No space left on device
          collect2: error: ld returned 1 exit status
```