### PR TITLE
refactor(cli): rename `--db-dir` to `--data-dir`

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -71,9 +71,9 @@ pub struct SequencerNodeArgs {
     ///
     /// The path must either be an empty directory or a directory which already contains a
     /// previously initialized Katana database.
-    #[arg(long)]
+    #[arg(long, alias = "db-dir")]
     #[arg(value_name = "PATH")]
-    pub db_dir: Option<PathBuf>,
+    pub data_dir: Option<PathBuf>,
 
     /// Configuration file
     #[arg(long)]
@@ -415,7 +415,7 @@ impl SequencerNodeArgs {
     }
 
     fn db_config(&self) -> DbConfig {
-        DbConfig { dir: self.db_dir.clone() }
+        DbConfig { dir: self.data_dir.clone() }
     }
 
     fn metrics_config(&self) -> Option<MetricsConfig> {
@@ -483,8 +483,8 @@ impl SequencerNodeArgs {
             self.block_time = config.block_time;
         }
 
-        if self.db_dir.is_none() {
-            self.db_dir = config.db_dir;
+        if self.data_dir.is_none() {
+            self.data_dir = config.data_dir;
         }
 
         if self.logging == LoggingOptions::default() {
@@ -591,7 +591,7 @@ mod test {
             "200",
             "--validate-max-steps",
             "100",
-            "--db-dir",
+            "--data-dir",
             "/path/to/db",
         ]);
         let config = args.config().unwrap();
@@ -603,6 +603,14 @@ mod test {
         assert_eq!(config.db.dir, Some(PathBuf::from("/path/to/db")));
         assert_eq!(config.chain.id(), ChainId::GOERLI);
         assert_eq!(config.chain.genesis().sequencer_address, *DEFAULT_SEQUENCER_ADDRESS);
+    }
+
+    #[test]
+    fn test_db_dir_alias() {
+        // --db-dir should work as an alias for --data-dir
+        let args = SequencerNodeArgs::parse_from(["katana", "--db-dir", "/path/to/db"]);
+        let config = args.config().unwrap();
+        assert_eq!(config.db.dir, Some(PathBuf::from("/path/to/db")));
     }
 
     #[test]

--- a/crates/cli/src/file.rs
+++ b/crates/cli/src/file.rs
@@ -13,7 +13,8 @@ pub struct NodeArgsConfig {
     pub no_mining: Option<bool>,
     pub block_time: Option<u64>,
     pub block_cairo_steps_limit: Option<u64>,
-    pub db_dir: Option<PathBuf>,
+    #[serde(alias = "db_dir")]
+    pub data_dir: Option<PathBuf>,
     pub messaging: Option<MessagingConfig>,
     pub logging: Option<LoggingOptions>,
     pub starknet: Option<StarknetOptions>,
@@ -49,7 +50,7 @@ impl TryFrom<SequencerNodeArgs> for NodeArgsConfig {
             no_mining: if args.no_mining { Some(true) } else { None },
             block_time: args.block_time,
             block_cairo_steps_limit: args.block_cairo_steps_limit,
-            db_dir: args.db_dir,
+            data_dir: args.data_dir,
             messaging: args.messaging,
             ..Default::default()
         };

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -177,7 +177,7 @@ pub struct Katana {
     no_mining: bool,
     json_log: bool,
     block_time: Option<u64>,
-    db_dir: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
     l1_provider: Option<String>,
     fork_block_number: Option<u64>,
     messaging: Option<PathBuf>,
@@ -273,10 +273,16 @@ impl Katana {
         self
     }
 
-    /// Sets the database directory path which will be used when the `katana` instance is launched.
-    pub fn db_dir<T: Into<PathBuf>>(mut self, db_dir: T) -> Self {
-        self.db_dir = Some(db_dir.into());
+    /// Sets the data directory path which will be used when the `katana` instance is launched.
+    pub fn data_dir<T: Into<PathBuf>>(mut self, data_dir: T) -> Self {
+        self.data_dir = Some(data_dir.into());
         self
+    }
+
+    /// Sets the data directory path which will be used when the `katana` instance is launched.
+    #[deprecated(note = "Use `data_dir` instead")]
+    pub fn db_dir<T: Into<PathBuf>>(self, db_dir: T) -> Self {
+        self.data_dir(db_dir)
     }
 
     /// Sets the RPC URL to fork the network from.
@@ -458,8 +464,8 @@ impl Katana {
             cmd.arg("-b").arg(block_time.to_string());
         }
 
-        if let Some(db_dir) = self.db_dir {
-            cmd.arg("--db-dir").arg(db_dir);
+        if let Some(data_dir) = self.data_dir {
+            cmd.arg("--data-dir").arg(data_dir);
         }
 
         if let Some(url) = self.l1_provider {
@@ -817,16 +823,16 @@ mod tests {
     }
 
     #[test]
-    fn can_launch_katana_with_db_dir() {
+    fn can_launch_katana_with_data_dir() {
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
-        let db_path = temp_dir.path().join("test-db");
-        assert!(!db_path.exists());
+        let data_path = temp_dir.path().join("test-data");
+        assert!(!data_path.exists());
 
-        let _katana = Katana::new().db_dir(db_path.clone()).spawn();
+        let _katana = Katana::new().data_dir(data_path.clone()).spawn();
 
-        // Check that the db directory is created
-        assert!(db_path.exists());
-        assert!(db_path.is_dir());
+        // Check that the data directory is created
+        assert!(data_path.exists());
+        assert!(data_path.is_dir());
     }
 
     #[test]


### PR DESCRIPTION
Renames the `--db-dir` CLI flag to `--data-dir` while keeping `--db-dir` as an alias for backward compatibility. Config files also accept both `data_dir` and `db_dir` keys. The `katana-node-bindings` crate adds a new `data_dir()` method and deprecates `db_dir()`.

🤖 Generated with [Claude Code](https://claude.ai/code)