### PR TITLE
feat(utils): feature-gate `node` module behind `node` feature

### DIFF
--- a/crates/rpc/rpc-server/Cargo.toml
+++ b/crates/rpc/rpc-server/Cargo.toml
@@ -54,7 +54,7 @@ katana-rpc-api = { workspace = true, features = [ "client" ] }
 katana-rpc-client.workspace = true
 katana-trie.workspace = true
 katana-genesis.workspace = true
-katana-utils.workspace = true
+katana-utils = { workspace = true, features = ["node"] }
 
 alloy-contract = { workspace = true, default-features = false }
 alloy-node-bindings = "1.0.24"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -6,13 +6,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-katana-chain-spec.workspace = true
-katana-core.workspace = true
-katana-executor.workspace = true
-katana-node.workspace = true
 katana-primitives.workspace = true
-katana-provider.workspace = true
-katana-rpc-server.workspace = true
 katana-rpc-api.workspace = true
 katana-rpc-client.workspace = true
 katana-rpc-types.workspace = true
@@ -24,10 +18,28 @@ assert_matches.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 rand.workspace = true
-starknet.workspace = true
-tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [ "macros", "signal", "time" ], default-features = false }
 
+# node-only dependencies
+katana-chain-spec = { workspace = true, optional = true }
+katana-core = { workspace = true, optional = true }
+katana-executor = { workspace = true, optional = true }
+katana-node = { workspace = true, optional = true }
+katana-provider = { workspace = true, optional = true }
+katana-rpc-server = { workspace = true, optional = true }
+starknet = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
+
 [features]
-explorer = [ "katana-node/explorer" ]
+node = [
+    "katana-chain-spec",
+    "katana-core",
+    "katana-executor",
+    "katana-node",
+    "katana-provider",
+    "katana-rpc-server",
+    "starknet",
+    "tempfile",
+]
+explorer = [ "node", "katana-node/explorer" ]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,10 +1,12 @@
 pub use arbitrary::{Arbitrary, Unstructured};
 pub use katana_utils_macro::mock_provider;
 
+#[cfg(feature = "node")]
 pub mod node;
 mod signal;
 mod tx_waiter;
 
+#[cfg(feature = "node")]
 pub use node::TestNode;
 pub use signal::wait_shutdown_signals;
 pub use tx_waiter::*;

--- a/crates/utils/src/tx_waiter.rs
+++ b/crates/utils/src/tx_waiter.rs
@@ -316,10 +316,11 @@ mod tests {
     use katana_rpc_types::{ExecutionResources, FeePayment};
 
     use super::{Duration, TxWaiter};
-    use crate::{TestNode, TxWaitingError};
+    use crate::TxWaitingError;
 
-    async fn create_test_sequencer() -> TestNode {
-        TestNode::new().await
+    #[cfg(feature = "node")]
+    async fn create_test_sequencer() -> crate::TestNode {
+        crate::TestNode::new().await
     }
 
     const EXECUTION_RESOURCES: ExecutionResources =
@@ -365,6 +366,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "node")]
     #[tokio::test]
     async fn should_timeout_on_nonexistant_transaction() {
         let sequencer = create_test_sequencer().await;


### PR DESCRIPTION
Avoid pulling in the entire `katana-node` dependencies if the `TestNode` is not used when relying on `katana-utils`