### PR TITLE
make: build all artifacts by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,12 @@ VRF_SCARB_VERSION := $(shell if [ -f $(VRF_DIR)/.tool-versions ]; then awk '$$1 
 # All scarb versions needed for `make contracts`.
 SCARB_REQUIRED_VERSIONS := $(sort $(SCARB_VERSION) $(AVNU_SCARB_VERSION) $(VRF_SCARB_VERSION))
 
-.DEFAULT_GOAL := usage
+.DEFAULT_GOAL := all
 .SILENT: clean
-.PHONY: usage help check-llvm native-deps native-deps-macos native-deps-linux native-deps-windows build-explorer contracts tee-sev-snp clean deps install-scarb fixtures snos-artifacts db-compat-artifacts generate-db-fixtures install-pyenv
+.PHONY: all usage help check-llvm native-deps native-deps-macos native-deps-linux native-deps-windows build-explorer contracts tee-sev-snp clean deps install-scarb fixtures snos-artifacts db-compat-artifacts generate-db-fixtures install-pyenv
+
+all: fixtures build-explorer
+	@echo "All build artifacts generated successfully."
 
 usage help:
 	@echo "Usage:"


### PR DESCRIPTION
Change the default `make` target from `usage` to a new `all` target that builds fixtures (including contracts) and the explorer. Help text remains available via `make help` or `make usage`.