### PR TITLE
fix(core): remove mined txs from pool directly in `force_mine()`

### DIFF
--- a/crates/core/src/service/block_producer.rs
+++ b/crates/core/src/service/block_producer.rs
@@ -20,6 +20,7 @@ use futures::stream::{Stream, StreamExt};
 use futures::FutureExt;
 use katana_executor::{ExecutionResult, ExecutionStats, Executor};
 use katana_pool::validation::stateful::TxValidator;
+use katana_pool::TransactionPool;
 use katana_primitives::block::{BlockHash, BlockHashOrNumber};
 use katana_primitives::execution::TransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
@@ -159,12 +160,16 @@ where
     }
 
     // Handler for the `katana_generateBlock` RPC method.
-    pub fn force_mine(&self) {
+    pub fn force_mine(&self, pool: &impl TransactionPool) {
         trace!(target: LOG_TARGET, "Scheduling force block mining.");
         let mut mode = self.producer.write();
-        match &mut *mode {
+        let outcome = match &mut *mode {
             BlockProducerMode::Instant(producer) => producer.force_mine(),
             BlockProducerMode::Interval(producer) => producer.force_mine(),
+        };
+
+        if let Some(outcome) = outcome {
+            pool.remove_transactions(&outcome.txs);
         }
     }
 
@@ -330,7 +335,7 @@ where
     <PF as ProviderFactory>::ProviderMut: ProviderRW,
 {
     /// Force mine a new block. It will only able to mine if there is no ongoing mining process.
-    pub fn force_mine(&mut self) {
+    pub fn force_mine(&mut self) -> Option<MinedBlockOutcome> {
         match Self::do_mine(self.permit.clone(), self.executor.clone(), self.backend.clone()) {
             Ok(outcome) => {
                 info!(target: LOG_TARGET, block_number = %outcome.block_number, "Force mined block.");
@@ -349,9 +354,11 @@ where
                 // -------------------------------------------
 
                 unsafe { self.permit.raw().unlock() };
+                Some(outcome)
             }
             Err(e) => {
                 error!(target: LOG_TARGET, error = %e, "On force mine.");
+                None
             }
         }
     }
@@ -651,17 +658,24 @@ where
         }
     }
 
-    pub fn force_mine(&mut self) {
+    pub fn force_mine(&mut self) -> Option<MinedBlockOutcome> {
         if self.block_mining.is_none() {
             let txs = std::mem::take(&mut self.queued);
-            let _ = Self::do_mine(
+            match Self::do_mine(
                 self.validator.clone(),
                 self.permit.clone(),
                 self.backend.clone(),
                 txs,
-            );
+            ) {
+                Ok(outcome) => Some(outcome),
+                Err(e) => {
+                    error!(target: LOG_TARGET, error = %e, "On force mine.");
+                    None
+                }
+            }
         } else {
-            trace!(target: LOG_TARGET, "Unable to force mine while a mining process is running.")
+            trace!(target: LOG_TARGET, "Unable to force mine while a mining process is running.");
+            None
         }
     }
 

--- a/crates/node/sequencer/src/lib.rs
+++ b/crates/node/sequencer/src/lib.rs
@@ -322,7 +322,7 @@ where
         }
 
         if config.rpc.apis.contains(&RpcModuleKind::Dev) {
-            let api = DevApi::new(backend.clone(), block_producer.clone());
+            let api = DevApi::new(backend.clone(), block_producer.clone(), pool.clone());
             rpc_modules.merge(DevApiServer::into_rpc(api))?;
         }
 

--- a/crates/rpc/rpc-server/src/cartridge/mod.rs
+++ b/crates/rpc/rpc-server/src/cartridge/mod.rs
@@ -203,7 +203,7 @@ where
                 ).await? {
                     debug!(target: "rpc::cartridge", controller = %address, tx = format!("{:#x}", tx.hash), "Inserting Controller deployment transaction");
                     this.pool.add_transaction(tx).await?;
-                    this.block_producer.force_mine();
+                    this.block_producer.force_mine(&this.pool);
                 }
             }
             // ===================================================================

--- a/crates/rpc/rpc-server/src/dev.rs
+++ b/crates/rpc/rpc-server/src/dev.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use jsonrpsee::core::{async_trait, RpcResult};
 use katana_core::backend::Backend;
 use katana_core::service::block_producer::{BlockProducer, BlockProducerMode, PendingExecutor};
+use katana_pool::TxPool;
 use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
 use katana_provider::api::state::StateWriter;
 use katana_provider::{MutableProvider, ProviderFactory, ProviderRO, ProviderRW};
@@ -17,6 +18,7 @@ where
 {
     backend: Arc<Backend<PF>>,
     block_producer: BlockProducer<PF>,
+    pool: TxPool,
 }
 
 impl<PF> DevApi<PF>
@@ -25,8 +27,8 @@ where
     <PF as ProviderFactory>::Provider: ProviderRO,
     <PF as ProviderFactory>::ProviderMut: ProviderRW,
 {
-    pub fn new(backend: Arc<Backend<PF>>, block_producer: BlockProducer<PF>) -> Self {
-        Self { backend, block_producer }
+    pub fn new(backend: Arc<Backend<PF>>, block_producer: BlockProducer<PF>, pool: TxPool) -> Self {
+        Self { backend, block_producer, pool }
     }
 
     /// Returns the pending state if the sequencer is running in _interval_ mode. Otherwise `None`.
@@ -105,7 +107,7 @@ where
     <PF as ProviderFactory>::ProviderMut: ProviderRW,
 {
     async fn generate_block(&self) -> RpcResult<()> {
-        self.block_producer.force_mine();
+        self.block_producer.force_mine(&self.pool);
         Ok(())
     }
 

--- a/crates/rpc/rpc-server/tests/dev.rs
+++ b/crates/rpc/rpc-server/tests/dev.rs
@@ -1,3 +1,5 @@
+use common::{Erc20Contract, Uint256};
+use katana_genesis::constant::DEFAULT_ETH_FEE_TOKEN_ADDRESS;
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::Felt;
 use katana_provider::api::block::{BlockNumberProvider, BlockProvider};
@@ -5,7 +7,10 @@ use katana_provider::api::env::BlockEnvProvider;
 use katana_provider::api::state::StateFactoryProvider;
 use katana_provider::ProviderFactory;
 use katana_rpc_server::api::dev::DevApiClient;
+use katana_rpc_server::api::txpool::TxPoolApiClient;
 use katana_utils::TestNode;
+
+mod common;
 
 #[tokio::test]
 async fn test_next_block_timestamp_in_past() {
@@ -190,4 +195,32 @@ async fn test_set_storage_at_with_pending_block() {
         let read_val = state.storage(contract_address, key).unwrap();
         assert_eq!(read_val, Some(value), "storage value should persist after block is mined");
     }
+}
+
+#[tokio::test]
+async fn test_generate_block_drains_pool_transactions() {
+    let mut config = katana_utils::node::test_config();
+    config.sequencing.no_mining = true;
+
+    let sequencer = TestNode::new_with_config(config).await;
+
+    let client = sequencer.rpc_http_client();
+    let provider = sequencer.starknet_rpc_client();
+    let account = sequencer.account();
+
+    let contract = Erc20Contract::new(DEFAULT_ETH_FEE_TOKEN_ADDRESS.into(), &account);
+    let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+
+    let res = contract.transfer(&Felt::ONE, &amount).send().await.unwrap();
+    katana_utils::TxWaiter::new(res.transaction_hash, &provider).await.unwrap();
+
+    let status = client.txpool_status().await.unwrap();
+    assert_eq!(status.pending, 1, "pool should contain submitted tx before force mining");
+    assert_eq!(status.queued, 0, "queued pool is currently unsupported");
+
+    client.generate_block().await.unwrap();
+
+    let status = client.txpool_status().await.unwrap();
+    assert_eq!(status.pending, 0, "pool should be drained after force mining");
+    assert_eq!(status.queued, 0, "queued pool is currently unsupported");
 }


### PR DESCRIPTION
When `dev_generateBlock` is called, `force_mine()` mines a block synchronously but discards the `MinedBlockOutcome`. The only code path that removes mined transactions from the pool goes through `BlockProductionTask`, which receives outcomes via `Stream::poll_next()`. Since `force_mine()` bypasses the stream, mined transactions are never removed — they stay as ghosts in the pool, inflating the pending count and causing duplicate processing on subsequent blocks.

This changes `force_mine()` to accept a pool reference and call `pool.remove_transactions()` directly after a successful mine. The inner `force_mine()` on both `IntervalBlockProducer` and `InstantBlockProducer` now returns `Option<MinedBlockOutcome>` so the caller can act on it. DevApi gains a pool field so it can pass it through.