### PR TITLE
feat(utils): add migrate methods to `TestNode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6634,6 +6634,7 @@ dependencies = [
  "katana-utils-macro",
  "rand 0.8.5",
  "starknet",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -25,6 +25,7 @@ async-trait.workspace = true
 futures.workspace = true
 rand.workspace = true
 starknet.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [ "macros", "signal", "time" ], default-features = false }
 

--- a/crates/utils/src/node.rs
+++ b/crates/utils/src/node.rs
@@ -1,4 +1,6 @@
 use std::net::SocketAddr;
+use std::path::Path;
+use std::process::Command;
 use std::sync::Arc;
 
 use katana_chain_spec::{dev, ChainSpec};
@@ -22,6 +24,23 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Url};
 pub use starknet::providers::{Provider, ProviderError};
 use starknet::signers::{LocalWallet, SigningKey};
+
+/// Errors that can occur when populating a test node with contracts.
+#[derive(Debug, thiserror::Error)]
+pub enum PopulateError {
+    #[error("Failed to create temp directory: {0}")]
+    TempDir(#[from] std::io::Error),
+    #[error("Git clone failed: {0}")]
+    GitClone(String),
+    #[error("Scarb build failed: {0}")]
+    ScarbBuild(String),
+    #[error("Sozo migrate failed: {0}")]
+    SozoMigrate(String),
+    #[error("Missing genesis account private key")]
+    MissingPrivateKey,
+    #[error("Spawn blocking task failed: {0}")]
+    SpawnBlocking(#[from] tokio::task::JoinError),
+}
 
 pub type ForkTestNode = TestNode<ForkProviderFactory>;
 
@@ -124,6 +143,117 @@ where
         let client = self.rpc_http_client();
         katana_rpc_client::starknet::Client::new_with_client(client)
     }
+
+    /// Populates the node with contracts by cloning the dojo repository,
+    /// building contracts with `scarb`, and deploying them with `sozo migrate`.
+    ///
+    /// This method requires `git`, `asdf`, and `sozo` to be available in PATH.
+    /// The scarb version is managed by asdf using the `.tool-versions` file
+    /// in the dojo repository.
+    pub async fn populate(&self) -> Result<(), PopulateError> {
+        let rpc_url = format!("http://{}", self.rpc_addr());
+
+        let (address, account) = self
+            .backend()
+            .chain_spec
+            .genesis()
+            .accounts()
+            .next()
+            .expect("must have at least one genesis account");
+        let private_key = account.private_key().ok_or(PopulateError::MissingPrivateKey)?;
+
+        let address_hex = address.to_string();
+        let private_key_hex = format!("{private_key:#x}");
+
+        tokio::task::spawn_blocking(move || {
+            let temp_dir = tempfile::tempdir()?;
+
+            // Clone dojo repository at v1.7.0
+            run_git_clone(temp_dir.path())?;
+
+            let project_dir = temp_dir.path().join("dojo/examples/spawn-and-move");
+
+            // Build contracts using asdf to ensure correct scarb version
+            run_scarb_build(&project_dir)?;
+
+            // Deploy contracts to the katana node
+            run_sozo_migrate(&project_dir, &rpc_url, &address_hex, &private_key_hex)?;
+
+            Ok(())
+        })
+        .await?
+    }
+}
+
+fn run_git_clone(temp_dir: &Path) -> Result<(), PopulateError> {
+    let output = Command::new("git")
+        .args(["clone", "--depth", "1", "--branch", "v1.7.0", "https://github.com/dojoengine/dojo"])
+        .current_dir(temp_dir)
+        .output()
+        .map_err(|e| PopulateError::GitClone(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(PopulateError::GitClone(stderr.to_string()));
+    }
+    Ok(())
+}
+
+fn run_scarb_build(project_dir: &Path) -> Result<(), PopulateError> {
+    let output = Command::new("asdf")
+        .args(["exec", "scarb", "build"])
+        .current_dir(project_dir)
+        .output()
+        .map_err(|e| PopulateError::ScarbBuild(e.to_string()))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}\n{stderr}");
+
+        let lines: Vec<&str> = combined.lines().collect();
+        let last_50: String =
+            lines.iter().rev().take(50).rev().cloned().collect::<Vec<_>>().join("\n");
+
+        return Err(PopulateError::ScarbBuild(last_50));
+    }
+    Ok(())
+}
+
+fn run_sozo_migrate(
+    project_dir: &Path,
+    rpc_url: &str,
+    address: &str,
+    private_key: &str,
+) -> Result<(), PopulateError> {
+    let output = Command::new("sozo")
+        .args([
+            "migrate",
+            "--rpc-url",
+            rpc_url,
+            "--account-address",
+            address,
+            "--private-key",
+            private_key,
+        ])
+        .current_dir(project_dir)
+        .output()
+        .map_err(|e| PopulateError::SozoMigrate(e.to_string()))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}\n{stderr}");
+
+        let lines: Vec<&str> = combined.lines().collect();
+        let last_50: String =
+            lines.iter().rev().take(50).rev().cloned().collect::<Vec<_>>().join("\n");
+
+        eprintln!("sozo migrate failed. Last 50 lines of output:\n{last_50}");
+
+        return Err(PopulateError::SozoMigrate(last_50));
+    }
+    Ok(())
 }
 
 pub fn test_config() -> Config {

--- a/crates/utils/src/node.rs
+++ b/crates/utils/src/node.rs
@@ -144,13 +144,33 @@ where
         katana_rpc_client::starknet::Client::new_with_client(client)
     }
 
-    /// Populates the node with contracts by cloning the dojo repository,
-    /// building contracts with `scarb`, and deploying them with `sozo migrate`.
+    /// Populates the node with the `spawn-and-move` example contracts from the dojo repository.
     ///
     /// This method requires `git`, `asdf`, and `sozo` to be available in PATH.
     /// The scarb version is managed by asdf using the `.tool-versions` file
     /// in the dojo repository.
     pub async fn populate(&self) -> Result<(), PopulateError> {
+        self.populate_example("spawn-and-move").await
+    }
+
+    /// Populates the node with the `simple` example contracts from the dojo repository.
+    ///
+    /// This method requires `git`, `asdf`, and `sozo` to be available in PATH.
+    /// The scarb version is managed by asdf using the `.tool-versions` file
+    /// in the dojo repository.
+    pub async fn populate_simple(&self) -> Result<(), PopulateError> {
+        self.populate_example("simple").await
+    }
+
+    /// Populates the node with contracts from a dojo example project.
+    ///
+    /// Clones the dojo repository, builds contracts with `scarb`, and deploys
+    /// them with `sozo migrate`.
+    ///
+    /// This method requires `git`, `asdf`, and `sozo` to be available in PATH.
+    /// The scarb version is managed by asdf using the `.tool-versions` file
+    /// in the dojo repository.
+    async fn populate_example(&self, example: &str) -> Result<(), PopulateError> {
         let rpc_url = format!("http://{}", self.rpc_addr());
 
         let (address, account) = self
@@ -164,6 +184,7 @@ where
 
         let address_hex = address.to_string();
         let private_key_hex = format!("{private_key:#x}");
+        let example_path = format!("dojo/examples/{example}");
 
         tokio::task::spawn_blocking(move || {
             let temp_dir = tempfile::tempdir()?;
@@ -171,7 +192,7 @@ where
             // Clone dojo repository at v1.7.0
             run_git_clone(temp_dir.path())?;
 
-            let project_dir = temp_dir.path().join("dojo/examples/spawn-and-move");
+            let project_dir = temp_dir.path().join(&example_path);
 
             // Build contracts using asdf to ensure correct scarb version
             run_scarb_build(&project_dir)?;


### PR DESCRIPTION
Adds `migrate_spawn_and_move()` and `migrate_simple()` methods to `TestNode` for bootstrapping the blockchain's state.