### PR TITLE
Add `tee-sev-snp` target and Katana build confirmation

### DIFF
--- a/misc/AMDSEV/README.md
+++ b/misc/AMDSEV/README.md
@@ -26,7 +26,7 @@ Output is written to `misc/AMDSEV/output/qemu/`.
 
 ### Katana Binary
 
-If `--katana` is not provided, `build.sh` automatically builds a statically linked katana binary using musl libc via `scripts/build-musl.sh`.
+If `--katana` is not provided, `build.sh` prompts for confirmation (`y/N`) before building a statically linked katana binary using musl libc via `scripts/build-musl.sh`.
 
 **Important:** The initrd is minimal and contains no libc or shared libraries. Only statically linked binaries will work. If providing a custom binary with `--katana`, ensure it is statically linked (e.g., built with musl).
 

--- a/misc/AMDSEV/build.sh
+++ b/misc/AMDSEV/build.sh
@@ -101,7 +101,24 @@ fi
 
 # Build katana if needed for initrd and not provided
 if [ $BUILD_INITRD -eq 1 ] && [ -z "$KATANA_BINARY" ]; then
-	echo "No --katana provided, building katana with musl..."
+	echo "No --katana provided."
+	if [ ! -t 0 ]; then
+		echo "ERROR: Cannot prompt without an interactive terminal."
+		echo "Pass --katana /path/to/katana to use a pre-built binary."
+		exit 1
+	fi
+
+	read -r -p "Build katana from source with musl now? [y/N] " CONFIRM_BUILD_KATANA
+	case "$CONFIRM_BUILD_KATANA" in
+		[yY]|[yY][eE][sS])
+			echo "Building katana with musl..."
+			;;
+		*)
+			echo "Aborting. Provide --katana /path/to/katana to use a pre-built binary."
+			exit 1
+			;;
+	esac
+
 	PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 	"${PROJECT_ROOT}/scripts/build-musl.sh"
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
* Adds a new `make tee-sev-snp` target that builds AMD SEV-SNP VM components via `misc/AMDSEV/build.sh`.
* Updates `build.sh` so missing `--katana` now asks for confirmation before building the Katana binary from source.