### PR TITLE
chore(skills): add katana development skill

### DIFF
--- a/.agents/skills/katana-development/SKILL.md
+++ b/.agents/skills/katana-development/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: katana-development
+description: Contributor workflow for dojoengine/katana. Use when implementing or reviewing changes in Katana's Rust crates, native/explorer integration, fixtures, and CI-parity checks.
+---
+
+# Katana Development
+
+Use this skill to contribute safely to `dojoengine/katana` with the expected dependency setup and test flow.
+
+## Core Workflow
+
+1. Prepare dependencies before builds/tests:
+   - `make install-scarb`
+   - `make native-deps-macos` or `make native-deps-linux`
+2. Build targets based on scope:
+   - `cargo build`
+   - `cargo build --release`
+   - `make build-explorer` when explorer assets are affected
+3. Refresh fixtures before test runs:
+   - `make fixtures`
+4. Run tests:
+   - `cargo nextest run`
+   - Use `cargo nextest run -p <crate_name>` for focused iteration
+5. Run formatting and lint checks:
+   - `cargo +nightly-2025-02-20 fmt --all`
+   - `./scripts/clippy.sh`
+
+## PR Checklist
+
+- Run `make fixtures` before final test pass.
+- Note whether explorer/native paths were touched.
+- Include exact commands used for validation.

--- a/.agents/skills/katana-development/agents/openai.yaml
+++ b/.agents/skills/katana-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Katana Development"
+  short_description: "Contributor workflow for dojoengine/katana"
+  default_prompt: "Use $katana-development to implement and validate changes in katana."


### PR DESCRIPTION
## Summary
- add a repository-specific development skill at `.agents/skills/katana-development`
- include `agents/openai.yaml` metadata for discoverability and default invocation

## Validation
- `/tmp/skillcreator-venv/bin/python /Users/nasr/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/katana-development`