### PR TITLE
feat(cli): add `--trie.disable` flag for full node

### DIFF
--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -55,6 +55,9 @@ pub struct FullNodeArgs {
     pub explorer: ExplorerOptions,
 
     #[command(flatten)]
+    pub trie: TrieOptions,
+
+    #[command(flatten)]
     pub pruning: PruningOptions,
 }
 
@@ -114,6 +117,7 @@ impl FullNodeArgs {
             pruning,
             network: self.network,
             gateway_api_key: self.gateway_api_key.clone(),
+            trie: !self.trie.disable,
         })
     }
 

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -5,6 +5,7 @@ pub use clap::Parser;
 use katana_full_node::config::db::DbConfig;
 use katana_full_node::config::metrics::MetricsConfig;
 use katana_full_node::config::rpc::RpcConfig;
+use katana_full_node::config::trie::TrieConfig;
 use katana_full_node::Network;
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -117,7 +118,7 @@ impl FullNodeArgs {
             pruning,
             network: self.network,
             gateway_api_key: self.gateway_api_key.clone(),
-            trie: !self.trie.disable,
+            trie: TrieConfig { compute: !self.trie.disable },
         })
     }
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -920,7 +920,7 @@ impl TracerOptions {
     }
 }
 
-#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[command(next_help_heading = "Trie options")]
 pub struct TrieOptions {
     /// Disable state trie computation.
@@ -930,12 +930,6 @@ pub struct TrieOptions {
     #[arg(long = "trie.disable")]
     #[serde(default)]
     pub disable: bool,
-}
-
-impl Default for TrieOptions {
-    fn default() -> Self {
-        Self { disable: false }
-    }
 }
 
 #[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -921,6 +921,24 @@ impl TracerOptions {
 }
 
 #[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
+#[command(next_help_heading = "Trie options")]
+pub struct TrieOptions {
+    /// Disable state trie computation.
+    ///
+    /// By default, the node computes and verifies state roots against expected values
+    /// from block headers during synchronization. Use this flag to skip trie computation.
+    #[arg(long = "trie.disable")]
+    #[serde(default)]
+    pub disable: bool,
+}
+
+impl Default for TrieOptions {
+    fn default() -> Self {
+        Self { disable: false }
+    }
+}
+
+#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Pruning options")]
 pub struct PruningOptions {
     /// State pruning mode

--- a/crates/node/full/src/config.rs
+++ b/crates/node/full/src/config.rs
@@ -1,1 +1,16 @@
 pub use katana_node_config::{db, metrics, rpc};
+
+pub mod trie {
+    /// Configuration for state trie computation.
+    #[derive(Debug, Clone)]
+    pub struct TrieConfig {
+        /// Whether to compute and verify state roots during synchronization.
+        pub compute: bool,
+    }
+
+    impl Default for TrieConfig {
+        fn default() -> Self {
+            Self { compute: true }
+        }
+    }
+}

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use config::db::DbConfig;
 use config::metrics::MetricsConfig;
 use config::rpc::{RpcConfig, RpcModuleKind};
+use config::trie::TrieConfig;
 use http::header::CONTENT_TYPE;
 use http::Method;
 use jsonrpsee::RpcModule;
@@ -73,7 +74,7 @@ pub struct Config {
     pub metrics: Option<MetricsConfig>,
     pub gateway_api_key: Option<String>,
     pub network: Network,
-    pub trie: bool,
+    pub trie: TrieConfig,
 }
 
 #[derive(Debug)]
@@ -145,7 +146,7 @@ impl Node {
         let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
         pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
         pipeline.add_stage(Classes::new(storage_provider.clone(), gateway_client.clone(), 20));
-        if config.trie {
+        if config.trie.compute {
             pipeline.add_stage(StateTrie::new(storage_provider.clone(), task_spawner.clone()));
         }
 

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -73,6 +73,7 @@ pub struct Config {
     pub metrics: Option<MetricsConfig>,
     pub gateway_api_key: Option<String>,
     pub network: Network,
+    pub trie: bool,
 }
 
 #[derive(Debug)]
@@ -144,7 +145,9 @@ impl Node {
         let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
         pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
         pipeline.add_stage(Classes::new(storage_provider.clone(), gateway_client.clone(), 20));
-        pipeline.add_stage(StateTrie::new(storage_provider.clone(), task_spawner.clone()));
+        if config.trie {
+            pipeline.add_stage(StateTrie::new(storage_provider.clone(), task_spawner.clone()));
+        }
 
         // -- build chain tip watcher using gateway client
 


### PR DESCRIPTION
Add a CLI flag to conditionally disable state trie computation during full node synchronization. The `StateTrie` pipeline stage is included by default, preserving the current behavior. Passing `--trie.disable` skips trie computation entirely, which is useful when state root verification is not needed or to reduce sync overhead. The flag is exposed through a `TrieOptions` CLI struct following the existing options pattern.