### PR TITLE
feat(sync): support unversioned blocks and verify block hashes

### DIFF
--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -136,8 +136,13 @@ impl Node {
         // Configure pruning
         pipeline.set_pruning_config(config.pruning.clone());
 
+        let chain_id = match config.network {
+            Network::Mainnet => katana_primitives::chain::ChainId::MAINNET,
+            Network::Sepolia => katana_primitives::chain::ChainId::SEPOLIA,
+        };
+
         let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
-        pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader));
+        pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
         pipeline.add_stage(Classes::new(storage_provider.clone(), gateway_client.clone(), 20));
         pipeline.add_stage(StateTrie::new(storage_provider.clone(), task_spawner.clone()));
 

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -321,7 +321,7 @@ impl Header {
     ///     parent_block_hash
     /// )
     ///
-    /// Based on StarkWare's [Sequencer implementation].
+    /// Based on StarkWare’s [Sequencer implementation].
     ///
     /// [sequencer implementation]: https://github.com/starkware-libs/sequencer/blob/bb361ec67396660d5468fd088171913e11482708/crates/starknet_api/src/block_hash/block_hash_calculator.rs#l62-l93
     pub fn compute_hash(&self) -> Felt {
@@ -370,7 +370,7 @@ impl Header {
     // where, L1 DA mode is 0 for calldata, and 1 for blob.
     //
     // Based on https://github.com/starkware-libs/sequencer/blob/bb361ec67396660d5468fd088171913e11482708/crates/starknet_api/src/block_hash/block_hash_calculator.rs#L135-L164
-    fn concat_counts(
+    pub fn concat_counts(
         transaction_count: u32,
         event_count: u32,
         state_diff_length: u32,

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -12,11 +12,24 @@
 pub const CURRENT_STARKNET_VERSION: StarknetVersion = StarknetVersion::new([0, 13, 4, 0]);
 
 /// Starknet protocol version.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
 pub struct StarknetVersion {
     /// Each segments represents a part of the version number.
     segments: [u8; 4],
+}
+
+impl StarknetVersion {
+    /// Represents blocks that predate Starknet protocol versioning.
+    ///
+    /// Early Starknet mainnet blocks were produced before the protocol included a version
+    /// field. This constant represents that absence as a first-class value rather than
+    /// using `Option` or a sentinel error. No official Starknet release uses version `0.0.0`,
+    /// so this is unambiguous.
+    pub const UNVERSIONED: Self = Self::new([0, 0, 0, 0]);
+
+    pub const V0_7_0: Self = Self::new([0, 7, 0, 0]);
+    pub const V0_13_2: Self = Self::new([0, 13, 2, 0]);
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -36,7 +49,7 @@ impl StarknetVersion {
     /// The string can have fewer than 4 segments; missing segments are filled with zeros.
     pub fn parse(version: &str) -> Result<Self, ParseVersionError> {
         if version.is_empty() {
-            return Err(ParseVersionError::InvalidFormat);
+            return Ok(Self::UNVERSIONED);
         }
 
         let segments = version.split('.').collect::<Vec<&str>>();
@@ -69,6 +82,12 @@ impl core::default::Default for StarknetVersion {
 // - Version::new([0, 2, 3, 0]) will be displayed as "0.2.3"
 impl core::fmt::Display for StarknetVersion {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Unversioned blocks display as empty string, matching the empty protocol
+        // version field used in early Starknet block hash computation.
+        if *self == Self::UNVERSIONED {
+            return Ok(());
+        }
+
         for (idx, segment) in self.segments.iter().enumerate() {
             // If it's the last segment, don't print it if it's zero.
             if idx == self.segments.len() - 1 {
@@ -126,6 +145,8 @@ impl TryFrom<StarknetVersion> for starknet_api::block::StarknetVersion {
 
     fn try_from(version: StarknetVersion) -> Result<Self, Self::Error> {
         match version.segments {
+            // Unversioned blocks predate all known releases; map to the earliest.
+            [0, 0, 0, 0] => Ok(Self::V0_9_1),
             [0, 9, 1, 0] => Ok(Self::V0_9_1),
             [0, 10, 0, 0] => Ok(Self::V0_10_0),
             [0, 10, 1, 0] => Ok(Self::V0_10_1),
@@ -197,10 +218,34 @@ mod tests {
 
     #[test]
     fn parse_invalid_formats() {
-        let version = "";
-        assert!(StarknetVersion::parse(version).is_err());
         let version = "1.2.3.4.5";
         assert!(StarknetVersion::parse(version).is_err());
+    }
+
+    #[test]
+    fn parse_empty_string_returns_unversioned() {
+        let parsed = StarknetVersion::parse("").unwrap();
+        assert_eq!(parsed, StarknetVersion::UNVERSIONED);
+        assert_eq!(parsed.segments, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn unversioned_displays_as_empty_string() {
+        assert_eq!(StarknetVersion::UNVERSIONED.to_string(), "");
+    }
+
+    #[test]
+    fn unversioned_roundtrips_through_string() {
+        let display = StarknetVersion::UNVERSIONED.to_string();
+        let parsed = StarknetVersion::parse(&display).unwrap();
+        assert_eq!(parsed, StarknetVersion::UNVERSIONED);
+    }
+
+    #[test]
+    fn version_ordering() {
+        assert!(StarknetVersion::UNVERSIONED < StarknetVersion::V0_7_0);
+        assert!(StarknetVersion::V0_7_0 < StarknetVersion::V0_13_2);
+        assert!(StarknetVersion::V0_13_2 < CURRENT_STARKNET_VERSION);
     }
 
     #[cfg(feature = "serde")]
@@ -218,6 +263,23 @@ mod tests {
         #[test]
         fn rt_non_human_readable() {
             let version = StarknetVersion::new([1, 2, 3, 4]);
+            let serialized = postcard::to_stdvec(&version).unwrap();
+            let deserialized: StarknetVersion = postcard::from_bytes(&serialized).unwrap();
+            assert_eq!(version, deserialized);
+        }
+
+        #[test]
+        fn rt_unversioned_human_readable() {
+            let version = StarknetVersion::UNVERSIONED;
+            let serialized = serde_json::to_string(&version).unwrap();
+            assert_eq!(serialized, "\"\"");
+            let deserialized: StarknetVersion = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(version, deserialized);
+        }
+
+        #[test]
+        fn rt_unversioned_non_human_readable() {
+            let version = StarknetVersion::UNVERSIONED;
             let serialized = postcard::to_stdvec(&version).unwrap();
             let deserialized: StarknetVersion = postcard::from_bytes(&serialized).unwrap();
             assert_eq!(version, deserialized);

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -1,0 +1,158 @@
+//! Version-aware block hash computation for synced blocks.
+//!
+//! The Starknet block hash algorithm changed across protocol versions:
+//!
+//! - **Pre-0.7**: Pedersen hash chain with chain ID, uses zero for timestamp and sequencer address.
+//!
+//! - **0.7 to pre-0.13.2**: Pedersen hash chain without chain ID, uses actual timestamp and
+//!   sequencer address.
+//!
+//! - **Post-0.13.2 (v0)**: Poseidon hash with `STARKNET_BLOCK_HASH0` prefix, individual gas price
+//!   fields, and the protocol version as a short string.
+//!
+//! - **Post-0.13.4 (v1)**: Poseidon hash with `STARKNET_BLOCK_HASH1` prefix, gas prices
+//!   consolidated into a single Poseidon hash.
+
+use katana_primitives::block::Header;
+use katana_primitives::cairo::ShortString;
+use katana_primitives::chain::ChainId;
+use katana_primitives::version::StarknetVersion;
+use katana_primitives::Felt;
+use starknet::core::utils::cairo_short_string_to_felt;
+use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
+
+/// Computes the block hash for a header, dispatching to the correct algorithm based
+/// on the block's `starknet_version`.
+///
+/// The `chain_id` is required for pre-0.7 blocks which include the chain ID in the hash.
+pub fn compute_hash(header: &Header, chain_id: &ChainId) -> Felt {
+    let version_str = header.starknet_version.to_string();
+
+    if header.starknet_version < StarknetVersion::V0_7_0 {
+        compute_hash_pre_0_7(header, chain_id)
+    } else if header.starknet_version < StarknetVersion::V0_13_2 {
+        compute_hash_pre_0_13_2(header)
+    } else if header.starknet_version < StarknetVersion::new([0, 13, 4, 0]) {
+        compute_hash_post_0_13_2(header, &version_str)
+    } else {
+        compute_hash_post_0_13_4(header, &version_str)
+    }
+}
+
+/// Pre-0.7 block hash using Pedersen hash chain with chain ID.
+///
+/// Used for the earliest Starknet blocks (mainnet blocks before ~833). These blocks
+/// use zero for both timestamp and sequencer address, and include the chain ID as
+/// an extra field in the hash.
+fn compute_hash_pre_0_7(header: &Header, chain_id: &ChainId) -> Felt {
+    Pedersen::hash_array(&[
+        header.number.into(), // block number
+        header.state_root,    // global state root
+        Felt::ZERO,           // sequencer address (zero for pre-0.7)
+        Felt::ZERO,           // block timestamp (zero for pre-0.7)
+        Felt::from(header.transaction_count),
+        header.transactions_commitment,
+        Felt::ZERO,    // number of events (zero for pre-0.7)
+        Felt::ZERO,    // event commitment (zero for pre-0.7)
+        Felt::ZERO,    // protocol version
+        Felt::ZERO,    // extra data
+        chain_id.id(), // chain id (extra field in pre-0.7)
+        header.parent_hash,
+    ])
+}
+
+/// Pre-0.13.2 block hash using Pedersen hash chain.
+///
+/// Used for blocks with `0.7 <= starknet_version < 0.13.2`.
+/// Protocol version and extra data fields are set to `Felt::ZERO`.
+fn compute_hash_pre_0_13_2(header: &Header) -> Felt {
+    Pedersen::hash_array(&[
+        header.number.into(),
+        header.state_root,
+        header.sequencer_address.into(),
+        header.timestamp.into(),
+        Felt::from(header.transaction_count),
+        header.transactions_commitment,
+        Felt::from(header.events_count),
+        header.events_commitment,
+        Felt::ZERO, // protocol version
+        Felt::ZERO, // extra data
+        header.parent_hash,
+    ])
+}
+
+/// Post-0.13.2 (v0) block hash using Poseidon with `STARKNET_BLOCK_HASH0`.
+///
+/// Used for blocks with `0.13.2 <= starknet_version < 0.13.4`.
+/// Gas prices are included as individual fields.
+fn compute_hash_post_0_13_2(header: &Header, version_str: &str) -> Felt {
+    const BLOCK_HASH_VERSION: ShortString = ShortString::from_ascii("STARKNET_BLOCK_HASH0");
+
+    let concat = Header::concat_counts(
+        header.transaction_count,
+        header.events_count,
+        header.state_diff_length,
+        header.l1_da_mode,
+    );
+
+    Poseidon::hash_array(&[
+        BLOCK_HASH_VERSION.into(),
+        header.number.into(),
+        header.state_root,
+        header.sequencer_address.into(),
+        header.timestamp.into(),
+        concat,
+        header.state_diff_commitment,
+        header.transactions_commitment,
+        header.events_commitment,
+        header.receipts_commitment,
+        header.l1_gas_prices.eth.get().into(),
+        header.l1_gas_prices.strk.get().into(),
+        header.l1_data_gas_prices.eth.get().into(),
+        header.l1_data_gas_prices.strk.get().into(),
+        cairo_short_string_to_felt(version_str).unwrap(),
+        Felt::ZERO,
+        header.parent_hash,
+    ])
+}
+
+/// Post-0.13.4 (v1) block hash using Poseidon with `STARKNET_BLOCK_HASH1`.
+///
+/// Used for blocks with `starknet_version >= 0.13.4`.
+/// Gas prices are consolidated into a single Poseidon hash.
+fn compute_hash_post_0_13_4(header: &Header, version_str: &str) -> Felt {
+    const BLOCK_HASH_VERSION: ShortString = ShortString::from_ascii("STARKNET_BLOCK_HASH1");
+
+    let concat = Header::concat_counts(
+        header.transaction_count,
+        header.events_count,
+        header.state_diff_length,
+        header.l1_da_mode,
+    );
+
+    let gas_prices_hash = Poseidon::hash_array(&[
+        header.l1_gas_prices.eth.get().into(),
+        header.l1_gas_prices.strk.get().into(),
+        header.l1_data_gas_prices.eth.get().into(),
+        header.l1_data_gas_prices.strk.get().into(),
+        header.l2_gas_prices.eth.get().into(),
+        header.l2_gas_prices.strk.get().into(),
+    ]);
+
+    Poseidon::hash_array(&[
+        BLOCK_HASH_VERSION.into(),
+        header.number.into(),
+        header.state_root,
+        header.sequencer_address.into(),
+        header.timestamp.into(),
+        concat,
+        header.state_diff_commitment,
+        header.transactions_commitment,
+        header.events_commitment,
+        header.receipts_commitment,
+        gas_prices_hash,
+        cairo_short_string_to_felt(version_str).unwrap(),
+        Felt::ZERO,
+        header.parent_hash,
+    ])
+}

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -4,6 +4,7 @@ use katana_gateway_types::{BlockStatus, StateUpdate as GatewayStateUpdate, State
 use katana_primitives::block::{
     FinalityStatus, GasPrices, Header, SealedBlock, SealedBlockWithStatus,
 };
+use katana_primitives::chain::ChainId;
 use katana_primitives::fee::{FeeInfo, PriceUnit};
 use katana_primitives::receipt::{
     DeclareTxReceipt, DeployAccountTxReceipt, DeployTxReceipt, InvokeTxReceipt, L1HandlerTxReceipt,
@@ -16,7 +17,7 @@ use katana_provider::api::block::{BlockHashProvider, BlockWriter};
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderError, ProviderFactory};
 use num_traits::ToPrimitive;
 use starknet::core::types::ResourcePrice;
-use tracing::{error, info_span, Instrument};
+use tracing::{error, info_span, warn, Instrument};
 
 use crate::{
     PruneInput, PruneOutput, PruneResult, Stage, StageExecutionInput, StageExecutionOutput,
@@ -24,6 +25,7 @@ use crate::{
 };
 
 mod downloader;
+pub mod hash;
 
 pub use downloader::{BatchBlockDownloader, BlockDownloader};
 
@@ -32,12 +34,13 @@ pub use downloader::{BatchBlockDownloader, BlockDownloader};
 pub struct Blocks<B> {
     provider: DbProviderFactory,
     downloader: B,
+    chain_id: ChainId,
 }
 
 impl<B> Blocks<B> {
     /// Create a new [`Blocks`] stage.
-    pub fn new(provider: DbProviderFactory, downloader: B) -> Self {
-        Self { provider, downloader }
+    pub fn new(provider: DbProviderFactory, downloader: B, chain_id: ChainId) -> Self {
+        Self { provider, downloader, chain_id }
     }
 
     /// Validates that the downloaded blocks form a valid chain.
@@ -121,6 +124,17 @@ where
                 let (block, receipts, state_updates) = extract_block_data(block)?;
                 let block_number = block.block.header.number;
 
+                // Verify the block hash matches what we compute locally.
+                let computed_hash = hash::compute_hash(&block.block.header, &self.chain_id);
+                if computed_hash != block.block.hash {
+                    warn!(
+                        block = %block_number,
+                        expected = %block.block.hash,
+                        computed = %computed_hash,
+                        "Block hash mismatch"
+                    );
+                }
+
                 provider_mut
                     .insert_block_with_states_and_receipts(
                         block,
@@ -160,6 +174,12 @@ pub enum Error {
          previous block hash {expected_hash:#x}"
     )]
     ChainInvariantViolation { block_num: u64, parent_hash: Felt, expected_hash: Felt },
+
+    #[error(
+        "block hash mismatch: block {block_num} gateway hash {expected:#x} does not match \
+         computed hash {computed:#x}"
+    )]
+    BlockHashMismatch { block_num: u64, expected: Felt, computed: Felt },
 }
 
 fn extract_block_data(

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -10,6 +10,7 @@ use katana_gateway_types::{
 use katana_primitives::block::{
     BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,
 };
+use katana_primitives::chain::ChainId;
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::{felt, ContractAddress, Felt};
 use katana_provider::api::block::{BlockHashProvider, BlockNumberProvider, BlockWriter};
@@ -223,7 +224,7 @@ async fn download_and_store_blocks(
         downloader = downloader.with_block(block_num, create_downloaded_block(block_num));
     }
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
+    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(from_block, to_block);
 
     let result = stage.execute(&input).await;
@@ -246,7 +247,7 @@ async fn download_failure_returns_error() {
     // Create provider with initial block at block_number - 1
     let provider = create_provider_with_block(create_stored_block(block_number - 1));
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
+    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(block_number, block_number);
 
     let result = stage.execute(&input).await;
@@ -281,7 +282,7 @@ async fn partial_download_failure_stops_execution() {
     downloader = downloader.with_error(103, "Block not found".to_string());
 
     let provider = create_provider_with_block(create_stored_block(from_block - 1));
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
+    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
 
     let input = StageExecutionInput::new(from_block, to_block);
     let result = stage.execute(&input).await;
@@ -306,7 +307,7 @@ async fn fetch_blocks_from_gateway() {
     let feeder_gateway = SequencerGateway::sepolia();
     let downloader = BatchBlockDownloader::new_gateway(feeder_gateway, 10);
 
-    let mut stage = Blocks::new(provider.clone(), downloader);
+    let mut stage = Blocks::new(provider.clone(), downloader, ChainId::SEPOLIA);
 
     let input = StageExecutionInput::new(from_block, to_block);
     stage.execute(&input).await.expect("failed to execute stage");
@@ -325,7 +326,7 @@ async fn downloaded_blocks_do_not_form_valid_chain_with_stored_blocks() {
     let downloader = MockBlockDownloader::new()
         .with_block(100, create_downloaded_block_with_parent(100, felt!("0x1337")));
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
+    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(100, 100);
 
     let result = stage.execute(&input).await;
@@ -364,7 +365,7 @@ async fn downloaded_blocks_do_not_form_valid_chain() {
         // Block 102 with incorrect parent hash (should be 101)
         .with_block(102, create_downloaded_block_with_parent(102, Felt::from(999)));
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone());
+    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(100, 102);
 
     let result = stage.execute(&input).await;


### PR DESCRIPTION
Early Starknet mainnet blocks have no `starknet_version` field. The full node sync crashes when parsing the empty string. This treats "unversioned" as a first-class `StarknetVersion` value (`UNVERSIONED = [0,0,0,0]`) with proper parse/display roundtripping, lexicographic ordering via `Ord`, and serde support.

Adds version-aware block hash computation in the sync stage covering all four historical algorithms;

- **pre-0.7** Pedersen with chain ID
- **0.7 – 0.13.2** Pedersen
- **0.13.2 – 0.13.4** Poseidon v0
- **0.13.4+** Poseidon v1

and verifies each synced block's hash against the locally computed one.
