### PR TITLE
Add starknet-specs release tracker workflow

### DIFF
--- a/.github/workflows/starknet-specs-release.yml
+++ b/.github/workflows/starknet-specs-release.yml
@@ -16,24 +16,53 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE=$(gh api repos/starkware-libs/starknet-specs/releases/latest --jq '{tag: .tag_name, name: .name, url: .html_url, body: .body, published_at: .published_at}')
+          RELEASE=$(gh api repos/starkware-libs/starknet-specs/releases/latest \
+            --jq '{tag: .tag_name, name: .name, url: .html_url, body: .body, published_at: .published_at}')
           TAG=$(echo "$RELEASE" | jq -r '.tag')
           NAME=$(echo "$RELEASE" | jq -r '.name')
           URL=$(echo "$RELEASE" | jq -r '.url')
           PUBLISHED=$(echo "$RELEASE" | jq -r '.published_at')
 
-          # Escape body for multiline output
           BODY=$(echo "$RELEASE" | jq -r '.body')
           echo "body<<EOF" >> $GITHUB_OUTPUT
           echo "$BODY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Strip 'v' prefix for version comparison
+          VERSION="${TAG#v}"
+
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "url=$URL" >> $GITHUB_OUTPUT
           echo "published_at=$PUBLISHED" >> $GITHUB_OUTPUT
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read current spec version
+        id: current-version
+        run: |
+          CURRENT=$(sed -n 's/.*RPC_SPEC_VERSION.*"\([^"]*\)".*/\1/p' \
+            crates/rpc/rpc-api/src/starknet.rs)
+          echo "version=$CURRENT" >> $GITHUB_OUTPUT
+          echo "Current RPC_SPEC_VERSION: $CURRENT"
+
+      - name: Check if update needed
+        id: version-check
+        run: |
+          CURRENT="${{ steps.current-version.outputs.version }}"
+          LATEST="${{ steps.latest-release.outputs.version }}"
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "Already up to date (v$CURRENT)"
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          else
+            echo "New version available: v$CURRENT -> v$LATEST"
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check if issue already exists
+        if: steps.version-check.outputs.needs_update == 'true'
         id: check-existing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,8 +77,44 @@ jobs:
             --jq 'length')
           echo "exists=$([[ "$EXISTING" -gt 0 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
 
+      - name: Fetch spec files
+        if: steps.version-check.outputs.needs_update == 'true' && steps.check-existing.outputs.exists == 'false'
+        run: |
+          CURRENT_TAG="v${{ steps.current-version.outputs.version }}"
+          NEW_TAG="${{ steps.latest-release.outputs.tag }}"
+          BASE_URL="https://raw.githubusercontent.com/starkware-libs/starknet-specs"
+
+          mkdir -p /tmp/specs/old /tmp/specs/new
+
+          for FILE in starknet_api_openrpc.json starknet_write_api.json starknet_trace_api_openrpc.json; do
+            curl -sfL "$BASE_URL/$CURRENT_TAG/api/$FILE" -o "/tmp/specs/old/$FILE"
+            curl -sfL "$BASE_URL/$NEW_TAG/api/$FILE" -o "/tmp/specs/new/$FILE"
+          done
+
+      - name: Install uv
+        if: steps.version-check.outputs.needs_update == 'true' && steps.check-existing.outputs.exists == 'false'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Generate spec diff
+        if: steps.version-check.outputs.needs_update == 'true' && steps.check-existing.outputs.exists == 'false'
+        id: diff
+        run: |
+          DIFF=$(uv run scripts/diff-openrpc-specs.py \
+            --old-read /tmp/specs/old/starknet_api_openrpc.json \
+            --new-read /tmp/specs/new/starknet_api_openrpc.json \
+            --old-write /tmp/specs/old/starknet_write_api.json \
+            --new-write /tmp/specs/new/starknet_write_api.json \
+            --old-trace /tmp/specs/old/starknet_trace_api_openrpc.json \
+            --new-trace /tmp/specs/new/starknet_trace_api_openrpc.json \
+            --old-version "${{ steps.current-version.outputs.version }}" \
+            --new-version "${{ steps.latest-release.outputs.version }}")
+
+          echo "diff<<EOF" >> $GITHUB_OUTPUT
+          echo "$DIFF" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create tracking issue
-        if: steps.check-existing.outputs.exists == 'false'
+        if: steps.version-check.outputs.needs_update == 'true' && steps.check-existing.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -57,25 +122,39 @@ jobs:
           NAME="${{ steps.latest-release.outputs.name }}"
           URL="${{ steps.latest-release.outputs.url }}"
           PUBLISHED="${{ steps.latest-release.outputs.published_at }}"
-          BODY="${{ steps.latest-release.outputs.body }}"
+          CURRENT="${{ steps.current-version.outputs.version }}"
 
-          gh issue create \
-            --repo ${{ github.repository }} \
-            --title "starknet-specs release ${TAG}" \
-            --label "starknet-specs-release" \
-            --body "$(cat <<EOF
+          cat > /tmp/issue-body.md <<ISSUE_EOF
           A new version of [starknet-specs](https://github.com/starkware-libs/starknet-specs) has been released.
 
           **Release:** [${NAME}](${URL})
           **Tag:** \`${TAG}\`
           **Published:** ${PUBLISHED}
+          **Current Katana spec version:** \`${CURRENT}\`
 
           ### Release Notes
 
-          ${BODY}
+          ${{ steps.latest-release.outputs.body }}
 
           ---
 
-          Review the changes and update Katana's RPC implementation as needed.
-          EOF
-          )"
+          ${{ steps.diff.outputs.diff }}
+
+          ---
+
+          ### Action Items
+
+          - [ ] Review the API changes above
+          - [ ] Update \`RPC_SPEC_VERSION\` in \`crates/rpc/rpc-api/src/starknet.rs\`
+          - [ ] Implement new methods (if any)
+          - [ ] Update changed method signatures (if any)
+          - [ ] Remove deprecated methods (if any)
+          - [ ] Update RPC type definitions in \`crates/rpc/rpc-types/\`
+          - [ ] Add/update tests for changed endpoints
+          ISSUE_EOF
+
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "starknet-specs release ${TAG}" \
+            --label "starknet-specs-release" \
+            --body-file /tmp/issue-body.md

--- a/.github/workflows/starknet-specs-release.yml
+++ b/.github/workflows/starknet-specs-release.yml
@@ -1,0 +1,81 @@
+name: Starknet Specs Release Tracker
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Check every Monday at 9:00 AM UTC
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  check-release:
+    name: Check for new starknet-specs release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest starknet-specs release
+        id: latest-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE=$(gh api repos/starkware-libs/starknet-specs/releases/latest --jq '{tag: .tag_name, name: .name, url: .html_url, body: .body, published_at: .published_at}')
+          TAG=$(echo "$RELEASE" | jq -r '.tag')
+          NAME=$(echo "$RELEASE" | jq -r '.name')
+          URL=$(echo "$RELEASE" | jq -r '.url')
+          PUBLISHED=$(echo "$RELEASE" | jq -r '.published_at')
+
+          # Escape body for multiline output
+          BODY=$(echo "$RELEASE" | jq -r '.body')
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "published_at=$PUBLISHED" >> $GITHUB_OUTPUT
+
+      - name: Check if issue already exists
+        id: check-existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.latest-release.outputs.tag }}"
+          EXISTING=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label "starknet-specs-release" \
+            --search "starknet-specs release ${TAG}" \
+            --state all \
+            --json number \
+            --jq 'length')
+          echo "exists=$([[ "$EXISTING" -gt 0 ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Create tracking issue
+        if: steps.check-existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.latest-release.outputs.tag }}"
+          NAME="${{ steps.latest-release.outputs.name }}"
+          URL="${{ steps.latest-release.outputs.url }}"
+          PUBLISHED="${{ steps.latest-release.outputs.published_at }}"
+          BODY="${{ steps.latest-release.outputs.body }}"
+
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "starknet-specs release ${TAG}" \
+            --label "starknet-specs-release" \
+            --body "$(cat <<EOF
+          A new version of [starknet-specs](https://github.com/starkware-libs/starknet-specs) has been released.
+
+          **Release:** [${NAME}](${URL})
+          **Tag:** \`${TAG}\`
+          **Published:** ${PUBLISHED}
+
+          ### Release Notes
+
+          ${BODY}
+
+          ---
+
+          Review the changes and update Katana's RPC implementation as needed.
+          EOF
+          )"

--- a/.github/workflows/starknet-specs-release.yml
+++ b/.github/workflows/starknet-specs-release.yml
@@ -1,9 +1,17 @@
+# Tracks new releases of starkware-libs/starknet-specs.
+#
+# Compares the latest stable release against RPC_SPEC_VERSION in
+# crates/rpc/rpc-api/src/starknet.rs. If a newer version exists,
+# diffs the OpenRPC spec files (read, write, trace) and opens a
+# tracking issue with the changes.
+#
+# Deduplication: skips if version matches or a matching issue already exists.
 name: Starknet Specs Release Tracker
 
 on:
   schedule:
-    - cron: "0 9 * * 1" # Check every Monday at 9:00 AM UTC
-  workflow_dispatch: # Allow manual triggering
+    - cron: "0 9 * * 1" # Every Monday at 9:00 AM UTC
+  workflow_dispatch:
 
 jobs:
   check-release:

--- a/scripts/diff-openrpc-specs.py
+++ b/scripts/diff-openrpc-specs.py
@@ -132,9 +132,7 @@ def format_section(title, filename, added, removed, changed, new_map):
     lines = [f"### {title} (`{filename}`)", ""]
 
     if not added and not removed and not changed:
-        lines.append("No changes.")
-        lines.append("")
-        return lines, 0, 0, 0
+        return [], 0, 0, 0
 
     lines.append("| Method | Status | Details |")
     lines.append("|--------|--------|---------|")

--- a/scripts/diff-openrpc-specs.py
+++ b/scripts/diff-openrpc-specs.py
@@ -36,22 +36,22 @@ def compare_params(old_params, new_params):
 
     for name in sorted(set(new_by_name) - set(old_by_name)):
         req = new_by_name[name].get("required", True)
-        changes.append(f"  - Parameter `{name}` added (required: `{req}`)")
+        changes.append(f"Parameter `{name}` added (required: `{req}`)")
 
     for name in sorted(set(old_by_name) - set(new_by_name)):
-        changes.append(f"  - Parameter `{name}` removed")
+        changes.append(f"Parameter `{name}` removed")
 
     for name in sorted(set(old_by_name) & set(new_by_name)):
         old_p, new_p = old_by_name[name], new_by_name[name]
         if old_p.get("required", True) != new_p.get("required", True):
             changes.append(
-                f"  - Parameter `{name}`: required changed "
+                f"Parameter `{name}`: required "
                 f"`{old_p.get('required', True)}` → `{new_p.get('required', True)}`"
             )
         if schema_fingerprint(old_p.get("schema")) != schema_fingerprint(
             new_p.get("schema")
         ):
-            changes.append(f"  - Parameter `{name}`: schema changed")
+            changes.append(f"Parameter `{name}`: schema changed")
 
     return changes
 
@@ -61,7 +61,7 @@ def compare_result(old_result, new_result):
     old_schema = schema_fingerprint(old_result.get("schema") if old_result else None)
     new_schema = schema_fingerprint(new_result.get("schema") if new_result else None)
     if old_schema != new_schema:
-        return ["  - Return type changed"]
+        return ["Return type changed"]
     return []
 
 
@@ -71,9 +71,9 @@ def compare_errors(old_errors, new_errors):
     new_set = {schema_fingerprint(e) for e in new_errors}
     changes = []
     for e in sorted(new_set - old_set):
-        changes.append(f"  - Error added: `{extract_ref_name(json.loads(e))}`")
+        changes.append(f"Error added: `{extract_ref_name(json.loads(e))}`")
     for e in sorted(old_set - new_set):
-        changes.append(f"  - Error removed: `{extract_ref_name(json.loads(e))}`")
+        changes.append(f"Error removed: `{extract_ref_name(json.loads(e))}`")
     return changes
 
 
@@ -128,7 +128,7 @@ def diff_api(old_spec, new_spec):
 
 
 def format_section(title, filename, added, removed, changed, new_map):
-    """Format a single API section as markdown."""
+    """Format a single API section as a markdown table."""
     lines = [f"### {title} (`{filename}`)", ""]
 
     if not added and not removed and not changed:
@@ -136,27 +136,20 @@ def format_section(title, filename, added, removed, changed, new_map):
         lines.append("")
         return lines, 0, 0, 0
 
-    if added:
-        lines.append("#### New Methods")
-        for name in added:
-            params_str = format_method_params(new_map.get(name, {}))
-            lines.append(f"- `{name}` — {params_str}")
-        lines.append("")
+    lines.append("| Method | Status | Details |")
+    lines.append("|--------|--------|---------|")
 
-    if removed:
-        lines.append("#### Removed Methods")
-        for name in removed:
-            lines.append(f"- `{name}`")
-        lines.append("")
+    for name in added:
+        params_str = format_method_params(new_map.get(name, {}))
+        lines.append(f"| `{name}` | Added | {params_str} |")
 
-    if changed:
-        lines.append("#### Changed Methods")
-        for name, changes in changed.items():
-            lines.append(f"- **`{name}`**")
-            for c in changes:
-                lines.append(c)
-        lines.append("")
+    for name in removed:
+        lines.append(f"| `{name}` | Removed | |")
 
+    for name, details in changed.items():
+        lines.append(f"| `{name}` | Changed | {'; '.join(details)} |")
+
+    lines.append("")
     return lines, len(added), len(removed), len(changed)
 
 

--- a/scripts/diff-openrpc-specs.py
+++ b/scripts/diff-openrpc-specs.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Diff two versions of the Starknet OpenRPC specifications.
+
+Compares method signatures (name, params, result, errors) between two
+versions of the spec and outputs a structured markdown report.
+"""
+
+import argparse
+import json
+import sys
+
+
+def build_method_map(spec):
+    """Build a dict of method_name -> method_definition."""
+    return {m["name"]: m for m in spec.get("methods", [])}
+
+
+def extract_ref_name(obj):
+    """Extract the last path segment from a $ref string."""
+    if isinstance(obj, dict):
+        ref = obj.get("$ref", "")
+        return ref.rsplit("/", 1)[-1] if "/" in ref else json.dumps(obj, sort_keys=True)
+    return str(obj)
+
+
+def schema_fingerprint(schema):
+    """Return a canonical string representation of a schema for comparison."""
+    return json.dumps(schema, sort_keys=True)
+
+
+def compare_params(old_params, new_params):
+    """Compare parameter lists and return a list of change descriptions."""
+    changes = []
+    old_by_name = {p["name"]: p for p in old_params}
+    new_by_name = {p["name"]: p for p in new_params}
+
+    for name in sorted(set(new_by_name) - set(old_by_name)):
+        req = new_by_name[name].get("required", True)
+        changes.append(f"  - Parameter `{name}` added (required: `{req}`)")
+
+    for name in sorted(set(old_by_name) - set(new_by_name)):
+        changes.append(f"  - Parameter `{name}` removed")
+
+    for name in sorted(set(old_by_name) & set(new_by_name)):
+        old_p, new_p = old_by_name[name], new_by_name[name]
+        if old_p.get("required", True) != new_p.get("required", True):
+            changes.append(
+                f"  - Parameter `{name}`: required changed "
+                f"`{old_p.get('required', True)}` → `{new_p.get('required', True)}`"
+            )
+        if schema_fingerprint(old_p.get("schema")) != schema_fingerprint(
+            new_p.get("schema")
+        ):
+            changes.append(f"  - Parameter `{name}`: schema changed")
+
+    return changes
+
+
+def compare_result(old_result, new_result):
+    """Compare result schemas and return change descriptions."""
+    old_schema = schema_fingerprint(old_result.get("schema") if old_result else None)
+    new_schema = schema_fingerprint(new_result.get("schema") if new_result else None)
+    if old_schema != new_schema:
+        return ["  - Return type changed"]
+    return []
+
+
+def compare_errors(old_errors, new_errors):
+    """Compare error lists and return change descriptions."""
+    old_set = {schema_fingerprint(e) for e in old_errors}
+    new_set = {schema_fingerprint(e) for e in new_errors}
+    changes = []
+    for e in sorted(new_set - old_set):
+        changes.append(f"  - Error added: `{extract_ref_name(json.loads(e))}`")
+    for e in sorted(old_set - new_set):
+        changes.append(f"  - Error removed: `{extract_ref_name(json.loads(e))}`")
+    return changes
+
+
+def format_method_params(method):
+    """Format a method's parameter list as a concise string."""
+    params = method.get("params", [])
+    if not params:
+        return "(no params)"
+    parts = []
+    for p in params:
+        req = "required" if p.get("required", True) else "optional"
+        parts.append(f"`{p['name']}` ({req})")
+    return ", ".join(parts)
+
+
+def diff_api(old_spec, new_spec):
+    """Diff two spec files and return (added, removed, changed, new_map)."""
+    old_map = build_method_map(old_spec)
+    new_map = build_method_map(new_spec)
+
+    old_names = set(old_map)
+    new_names = set(new_map)
+
+    added = sorted(new_names - old_names)
+    removed = sorted(old_names - new_names)
+
+    changed = {}
+    for name in sorted(old_names & new_names):
+        method_changes = []
+        method_changes.extend(
+            compare_params(
+                old_map[name].get("params", []),
+                new_map[name].get("params", []),
+            )
+        )
+        method_changes.extend(
+            compare_result(
+                old_map[name].get("result"),
+                new_map[name].get("result"),
+            )
+        )
+        method_changes.extend(
+            compare_errors(
+                old_map[name].get("errors", []),
+                new_map[name].get("errors", []),
+            )
+        )
+        if method_changes:
+            changed[name] = method_changes
+
+    return added, removed, changed, new_map
+
+
+def format_section(title, filename, added, removed, changed, new_map):
+    """Format a single API section as markdown."""
+    lines = [f"### {title} (`{filename}`)", ""]
+
+    if not added and not removed and not changed:
+        lines.append("No changes.")
+        lines.append("")
+        return lines, 0, 0, 0
+
+    if added:
+        lines.append("#### New Methods")
+        for name in added:
+            params_str = format_method_params(new_map.get(name, {}))
+            lines.append(f"- `{name}` — {params_str}")
+        lines.append("")
+
+    if removed:
+        lines.append("#### Removed Methods")
+        for name in removed:
+            lines.append(f"- `{name}`")
+        lines.append("")
+
+    if changed:
+        lines.append("#### Changed Methods")
+        for name, changes in changed.items():
+            lines.append(f"- **`{name}`**")
+            for c in changes:
+                lines.append(c)
+        lines.append("")
+
+    return lines, len(added), len(removed), len(changed)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Diff OpenRPC specs")
+    parser.add_argument("--old-read", required=True)
+    parser.add_argument("--new-read", required=True)
+    parser.add_argument("--old-write", required=True)
+    parser.add_argument("--new-write", required=True)
+    parser.add_argument("--old-trace", required=True)
+    parser.add_argument("--new-trace", required=True)
+    parser.add_argument("--old-version", required=True)
+    parser.add_argument("--new-version", required=True)
+    args = parser.parse_args()
+
+    specs = {}
+    for key, attr in [
+        ("old-read", "old_read"),
+        ("new-read", "new_read"),
+        ("old-write", "old_write"),
+        ("new-write", "new_write"),
+        ("old-trace", "old_trace"),
+        ("new-trace", "new_trace"),
+    ]:
+        path = getattr(args, attr)
+        try:
+            with open(path) as f:
+                specs[key] = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            print(f"Error loading {path}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    output = [f"## OpenRPC Spec Diff: v{args.old_version} → v{args.new_version}", ""]
+
+    api_stats = []
+
+    for title, filename, old_key, new_key in [
+        ("Read API", "starknet_api_openrpc.json", "old-read", "new-read"),
+        ("Write API", "starknet_write_api.json", "old-write", "new-write"),
+        ("Trace API", "starknet_trace_api_openrpc.json", "old-trace", "new-trace"),
+    ]:
+        added, removed, changed, new_map = diff_api(specs[old_key], specs[new_key])
+        lines, a, r, c = format_section(
+            title, filename, added, removed, changed, new_map
+        )
+        output.extend(lines)
+        api_stats.append((title, a, r, c))
+
+    total_a = sum(s[1] for s in api_stats)
+    total_r = sum(s[2] for s in api_stats)
+    total_c = sum(s[3] for s in api_stats)
+
+    output.append("### Summary")
+    output.append("")
+    output.append("| | Added | Removed | Changed |")
+    output.append("|---|---|---|---|")
+    for title, a, r, c in api_stats:
+        output.append(f"| {title} | {a} | {r} | {c} |")
+    output.append(f"| **Total** | **{total_a}** | **{total_r}** | **{total_c}** |")
+    output.append("")
+
+    print("\n".join(output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a weekly GitHub Actions workflow that checks for new releases of `starkware-libs/starknet-specs`, diffs the OpenRPC spec files against Katana's current `RPC_SPEC_VERSION`, and opens a tracking issue with the API changes in tabular format. Deduplicates by version comparison and existing issue check.

Example issue output (v0.9.0 → v0.10.0):

---

A new version of [starknet-specs](https://github.com/starkware-libs/starknet-specs) has been released.

**Release:** [v0.10.0](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.0)
**Tag:** `v0.10.0`
**Published:** 2025-11-25T16:29:10Z
**Current Katana spec version:** `0.9.0`

### Release Notes

...

---

## OpenRPC Spec Diff: v0.9.0 → v0.10.0

### Read API (`starknet_api_openrpc.json`)

| Method | Status | Details |
|--------|--------|---------|
| `starknet_estimateFee` | Changed | Error added: `CONTRACT_NOT_FOUND` |
| `starknet_estimateMessageFee` | Changed | Error added: `CONTRACT_NOT_FOUND` |
| `starknet_getStorageProof` | Changed | Parameter `contracts_storage_keys`: schema changed |

### Summary

| | Added | Removed | Changed |
|---|---|---|---|
| Read API | 0 | 0 | 3 |
| Write API | 0 | 0 | 0 |
| Trace API | 0 | 0 | 0 |
| **Total** | **0** | **0** | **3** |

---

### Action Items

- [ ] Review the API changes above
- [ ] Update `RPC_SPEC_VERSION` in `crates/rpc/rpc-api/src/starknet.rs`
- [ ] Implement new methods (if any)
- [ ] Update changed method signatures (if any)
- [ ] Remove deprecated methods (if any)
- [ ] Update RPC type definitions in `crates/rpc/rpc-types/`
- [ ] Add/update tests for changed endpoints

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)