### PR TITLE
sync(stage): default block downloader to iterator batching

### DIFF
--- a/crates/sync/stage/docs/downloader-architecture.md
+++ b/crates/sync/stage/docs/downloader-architecture.md
@@ -16,6 +16,7 @@ This guide explains how to use the `Downloader` trait and `BatchDownloader` arch
 
 The Downloader architecture provides a generic framework for:
 - **Batch Downloads**: Download multiple items concurrently in configurable batches
+- **Iterator-fed Downloads**: Stream keys lazily without materializing full key lists
 - **Automatic Retries**: Retry transient failures with exponential backoff
 - **Partial Failure Handling**: Only retry failed items, not entire batches
 - **Flexible Error Handling**: Distinguish between retryable and permanent errors
@@ -176,6 +177,11 @@ pub struct BatchDownloader<D, B = ExponentialBuilder> {
     backoff: B,         // Retry strategy
 }
 ```
+
+`BatchDownloader` exposes two entry points:
+- `download(Vec<Key>)` when you already have all keys.
+- `download_iter(impl IntoIterator<Item = Key>)` when keys can be produced lazily (for example,
+  block number ranges), reducing allocation overhead for large sync ranges.
 
 **Configuration:**
 

--- a/crates/sync/stage/docs/downloader-architecture.md
+++ b/crates/sync/stage/docs/downloader-architecture.md
@@ -178,10 +178,9 @@ pub struct BatchDownloader<D, B = ExponentialBuilder> {
 }
 ```
 
-`BatchDownloader` exposes two entry points:
-- `download(Vec<Key>)` when you already have all keys.
-- `download_iter(impl IntoIterator<Item = Key>)` when keys can be produced lazily (for example,
-  block number ranges), reducing allocation overhead for large sync ranges.
+`BatchDownloader` exposes `download(impl IntoIterator<Item = Key>)`, so callers can pass either a
+pre-built collection or a lazy key source (for example, block number ranges) without a separate
+API.
 
 **Configuration:**
 

--- a/crates/sync/stage/src/downloader.rs
+++ b/crates/sync/stage/src/downloader.rs
@@ -142,52 +142,60 @@ where
     /// assert_eq!(values.len(), 15);
     /// ```
     pub async fn download(&self, keys: Vec<D::Key>) -> Result<Vec<D::Value>, D::Error> {
-        let total_items = keys.len();
-        let total_batches = total_items.div_ceil(self.batch_size);
+        self.download_iter(keys).await
+    }
+
+    /// Downloads values for keys from an iterator, buffering only one batch at a time.
+    ///
+    /// This is useful when the caller can produce keys lazily (e.g. block number ranges),
+    /// because it avoids materializing the entire key set before downloading.
+    pub async fn download_iter<I>(&self, keys: I) -> Result<Vec<D::Value>, D::Error>
+    where
+        I: IntoIterator<Item = D::Key>,
+    {
+        let keys = keys.into_iter();
+        let (lower_bound, upper_bound) = keys.size_hint();
+        let estimated_items = upper_bound.unwrap_or(lower_bound);
+        let estimated_batches = estimated_items.div_ceil(self.batch_size);
 
         trace!(
-            total_items = %total_items,
+            estimated_items = %estimated_items,
             batch_size = %self.batch_size,
-            total_batches = %total_batches,
-            "Starting batch download."
+            estimated_batches = %estimated_batches,
+            "Starting iterator batch download."
         );
 
-        let mut items = Vec::with_capacity(keys.len());
+        let mut items = Vec::with_capacity(estimated_items);
+        let mut batch = Vec::with_capacity(self.batch_size);
+        let mut batch_num = 0usize;
 
-        for (batch_idx, chunk) in keys.chunks(self.batch_size).enumerate() {
-            let batch_num = batch_idx + 1;
-            trace!(
-                batch = %batch_num,
-                total_batches = %total_batches,
-                batch_size = %chunk.len(),
-                "Processing batch."
-            );
+        for key in keys {
+            batch.push(key);
 
-            let batch = self.download_batch_with_retry(chunk.to_vec()).await?;
-            items.extend(batch);
+            if batch.len() == self.batch_size {
+                batch_num += 1;
+                let downloaded = self.download_batch_with_retry(&batch).await?;
+                items.extend(downloaded);
+                batch.clear();
+            }
+        }
 
-            trace!(
-                batch = %batch_num,
-                total_batches = %total_batches,
-                downloaded = %items.len(),
-                total = %total_items,
-                "Completed batch."
-            );
+        if !batch.is_empty() {
+            batch_num += 1;
+            let downloaded = self.download_batch_with_retry(&batch).await?;
+            items.extend(downloaded);
         }
 
         trace!(
-            total_items = %total_items,
-            total_batches = %total_batches,
-            "Batch download completed successfully."
+            downloaded_items = %items.len(),
+            processed_batches = %batch_num,
+            "Iterator batch download completed successfully."
         );
 
         Ok(items)
     }
 
-    async fn download_batch_with_retry(
-        &self,
-        keys: Vec<D::Key>,
-    ) -> Result<Vec<D::Value>, D::Error> {
+    async fn download_batch_with_retry(&self, keys: &[D::Key]) -> Result<Vec<D::Value>, D::Error> {
         let mut results: Vec<Option<D::Value>> = (0..keys.len()).map(|_| None).collect();
 
         // Track indices of keys that still need to be downloaded.
@@ -508,6 +516,62 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Vec::<String>::new());
+    }
+
+    #[tokio::test]
+    async fn download_iter_succeeds_and_preserves_order() {
+        let mut downloader = MockDownloader::new();
+        for key in 1..=5 {
+            downloader =
+                downloader.with_response(key, vec![DownloaderResult::Ok(format!("value{key}"))]);
+        }
+
+        let batch_downloader = BatchDownloader::new(downloader.clone(), 2);
+        let result = batch_downloader.download_iter(1..=5).await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            vec![
+                "value1".to_string(),
+                "value2".to_string(),
+                "value3".to_string(),
+                "value4".to_string(),
+                "value5".to_string()
+            ]
+        );
+
+        for key in 1..=5 {
+            assert_eq!(downloader.get_attempts(key), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn download_iter_retries_only_failed_keys() {
+        let downloader = MockDownloader::new()
+            .with_response(1, vec![DownloaderResult::Ok("value1".to_string())])
+            .with_response(
+                2,
+                vec![
+                    DownloaderResult::Retry(MockError("temporary error".to_string())),
+                    DownloaderResult::Ok("value2".to_string()),
+                ],
+            )
+            .with_response(3, vec![DownloaderResult::Ok("value3".to_string())]);
+
+        let batch_downloader = BatchDownloader::new(downloader.clone(), 3)
+            .backoff(ConstantBuilder::default().with_delay(Duration::from_millis(1)));
+        let result = batch_downloader.download_iter([1, 2, 3]).await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            vec!["value1".to_string(), "value2".to_string(), "value3".to_string()]
+        );
+
+        assert_eq!(downloader.get_attempts(1), 1);
+        assert_eq!(downloader.get_attempts(2), 2);
+        assert_eq!(downloader.get_attempts(3), 1);
     }
 
     #[tokio::test]

--- a/crates/sync/stage/src/downloader.rs
+++ b/crates/sync/stage/src/downloader.rs
@@ -35,7 +35,7 @@ use tracing::{trace, warn};
 ///
 /// // Download multiple items
 /// let keys = vec![1, 2, 3, 4, 5];
-/// let values = downloader.download(&keys).await?;
+/// let values = downloader.download(keys).await?;
 /// ```
 #[derive(Debug, Clone)]
 pub struct BatchDownloader<D, B = ExponentialBuilder> {
@@ -119,7 +119,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `keys` - List of keys to download
+    /// * `keys` - Keys to download
     ///
     /// # Returns
     ///
@@ -138,18 +138,10 @@ where
     /// // With batch_size=10, this downloads items 1-10 concurrently in the first batch,
     /// // then items 11-15 concurrently in the second batch
     /// let keys = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-    /// let values = downloader.download(&keys).await?;
+    /// let values = downloader.download(keys).await?;
     /// assert_eq!(values.len(), 15);
     /// ```
-    pub async fn download(&self, keys: Vec<D::Key>) -> Result<Vec<D::Value>, D::Error> {
-        self.download_iter(keys).await
-    }
-
-    /// Downloads values for keys from an iterator, buffering only one batch at a time.
-    ///
-    /// This is useful when the caller can produce keys lazily (e.g. block number ranges),
-    /// because it avoids materializing the entire key set before downloading.
-    pub async fn download_iter<I>(&self, keys: I) -> Result<Vec<D::Value>, D::Error>
+    pub async fn download<I>(&self, keys: I) -> Result<Vec<D::Value>, D::Error>
     where
         I: IntoIterator<Item = D::Key>,
     {
@@ -519,7 +511,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_iter_succeeds_and_preserves_order() {
+    async fn download_with_iter_succeeds_and_preserves_order() {
         let mut downloader = MockDownloader::new();
         for key in 1..=5 {
             downloader =
@@ -527,7 +519,7 @@ mod tests {
         }
 
         let batch_downloader = BatchDownloader::new(downloader.clone(), 2);
-        let result = batch_downloader.download_iter(1..=5).await;
+        let result = batch_downloader.download(1..=5).await;
 
         assert!(result.is_ok());
         assert_eq!(
@@ -547,7 +539,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_iter_retries_only_failed_keys() {
+    async fn download_with_iter_retries_only_failed_keys() {
         let downloader = MockDownloader::new()
             .with_response(1, vec![DownloaderResult::Ok("value1".to_string())])
             .with_response(
@@ -561,7 +553,7 @@ mod tests {
 
         let batch_downloader = BatchDownloader::new(downloader.clone(), 3)
             .backoff(ConstantBuilder::default().with_delay(Duration::from_millis(1)));
-        let result = batch_downloader.download_iter([1, 2, 3]).await;
+        let result = batch_downloader.download([1, 2, 3]).await;
 
         assert!(result.is_ok());
         assert_eq!(


### PR DESCRIPTION
Removes per-batch key cloning and avoids materializing full block-number ranges before dispatching requests. 