### PR TITLE
feat(rpc): implement `dev_setStorageAt` endpoint

### DIFF
--- a/crates/executor/src/abstraction/executor.rs
+++ b/crates/executor/src/abstraction/executor.rs
@@ -1,4 +1,5 @@
 use katana_primitives::block::ExecutableBlock;
+use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
 use katana_primitives::env::{BlockEnv, VersionedConstantsOverrides};
 use katana_primitives::transaction::{ExecutableTxWithHash, TxWithHash};
 use katana_provider::api::state::StateProvider;
@@ -50,4 +51,17 @@ pub trait BlockExecutor<'a>: Send + Sync + core::fmt::Debug {
 
     /// Returns the current block environment of the executor.
     fn block_env(&self) -> BlockEnv;
+
+    // TEMP: This is primarily for `dev_setStorageAt` dev endpoint. To make sure the updated storage
+    // value is reflected in the pending state. This functionality should prolly be moved to the
+    // pending state level instead of the executor.
+    //
+    /// Sets the storage value for the given contract address and key.
+    /// This is used for dev purposes to manipulate state directly.
+    fn set_storage_at(
+        &self,
+        address: ContractAddress,
+        key: StorageKey,
+        value: StorageValue,
+    ) -> ExecutorResult<()>;
 }

--- a/crates/executor/src/implementation/blockifier/mod.rs
+++ b/crates/executor/src/implementation/blockifier/mod.rs
@@ -344,4 +344,23 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
             sequencer_address: utils::to_address(self.block_context.block_info().sequencer_address),
         }
     }
+
+    fn set_storage_at(
+        &self,
+        address: katana_primitives::contract::ContractAddress,
+        key: katana_primitives::contract::StorageKey,
+        value: katana_primitives::contract::StorageValue,
+    ) -> crate::ExecutorResult<()> {
+        use blockifier::state::state_api::State;
+
+        let blk_address = utils::to_blk_address(address);
+        let storage_key = starknet_api::state::StorageKey(key.try_into().unwrap());
+
+        self.state
+            .inner
+            .lock()
+            .cached_state
+            .set_storage_at(blk_address, storage_key, value)
+            .map_err(|e| crate::ExecutorError::Other(e.to_string().into()))
+    }
 }

--- a/crates/executor/src/implementation/noop.rs
+++ b/crates/executor/src/implementation/noop.rs
@@ -90,6 +90,15 @@ impl<'a> BlockExecutor<'a> for NoopExecutor {
     fn block_env(&self) -> BlockEnv {
         self.block_env.clone()
     }
+
+    fn set_storage_at(
+        &self,
+        _address: ContractAddress,
+        _key: StorageKey,
+        _value: StorageValue,
+    ) -> ExecutorResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]

--- a/crates/rpc/rpc-api/src/dev.rs
+++ b/crates/rpc/rpc-api/src/dev.rs
@@ -1,6 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
-use katana_primitives::Felt;
+use katana_primitives::contract::{StorageKey, StorageValue};
+use katana_primitives::ContractAddress;
 use katana_rpc_types::account::Account;
 
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "dev"))]
@@ -19,8 +20,12 @@ pub trait DevApi {
     async fn increase_next_block_timestamp(&self, timestamp: u64) -> RpcResult<()>;
 
     #[method(name = "setStorageAt")]
-    async fn set_storage_at(&self, contract_address: Felt, key: Felt, value: Felt)
-        -> RpcResult<()>;
+    async fn set_storage_at(
+        &self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+        value: StorageValue,
+    ) -> RpcResult<()>;
 
     #[method(name = "predeployedAccounts")]
     async fn predeployed_accounts(&self) -> RpcResult<Vec<Account>>;

--- a/crates/rpc/rpc-api/src/error/dev.rs
+++ b/crates/rpc/rpc-api/src/error/dev.rs
@@ -1,14 +1,36 @@
 use jsonrpsee::types::ErrorObjectOwned;
+use serde::{Deserialize, Serialize};
 
-#[derive(thiserror::Error, Clone, Copy, Debug)]
+#[derive(thiserror::Error, Clone, Debug)]
 #[allow(clippy::enum_variant_names)]
 pub enum DevApiError {
     #[error("Wait for pending transactions.")]
     PendingTransactions,
+    #[error("An unexpected error occurred: {}", .0.reason)]
+    UnexpectedError(UnexpectedErrorData),
+}
+
+impl DevApiError {
+    pub fn unexpected_error<T: ToString>(reason: T) -> Self {
+        DevApiError::UnexpectedError(UnexpectedErrorData { reason: reason.to_string() })
+    }
+}
+
+/// Data for the [`DevApiError::UnexpectedError`] error.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UnexpectedErrorData {
+    pub reason: String,
 }
 
 impl From<DevApiError> for ErrorObjectOwned {
     fn from(err: DevApiError) -> Self {
-        ErrorObjectOwned::owned(err as i32, err.to_string(), None::<()>)
+        match &err {
+            DevApiError::PendingTransactions => {
+                ErrorObjectOwned::owned(1, err.to_string(), None::<()>)
+            }
+            DevApiError::UnexpectedError(data) => {
+                ErrorObjectOwned::owned(2, err.to_string(), Some(data))
+            }
+        }
     }
 }

--- a/crates/rpc/rpc-server/src/dev.rs
+++ b/crates/rpc/rpc-server/src/dev.rs
@@ -5,8 +5,9 @@ use katana_core::backend::storage::{ProviderRO, ProviderRW};
 use katana_core::backend::Backend;
 use katana_core::service::block_producer::{BlockProducer, BlockProducerMode, PendingExecutor};
 use katana_executor::ExecutorFactory;
-use katana_primitives::Felt;
-use katana_provider::ProviderFactory;
+use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
+use katana_provider::api::state::StateWriter;
+use katana_provider::{MutableProvider, ProviderFactory};
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::error::dev::DevApiError;
 use katana_rpc_types::account::Account;
@@ -69,6 +70,35 @@ where
 
         Ok(())
     }
+
+    pub fn set_storage_at(
+        &self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+        value: StorageValue,
+    ) -> Result<(), DevApiError> {
+        // If there's a pending executor (interval mining mode), update the pending state
+        // so that the change is visible to the pending block.
+        if let Some(pending_executor) = self.pending_executor() {
+            // Leaky-leaky abstraction:
+            // The logic here might seem counterintuitive because we're taking a non-mutable
+            // reference (ie read lock) but we're allowed to update the pending state.
+            pending_executor
+                .read()
+                .set_storage_at(contract_address, key, value)
+                .map_err(DevApiError::unexpected_error)?;
+        } else {
+            let provider = self.backend.storage.provider_mut();
+
+            provider
+                .set_storage(contract_address, key, value)
+                .map_err(DevApiError::unexpected_error)?;
+
+            provider.commit().map_err(DevApiError::unexpected_error)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -99,15 +129,11 @@ where
 
     async fn set_storage_at(
         &self,
-        _contract_address: Felt,
-        _key: Felt,
-        _value: Felt,
+        contract_address: ContractAddress,
+        key: StorageKey,
+        value: StorageValue,
     ) -> RpcResult<()> {
-        // self.sequencer
-        //     .set_storage_at(contract_address.into(), key, value)
-        //     .await
-        //     .map_err(|_| Error::from(KatanaApiError::FailedToUpdateStorage))
-        Ok(())
+        Ok(self.set_storage_at(contract_address, key, value)?)
     }
 
     async fn predeployed_accounts(&self) -> RpcResult<Vec<Account>> {


### PR DESCRIPTION
Implements the `dev_setStorageAt` RPC endpoint which was previously a stub. This endpoint allows directly manipulating contract storage for development purposes. In instant mining mode, the storage is updated in the database immediately. In interval mining mode, the storage is updated in the pending block's state, ensuring the change is visible to subsequent transactions within that block, and persisted to the database when the block is mined.

🤖 Generated with [Claude Code](https://claude.ai/code)