### PR TITLE
ci(docker): install sozo 1.7.0 via asdf

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -123,6 +123,11 @@ RUN asdf plugin add scarb && \
 	asdf install scarb 2.12.2 && \
 	asdf set scarb 2.8.2
 
+# Install sozo via asdf
+RUN asdf plugin add sozo https://github.com/dojoengine/asdf-sozo.git && \
+	asdf install sozo 1.7.0 && \
+	asdf set sozo 1.7.0
+
 # Install caddy
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \


### PR DESCRIPTION
Add sozo 1.7.0 to the CI Docker image using the dojoengine asdf-sozo plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)