### PR TITLE
ci: run test workflow on release branches

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -71,5 +71,5 @@ jobs:
           title: "release(prepare): v${{ steps.version_info.outputs.version }}"
           commit-message: "release(prepare): v${{ steps.version_info.outputs.version }}"
           branch: prepare-release
-          base: main
+          base: ${{ github.ref_name }}
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
     types: [closed]
     branches:
       - main
+      - "release/**"
 
 env:
   RUST_VERSION: 1.86.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
     paths:
       - "Cargo.toml"
       - "bin/**/*.rs"


### PR DESCRIPTION
Run the test suite on pushes to `release/*` branches.