### PR TITLE
AMDSEV: harden reproducible VM component builds

### DIFF
--- a/misc/AMDSEV/README.md
+++ b/misc/AMDSEV/README.md
@@ -233,11 +233,45 @@ Use `ovmf-metadata` to inspect the OVMF firmware's SEV metadata sections:
 
 ## Reproducible Builds
 
-Set `SOURCE_DATE_EPOCH` for deterministic output:
+`SOURCE_DATE_EPOCH` is required for deterministic builds:
 
 ```sh
-SOURCE_DATE_EPOCH=$(git log -1 --format=%ct) ./misc/AMDSEV/build.sh
+export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+./misc/AMDSEV/build.sh
 ```
+
+For stronger package source determinism, pin apt to a snapshot:
+
+```sh
+export APT_SNAPSHOT_URL="http://snapshot.ubuntu.com/ubuntu/20250115T000000Z/"
+export APT_SNAPSHOT_SUITE="noble"
+export APT_SNAPSHOT_COMPONENTS="main"
+```
+
+If building in a containerized pipeline, set the image digest for provenance tracking:
+
+```sh
+export BUILD_CONTAINER_IMAGE_DIGEST="sha256:<digest>"
+```
+
+Run a built-in reproducibility check (double build + hash compare):
+
+```sh
+export KATANA_STRICT_REPRO=1   # optional: requires vendored cargo deps for strict katana reproducibility
+./misc/AMDSEV/build.sh --katana /path/to/katana --repro-check
+```
+
+You can also compare two build output directories directly:
+
+```sh
+./misc/AMDSEV/verify-build.sh --compare /path/to/build-a /path/to/build-b
+```
+
+Each build writes deterministic provenance metadata to:
+- `build-info.txt`
+- `materials.lock`
+
+See [`REPRODUCIBILITY.md`](./REPRODUCIBILITY.md) for the full policy.
 
 ## Troubleshooting
 

--- a/misc/AMDSEV/REPRODUCIBILITY.md
+++ b/misc/AMDSEV/REPRODUCIBILITY.md
@@ -1,0 +1,43 @@
+# AMD SEV-SNP Build Reproducibility Policy
+
+## Scope
+
+This policy targets byte-identical outputs for the following artifacts when built with the same:
+- source tree revision
+- `build-config` pins
+- `SOURCE_DATE_EPOCH`
+- toolchain/runtime environment
+
+Artifacts:
+- `OVMF.fd`
+- `vmlinuz`
+- `initrd.img`
+- `katana`
+
+## Required Inputs
+
+- `SOURCE_DATE_EPOCH` must be explicitly set and fixed.
+- `OVMF_COMMIT` must be pinned.
+- Package versions and SHA256 values in `build-config` must remain pinned.
+- `BUILD_CONTAINER_IMAGE_DIGEST` should be set when using a containerized CI pipeline.
+- For katana, prefer passing a prebuilt pinned binary via `--katana`. If auto-building, set `KATANA_STRICT_REPRO=1` with vendored dependencies.
+
+## Stronger Package Source Determinism
+
+To avoid host apt source drift, set:
+- `APT_SNAPSHOT_URL`
+- `APT_SNAPSHOT_SUITE`
+- `APT_SNAPSHOT_COMPONENTS`
+
+If unset, build scripts use host apt sources and reproducibility guarantees are weaker.
+
+## Validation
+
+- Use `./misc/AMDSEV/build.sh --repro-check` to run a double-build and hash comparison.
+- Use `./misc/AMDSEV/verify-build.sh --compare DIR_A DIR_B` for explicit directory comparisons.
+
+## Provenance Files
+
+Each build emits:
+- `build-info.txt` with pinned inputs and output checksums
+- `materials.lock` with immutable input and artifact hashes

--- a/misc/AMDSEV/build-config
+++ b/misc/AMDSEV/build-config
@@ -20,3 +20,13 @@ BUSYBOX_PKG_SHA256="944b2728f53ceb3916cec2c962873c9951e612408099601751db2a0a5d81
 # Kernel modules extra (Ubuntu package, for initrd SEV-SNP support)
 KERNEL_MODULES_EXTRA_PKG_VERSION="6.8.0-90.91"
 KERNEL_MODULES_EXTRA_PKG_SHA256="c17bd76779ce68a076dc1ef9b1669947f35f1868f6736dbd0a8a7ccacf7571f3"
+
+# Optional apt snapshot source for stronger reproducibility guarantees.
+# When set, build scripts use this source instead of host /etc/apt/sources.list.
+# Example:
+#   APT_SNAPSHOT_URL="http://snapshot.ubuntu.com/ubuntu/20250115T000000Z/"
+#   APT_SNAPSHOT_SUITE="noble"
+#   APT_SNAPSHOT_COMPONENTS="main"
+APT_SNAPSHOT_URL=""
+APT_SNAPSHOT_SUITE="noble"
+APT_SNAPSHOT_COMPONENTS="main"

--- a/misc/AMDSEV/verify-build.sh
+++ b/misc/AMDSEV/verify-build.sh
@@ -3,61 +3,124 @@
 # VERIFY-BUILD.SH - Verify reproducibility of TEE builds
 # ==============================================================================
 #
-# Computes and displays checksums for all TEE build artifacts.
-# Run this after building to verify reproducibility.
+# Computes and displays checksums for TEE build artifacts.
 #
 # Usage:
 #   ./verify-build.sh [OUTPUT_DIR]
+#   ./verify-build.sh --compare OUTPUT_DIR_A OUTPUT_DIR_B
 #
 # ==============================================================================
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OUTPUT_DIR="${1:-${SCRIPT_DIR}/output/qemu}"
+ARTIFACTS=(OVMF.fd vmlinuz initrd.img katana build-info.txt materials.lock)
 
-if [[ ! -d "$OUTPUT_DIR" ]]; then
-    echo "ERROR: Output directory not found: $OUTPUT_DIR"
-    echo ""
+usage() {
     echo "Usage: $0 [OUTPUT_DIR]"
-    echo "  Default: ${SCRIPT_DIR}/output/qemu"
-    exit 1
-fi
-
-echo "=========================================="
-echo "TEE Build Verification"
-echo "=========================================="
-echo "Output directory: $OUTPUT_DIR"
-echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-echo ""
-
-echo "Artifact Checksums (SHA256):"
-echo "-------------------------------------------"
-
-for file in OVMF.fd vmlinuz initrd.img katana; do
-    if [[ -f "$OUTPUT_DIR/$file" ]]; then
-        CHECKSUM=$(sha256sum "$OUTPUT_DIR/$file" | awk '{print $1}')
-        SIZE=$(du -h "$OUTPUT_DIR/$file" | awk '{print $1}')
-        printf "%-12s %s (%s)\n" "$file:" "$CHECKSUM" "$SIZE"
-    else
-        printf "%-12s <not found>\n" "$file:"
-    fi
-done
-
-echo ""
-echo "-------------------------------------------"
-
-if [[ -f "$OUTPUT_DIR/build-info.txt" ]]; then
+    echo "       $0 --compare OUTPUT_DIR_A OUTPUT_DIR_B"
     echo ""
-    echo "Build Configuration:"
+    echo "Default OUTPUT_DIR: ${SCRIPT_DIR}/output/qemu"
+    exit 1
+}
+
+checksum_file() {
+    local file="$1"
+    if [[ -f "$file" ]]; then
+        sha256sum "$file" | awk '{print $1}'
+    else
+        echo "<missing>"
+    fi
+}
+
+print_report() {
+    local output_dir="$1"
+
+    [[ -d "$output_dir" ]] || {
+        echo "ERROR: Output directory not found: $output_dir" >&2
+        exit 1
+    }
+
+    echo "=========================================="
+    echo "TEE Build Verification"
+    echo "=========================================="
+    echo "Output directory: $output_dir"
+    echo ""
+
+    echo "Artifact Checksums (SHA256):"
     echo "-------------------------------------------"
-    grep -E "^(SOURCE_DATE_EPOCH|OVMF_COMMIT|KERNEL_VERSION)=" "$OUTPUT_DIR/build-info.txt" 2>/dev/null || true
-    echo "-------------------------------------------"
+    for file in "${ARTIFACTS[@]}"; do
+        local path="$output_dir/$file"
+        if [[ -f "$path" ]]; then
+            local checksum
+            local size
+            checksum="$(sha256sum "$path" | awk '{print $1}')"
+            size="$(du -h "$path" | awk '{print $1}')"
+            printf "%-16s %s (%s)\n" "$file:" "$checksum" "$size"
+        else
+            printf "%-16s <not found>\n" "$file:"
+        fi
+    done
+
+    if [[ -f "$output_dir/build-info.txt" ]]; then
+        echo ""
+        echo "Build Configuration:"
+        echo "-------------------------------------------"
+        grep -E "^(SOURCE_DATE_EPOCH|INPUT_MANIFEST_SHA256|OVMF_COMMIT|KERNEL_VERSION)=" "$output_dir/build-info.txt" || true
+        echo "-------------------------------------------"
+    fi
+
+    echo ""
+}
+
+compare_reports() {
+    local dir_a="$1"
+    local dir_b="$2"
+    local failed=0
+
+    [[ -d "$dir_a" ]] || { echo "ERROR: Output directory not found: $dir_a" >&2; exit 1; }
+    [[ -d "$dir_b" ]] || { echo "ERROR: Output directory not found: $dir_b" >&2; exit 1; }
+
+    echo "=========================================="
+    echo "TEE Build Reproducibility Compare"
+    echo "=========================================="
+    echo "A: $dir_a"
+    echo "B: $dir_b"
+    echo ""
+
+    for file in "${ARTIFACTS[@]}"; do
+        local checksum_a checksum_b
+        checksum_a="$(checksum_file "$dir_a/$file")"
+        checksum_b="$(checksum_file "$dir_b/$file")"
+
+        if [[ "$checksum_a" == "$checksum_b" ]]; then
+            printf "[OK] %-16s %s\n" "$file" "$checksum_a"
+        else
+            printf "[FAIL] %-16s A=%s B=%s\n" "$file" "$checksum_a" "$checksum_b"
+            failed=1
+        fi
+    done
+
+    if [[ $failed -ne 0 ]]; then
+        echo ""
+        echo "Reproducibility check failed."
+        exit 1
+    fi
+
+    echo ""
+    echo "Reproducibility check passed."
+}
+
+if [[ $# -eq 0 ]]; then
+    print_report "${SCRIPT_DIR}/output/qemu"
+    exit 0
 fi
 
-echo ""
-echo "To verify reproducibility:"
-echo "  1. Save this output: $0 > build1.txt"
-echo "  2. Clean and rebuild with same SOURCE_DATE_EPOCH"
-echo "  3. Compare: diff build1.txt build2.txt"
-echo ""
+if [[ "$1" == "--compare" ]]; then
+    [[ $# -eq 3 ]] || usage
+    compare_reports "$2" "$3"
+    exit 0
+fi
+
+[[ $# -eq 1 ]] || usage
+print_report "$1"


### PR DESCRIPTION
- Require explicit `SOURCE_DATE_EPOCH` and remove wall-clock build metadata so host time cannot perturb outputs.
- Add optional apt snapshot source pinning (while keeping version+SHA checks) to eliminate package mirror drift as a hidden input.
- Enforce pinned `OVMF_COMMIT` and validate submodule state so firmware source resolution is immutable.
- Emit deterministic provenance (`build-info.txt`, `materials.lock`, `INPUT_MANIFEST_SHA256`, toolchain/container metadata) so rebuilds are auditable and comparable.
- Add machine-checkable verification (`build.sh --repro-check`, `verify-build.sh --compare`) so reproducibility is enforced by automated hash equivalence.
