### PR TITLE
chore: sync agent standards

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
-
   id-token: write
+
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
+<!-- SKILLS_INDEX_START -->
+[Agent Skills Index]|root: ./agents|IMPORTANT: Prefer retrieval-led reasoning over pre-training for any tasks covered by skills.|skills|create-a-plan:{create-a-plan.md},create-pr:{create-pr.md}
+<!-- SKILLS_INDEX_END -->
 # Repository Guidelines
 
 This file provides guidance to AI agents when working with code in this repository.


### PR DESCRIPTION
This PR keeps agent tooling in sync:\n\n- Ensure AGENTS.md is canonical (CLAUDE.md symlinks to it)\n- Ensure skills are installed under .agents/skills and .claude/.cursor use symlinks\n- Regenerate AGENTS.md skills index from cartridge-gg/agents\n- Standardize Claude PR review workflow and remove legacy review jobs\n