### PR TITLE
feat(db): compress `Receipts` rows with `zstd`

### DIFF
--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -8,6 +8,14 @@ use {postcard, zstd};
 use super::{Compress, Decompress};
 use crate::error::CodecError;
 
+// Receipt rows now use an explicit envelope so new writers can store compressed payloads while
+// readers remain compatible with legacy rows that were stored as raw postcard bytes.
+const RECEIPT_MAGIC: &[u8; 4] = b"KRCP";
+const RECEIPT_FORMAT_VERSION: u8 = 1;
+// Encoding `2` is reserved for zstd + dictionary support.
+const RECEIPT_ENCODING_ZSTD: u8 = 1;
+const RECEIPT_HEADER_LEN: usize = RECEIPT_MAGIC.len() + 2;
+
 /// A wrapper type for `Felt` that serializes/deserializes as a 32-byte big-endian array.
 ///
 /// This exists for backward compatibility - older versions of `Felt` used to always serialize as
@@ -91,9 +99,65 @@ impl Decompress for TypedTransactionExecutionInfo {
     }
 }
 
+impl Compress for Receipt {
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
+        let serialized =
+            postcard::to_stdvec(&self).map_err(|e| CodecError::Compress(e.to_string()))?;
+        let compressed = zstd::encode_all(serialized.as_slice(), 0)
+            .map_err(|e| CodecError::Compress(e.to_string()))?;
+
+        // Prefix the payload with a small format header so future receipt encodings can coexist
+        // with both legacy postcard rows and this zstd-backed format.
+        let mut encoded = Vec::with_capacity(RECEIPT_HEADER_LEN + compressed.len());
+        encoded.extend_from_slice(RECEIPT_MAGIC);
+        encoded.push(RECEIPT_FORMAT_VERSION);
+        encoded.push(RECEIPT_ENCODING_ZSTD);
+        encoded.extend_from_slice(&compressed);
+
+        Ok(encoded)
+    }
+}
+
+impl Decompress for Receipt {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+
+        if bytes.starts_with(RECEIPT_MAGIC) {
+            if bytes.len() < RECEIPT_HEADER_LEN {
+                return Err(CodecError::Decompress("Incomplete receipt envelope".into()));
+            }
+
+            let version = bytes[RECEIPT_MAGIC.len()];
+            if version != RECEIPT_FORMAT_VERSION {
+                return Err(CodecError::Decompress(format!(
+                    "Unsupported receipt encoding version: {version}"
+                )));
+            }
+
+            let encoding = bytes[RECEIPT_MAGIC.len() + 1];
+            if encoding != RECEIPT_ENCODING_ZSTD {
+                return Err(CodecError::Decompress(format!(
+                    "Unsupported receipt encoding: {encoding}"
+                )));
+            }
+
+            let serialized = zstd::decode_all(&bytes[RECEIPT_HEADER_LEN..])
+                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+
+            postcard::from_bytes(&serialized).map_err(|e| CodecError::Decompress(e.to_string()))
+        } else {
+            // Databases created before receipt compression stored raw postcard bytes.
+            // Only rows without the envelope use this fallback; malformed enveloped rows are
+            // treated as corruption instead of being reinterpreted as legacy data.
+            postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))
+        }
+    }
+}
+
 impl_compress_and_decompress_for_table_values!(
     u64,
-    Receipt,
     TrieDatabaseValue,
     BlockList,
     ExecutionCheckpoint,
@@ -102,3 +166,99 @@ impl_compress_and_decompress_for_table_values!(
     StoredBlockBodyIndices,
     ContractInfoChangeList
 );
+
+#[cfg(test)]
+mod tests {
+    use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
+
+    use super::{
+        Compress, Decompress, RECEIPT_ENCODING_ZSTD, RECEIPT_FORMAT_VERSION, RECEIPT_MAGIC,
+    };
+    use crate::abstraction::{Database, DbTx, DbTxMut};
+    use crate::error::CodecError;
+    use crate::{tables, Db};
+
+    fn sample_receipt() -> Receipt {
+        Receipt::Invoke(InvokeTxReceipt {
+            revert_error: Some("boom".into()),
+            events: Vec::new(),
+            fee: Default::default(),
+            messages_sent: Vec::new(),
+            execution_resources: Default::default(),
+        })
+    }
+
+    #[test]
+    fn receipt_roundtrip_uses_envelope_and_zstd() {
+        let receipt = sample_receipt();
+
+        let compressed = receipt.clone().compress().expect("failed to compress receipt");
+        assert_eq!(&compressed[..RECEIPT_MAGIC.len()], RECEIPT_MAGIC);
+        assert_eq!(compressed[RECEIPT_MAGIC.len()], RECEIPT_FORMAT_VERSION);
+        assert_eq!(compressed[RECEIPT_MAGIC.len() + 1], RECEIPT_ENCODING_ZSTD);
+
+        let decompressed =
+            <Receipt as Decompress>::decompress(compressed).expect("failed to decompress receipt");
+
+        assert_eq!(decompressed, receipt);
+    }
+
+    #[test]
+    fn receipt_decompresses_legacy_postcard_bytes() {
+        let receipt = sample_receipt();
+        let legacy = postcard::to_stdvec(&receipt).expect("failed to serialize legacy receipt");
+
+        let decompressed =
+            <Receipt as Decompress>::decompress(legacy).expect("failed to read legacy receipt");
+
+        assert_eq!(decompressed, receipt);
+    }
+
+    #[test]
+    fn receipt_rejects_unknown_envelope_version() {
+        let mut encoded = RECEIPT_MAGIC.to_vec();
+        encoded.push(RECEIPT_FORMAT_VERSION + 1);
+        encoded.push(RECEIPT_ENCODING_ZSTD);
+
+        let error = <Receipt as Decompress>::decompress(encoded).expect_err("must reject version");
+        assert!(matches!(error, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn receipt_rejects_unknown_envelope_encoding() {
+        let mut encoded = RECEIPT_MAGIC.to_vec();
+        encoded.push(RECEIPT_FORMAT_VERSION);
+        encoded.push(RECEIPT_ENCODING_ZSTD + 1);
+
+        let error = <Receipt as Decompress>::decompress(encoded).expect_err("must reject encoding");
+        assert!(matches!(error, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn receipt_rejects_corrupt_zstd_payload() {
+        let mut encoded = RECEIPT_MAGIC.to_vec();
+        encoded.push(RECEIPT_FORMAT_VERSION);
+        encoded.push(RECEIPT_ENCODING_ZSTD);
+        encoded.extend_from_slice(&[1, 2, 3, 4]);
+
+        let error =
+            <Receipt as Decompress>::decompress(encoded).expect_err("must reject corrupt payload");
+        assert!(matches!(error, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn receipts_table_roundtrip_uses_custom_codec() {
+        let db = Db::in_memory().expect("failed to create in-memory db");
+        let receipt = sample_receipt();
+
+        let tx = db.tx_mut().expect("failed to open write transaction");
+        tx.put::<tables::Receipts>(7, receipt.clone()).expect("failed to write receipt");
+        tx.commit().expect("failed to commit write transaction");
+
+        let tx = db.tx().expect("failed to open read transaction");
+        let stored = tx.get::<tables::Receipts>(7).expect("failed to read receipt");
+        tx.commit().expect("failed to commit read transaction");
+
+        assert_eq!(stored, Some(receipt));
+    }
+}

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -8,14 +8,6 @@ use {postcard, zstd};
 use super::{Compress, Decompress};
 use crate::error::CodecError;
 
-// Receipt rows now use an explicit envelope so new writers can store compressed payloads while
-// readers remain compatible with legacy rows that were stored as raw postcard bytes.
-const RECEIPT_MAGIC: &[u8; 4] = b"KRCP";
-const RECEIPT_FORMAT_VERSION: u8 = 1;
-// Encoding `2` is reserved for zstd + dictionary support.
-const RECEIPT_ENCODING_ZSTD: u8 = 1;
-const RECEIPT_HEADER_LEN: usize = RECEIPT_MAGIC.len() + 2;
-
 /// A wrapper type for `Felt` that serializes/deserializes as a 32-byte big-endian array.
 ///
 /// This exists for backward compatibility - older versions of `Felt` used to always serialize as
@@ -99,65 +91,11 @@ impl Decompress for TypedTransactionExecutionInfo {
     }
 }
 
-impl Compress for Receipt {
-    type Compressed = Vec<u8>;
-
-    fn compress(self) -> Result<Self::Compressed, CodecError> {
-        let serialized =
-            postcard::to_stdvec(&self).map_err(|e| CodecError::Compress(e.to_string()))?;
-        let compressed = zstd::encode_all(serialized.as_slice(), 0)
-            .map_err(|e| CodecError::Compress(e.to_string()))?;
-
-        // Prefix the payload with a small format header so future receipt encodings can coexist
-        // with both legacy postcard rows and this zstd-backed format.
-        let mut encoded = Vec::with_capacity(RECEIPT_HEADER_LEN + compressed.len());
-        encoded.extend_from_slice(RECEIPT_MAGIC);
-        encoded.push(RECEIPT_FORMAT_VERSION);
-        encoded.push(RECEIPT_ENCODING_ZSTD);
-        encoded.extend_from_slice(&compressed);
-
-        Ok(encoded)
-    }
-}
-
-impl Decompress for Receipt {
-    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
-        let bytes = bytes.as_ref();
-
-        if bytes.starts_with(RECEIPT_MAGIC) {
-            if bytes.len() < RECEIPT_HEADER_LEN {
-                return Err(CodecError::Decompress("Incomplete receipt envelope".into()));
-            }
-
-            let version = bytes[RECEIPT_MAGIC.len()];
-            if version != RECEIPT_FORMAT_VERSION {
-                return Err(CodecError::Decompress(format!(
-                    "Unsupported receipt encoding version: {version}"
-                )));
-            }
-
-            let encoding = bytes[RECEIPT_MAGIC.len() + 1];
-            if encoding != RECEIPT_ENCODING_ZSTD {
-                return Err(CodecError::Decompress(format!(
-                    "Unsupported receipt encoding: {encoding}"
-                )));
-            }
-
-            let serialized = zstd::decode_all(&bytes[RECEIPT_HEADER_LEN..])
-                .map_err(|e| CodecError::Decompress(e.to_string()))?;
-
-            postcard::from_bytes(&serialized).map_err(|e| CodecError::Decompress(e.to_string()))
-        } else {
-            // Databases created before receipt compression stored raw postcard bytes.
-            // Only rows without the envelope use this fallback; malformed enveloped rows are
-            // treated as corruption instead of being reinterpreted as legacy data.
-            postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))
-        }
-    }
-}
-
+// `Receipt` intentionally stays postcard-only. Compression envelopes are handled by
+// `models::ReceiptEnvelope`, which is used as the `Receipts` table value.
 impl_compress_and_decompress_for_table_values!(
     u64,
+    Receipt,
     TrieDatabaseValue,
     BlockList,
     ExecutionCheckpoint,
@@ -171,12 +109,8 @@ impl_compress_and_decompress_for_table_values!(
 mod tests {
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
 
-    use super::{
-        Compress, Decompress, RECEIPT_ENCODING_ZSTD, RECEIPT_FORMAT_VERSION, RECEIPT_MAGIC,
-    };
-    use crate::abstraction::{Database, DbTx, DbTxMut};
-    use crate::error::CodecError;
-    use crate::{tables, Db};
+    use super::{Compress, Decompress};
+    use crate::models::ReceiptEnvelope;
 
     fn sample_receipt() -> Receipt {
         Receipt::Invoke(InvokeTxReceipt {
@@ -189,13 +123,12 @@ mod tests {
     }
 
     #[test]
-    fn receipt_roundtrip_uses_envelope_and_zstd() {
+    fn receipt_roundtrip_uses_postcard() {
         let receipt = sample_receipt();
 
         let compressed = receipt.clone().compress().expect("failed to compress receipt");
-        assert_eq!(&compressed[..RECEIPT_MAGIC.len()], RECEIPT_MAGIC);
-        assert_eq!(compressed[RECEIPT_MAGIC.len()], RECEIPT_FORMAT_VERSION);
-        assert_eq!(compressed[RECEIPT_MAGIC.len() + 1], RECEIPT_ENCODING_ZSTD);
+        let expected = postcard::to_stdvec(&receipt).expect("failed to serialize postcard receipt");
+        assert_eq!(compressed, expected);
 
         let decompressed =
             <Receipt as Decompress>::decompress(compressed).expect("failed to decompress receipt");
@@ -204,61 +137,12 @@ mod tests {
     }
 
     #[test]
-    fn receipt_decompresses_legacy_postcard_bytes() {
+    fn receipt_does_not_decode_envelope_bytes() {
         let receipt = sample_receipt();
-        let legacy = postcard::to_stdvec(&receipt).expect("failed to serialize legacy receipt");
-
-        let decompressed =
-            <Receipt as Decompress>::decompress(legacy).expect("failed to read legacy receipt");
-
-        assert_eq!(decompressed, receipt);
-    }
-
-    #[test]
-    fn receipt_rejects_unknown_envelope_version() {
-        let mut encoded = RECEIPT_MAGIC.to_vec();
-        encoded.push(RECEIPT_FORMAT_VERSION + 1);
-        encoded.push(RECEIPT_ENCODING_ZSTD);
-
-        let error = <Receipt as Decompress>::decompress(encoded).expect_err("must reject version");
-        assert!(matches!(error, CodecError::Decompress(_)));
-    }
-
-    #[test]
-    fn receipt_rejects_unknown_envelope_encoding() {
-        let mut encoded = RECEIPT_MAGIC.to_vec();
-        encoded.push(RECEIPT_FORMAT_VERSION);
-        encoded.push(RECEIPT_ENCODING_ZSTD + 1);
-
-        let error = <Receipt as Decompress>::decompress(encoded).expect_err("must reject encoding");
-        assert!(matches!(error, CodecError::Decompress(_)));
-    }
-
-    #[test]
-    fn receipt_rejects_corrupt_zstd_payload() {
-        let mut encoded = RECEIPT_MAGIC.to_vec();
-        encoded.push(RECEIPT_FORMAT_VERSION);
-        encoded.push(RECEIPT_ENCODING_ZSTD);
-        encoded.extend_from_slice(&[1, 2, 3, 4]);
-
-        let error =
-            <Receipt as Decompress>::decompress(encoded).expect_err("must reject corrupt payload");
-        assert!(matches!(error, CodecError::Decompress(_)));
-    }
-
-    #[test]
-    fn receipts_table_roundtrip_uses_custom_codec() {
-        let db = Db::in_memory().expect("failed to create in-memory db");
-        let receipt = sample_receipt();
-
-        let tx = db.tx_mut().expect("failed to open write transaction");
-        tx.put::<tables::Receipts>(7, receipt.clone()).expect("failed to write receipt");
-        tx.commit().expect("failed to commit write transaction");
-
-        let tx = db.tx().expect("failed to open read transaction");
-        let stored = tx.get::<tables::Receipts>(7).expect("failed to read receipt");
-        tx.commit().expect("failed to commit read transaction");
-
-        assert_eq!(stored, Some(receipt));
+        let envelope_bytes =
+            ReceiptEnvelope::from(receipt).compress().expect("failed to compress receipt envelope");
+        let err = <Receipt as Decompress>::decompress(envelope_bytes)
+            .expect_err("receipt codec must remain postcard-only");
+        assert!(matches!(err, crate::error::CodecError::Decompress(_)));
     }
 }

--- a/crates/storage/db/src/models/mod.rs
+++ b/crates/storage/db/src/models/mod.rs
@@ -2,12 +2,14 @@ pub mod block;
 pub mod class;
 pub mod contract;
 pub mod list;
+pub mod receipt;
 pub mod stage;
 pub mod storage;
 pub mod trie;
 
 pub mod versioned;
 
+pub use receipt::ReceiptEnvelope;
 pub use versioned::block::VersionedHeader;
 pub use versioned::class::VersionedContractClass;
 pub use versioned::transaction::VersionedTx;

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -1,0 +1,189 @@
+use katana_primitives::receipt::Receipt;
+
+use crate::codecs::{Compress, Decompress};
+use crate::error::CodecError;
+
+/// On-disk representation for `Receipts` table values.
+///
+/// This wrapper keeps table-specific encoding concerns (envelope header, compression
+/// algorithm, and backward-compatibility fallbacks) out of `Receipt` itself.
+///
+/// New rows are written as `envelope + zstd(postcard(receipt))`.
+/// Rows without the envelope are treated as legacy postcard-only bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceiptEnvelope {
+    pub receipt: Receipt,
+}
+
+const RECEIPT_MAGIC: &[u8; 4] = b"KRCP";
+const RECEIPT_FORMAT_VERSION: u8 = 1;
+const RECEIPT_ENCODING_ZSTD: u8 = 1;
+// Encoding `2` is reserved for zstd + dictionary support.
+const RECEIPT_HEADER_LEN: usize = RECEIPT_MAGIC.len() + 2;
+
+impl From<Receipt> for ReceiptEnvelope {
+    fn from(receipt: Receipt) -> Self {
+        Self { receipt }
+    }
+}
+
+impl From<ReceiptEnvelope> for Receipt {
+    fn from(value: ReceiptEnvelope) -> Self {
+        value.receipt
+    }
+}
+
+impl Compress for ReceiptEnvelope {
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
+        let serialized =
+            postcard::to_stdvec(&self.receipt).map_err(|e| CodecError::Compress(e.to_string()))?;
+        let compressed = zstd::encode_all(serialized.as_slice(), 0)
+            .map_err(|e| CodecError::Compress(e.to_string()))?;
+
+        // The envelope allows multiple receipt encodings to coexist over time.
+        let mut encoded = Vec::with_capacity(RECEIPT_HEADER_LEN + compressed.len());
+        encoded.extend_from_slice(RECEIPT_MAGIC);
+        encoded.push(RECEIPT_FORMAT_VERSION);
+        encoded.push(RECEIPT_ENCODING_ZSTD);
+        encoded.extend_from_slice(&compressed);
+
+        Ok(encoded)
+    }
+}
+
+impl Decompress for ReceiptEnvelope {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+
+        if bytes.starts_with(RECEIPT_MAGIC) {
+            if bytes.len() < RECEIPT_HEADER_LEN {
+                return Err(CodecError::Decompress("Incomplete receipt envelope".into()));
+            }
+
+            let version = bytes[RECEIPT_MAGIC.len()];
+            if version != RECEIPT_FORMAT_VERSION {
+                return Err(CodecError::Decompress(format!(
+                    "Unsupported receipt encoding version: {version}"
+                )));
+            }
+
+            let encoding = bytes[RECEIPT_MAGIC.len() + 1];
+            if encoding != RECEIPT_ENCODING_ZSTD {
+                return Err(CodecError::Decompress(format!(
+                    "Unsupported receipt encoding: {encoding}"
+                )));
+            }
+
+            let serialized = zstd::decode_all(&bytes[RECEIPT_HEADER_LEN..])
+                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+            let receipt = postcard::from_bytes(&serialized)
+                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+            Ok(Self { receipt })
+        } else {
+            // Databases created before receipt compression stored raw postcard bytes.
+            let receipt =
+                postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))?;
+            Ok(Self { receipt })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
+
+    use super::{
+        Compress, Decompress, ReceiptEnvelope, RECEIPT_ENCODING_ZSTD, RECEIPT_FORMAT_VERSION,
+        RECEIPT_MAGIC,
+    };
+    use crate::abstraction::{Database, DbTx, DbTxMut};
+    use crate::error::CodecError;
+    use crate::{tables, Db};
+
+    fn sample_receipt() -> Receipt {
+        Receipt::Invoke(InvokeTxReceipt {
+            revert_error: Some("boom".into()),
+            events: Vec::new(),
+            fee: Default::default(),
+            messages_sent: Vec::new(),
+            execution_resources: Default::default(),
+        })
+    }
+
+    #[test]
+    fn receipt_envelope_roundtrip_uses_envelope_and_zstd() {
+        let receipt = sample_receipt();
+        let envelope = ReceiptEnvelope::from(receipt.clone());
+
+        let compressed = envelope.compress().expect("failed to compress receipt envelope");
+        assert_eq!(&compressed[..RECEIPT_MAGIC.len()], RECEIPT_MAGIC);
+        assert_eq!(compressed[RECEIPT_MAGIC.len()], RECEIPT_FORMAT_VERSION);
+        assert_eq!(compressed[RECEIPT_MAGIC.len() + 1], RECEIPT_ENCODING_ZSTD);
+
+        let decompressed =
+            ReceiptEnvelope::decompress(compressed).expect("failed to decompress receipt envelope");
+
+        assert_eq!(decompressed, ReceiptEnvelope::from(receipt));
+    }
+
+    #[test]
+    fn receipt_envelope_decompresses_legacy_postcard_bytes() {
+        let receipt = sample_receipt();
+        let legacy = postcard::to_stdvec(&receipt).expect("failed to serialize legacy receipt");
+
+        let decompressed =
+            ReceiptEnvelope::decompress(legacy).expect("failed to read legacy receipt");
+
+        assert_eq!(decompressed, ReceiptEnvelope::from(receipt));
+    }
+
+    #[test]
+    fn receipt_envelope_rejects_unknown_version() {
+        let mut encoded = RECEIPT_MAGIC.to_vec();
+        encoded.push(RECEIPT_FORMAT_VERSION + 1);
+        encoded.push(RECEIPT_ENCODING_ZSTD);
+
+        let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject version");
+        assert!(matches!(error, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn receipt_envelope_rejects_unknown_encoding() {
+        let mut encoded = RECEIPT_MAGIC.to_vec();
+        encoded.push(RECEIPT_FORMAT_VERSION);
+        encoded.push(RECEIPT_ENCODING_ZSTD + 1);
+
+        let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject encoding");
+        assert!(matches!(error, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn receipt_envelope_rejects_corrupt_zstd_payload() {
+        let mut encoded = RECEIPT_MAGIC.to_vec();
+        encoded.push(RECEIPT_FORMAT_VERSION);
+        encoded.push(RECEIPT_ENCODING_ZSTD);
+        encoded.extend_from_slice(&[1, 2, 3, 4]);
+
+        let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject corrupt payload");
+        assert!(matches!(error, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn receipts_table_roundtrip_uses_receipt_envelope() {
+        let db = Db::in_memory().expect("failed to create in-memory db");
+        let receipt = sample_receipt();
+        let envelope = ReceiptEnvelope::from(receipt.clone());
+
+        let tx = db.tx_mut().expect("failed to open write transaction");
+        tx.put::<tables::Receipts>(7, envelope).expect("failed to write receipt");
+        tx.commit().expect("failed to commit write transaction");
+
+        let tx = db.tx().expect("failed to open read transaction");
+        let stored = tx.get::<tables::Receipts>(7).expect("failed to read receipt");
+        tx.commit().expect("failed to commit read transaction");
+
+        assert_eq!(stored.map(Receipt::from), Some(receipt));
+    }
+}

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -95,9 +95,9 @@ impl Decompress for ReceiptEnvelope {
             Ok(Self { receipt })
         } else {
             // Databases created before receipt compression stored raw postcard bytes.
-            let receipt =
-                postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))?;
-            Ok(Self { receipt })
+            postcard::from_bytes::<Receipt>(bytes)
+                .map(|receipt| Self { receipt })
+                .map_err(|e| CodecError::Decompress(e.to_string()))
         }
     }
 }

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -10,6 +10,15 @@ use crate::error::CodecError;
 ///
 /// New rows are written as `envelope + zstd(postcard(receipt))`.
 /// Rows without the envelope are treated as legacy postcard-only bytes.
+///
+/// ```text
+/// +---------+-----------+------------+--------------------------+
+/// | magic   | version   | encoding   | payload                  |
+/// | 4 bytes | 1 byte    | 1 byte     | variable length          |
+/// +---------+-----------+------------+--------------------------+
+/// | "KRCP"  | 0x01      | 0x01       | zstd(postcard(receipt))  |
+/// +---------+-----------+------------+--------------------------+
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReceiptEnvelope {
     pub receipt: Receipt,

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -15,6 +15,9 @@ pub struct ReceiptEnvelope {
     pub receipt: Receipt,
 }
 
+// 4-byte ASCII magic used to identify a Katana receipt envelope.
+// Convention: `K` + 3-byte payload identifier, so future table envelopes can follow the same
+// recognizable, debuggable namespace pattern.
 const RECEIPT_MAGIC: &[u8; 4] = b"KRCP";
 const RECEIPT_FORMAT_VERSION: u8 = 1;
 const RECEIPT_ENCODING_ZSTD: u8 = 1;

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -2,7 +2,6 @@ use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
 use katana_primitives::execution::TypedTransactionExecutionInfo;
-use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::{TxHash, TxNumber};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
@@ -13,7 +12,7 @@ use crate::models::list::BlockList;
 use crate::models::stage::{ExecutionCheckpoint, PruningCheckpoint, StageId};
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 use crate::models::trie::{TrieDatabaseKey, TrieDatabaseValue, TrieHistoryEntry};
-use crate::models::{VersionedContractClass, VersionedHeader, VersionedTx};
+use crate::models::{ReceiptEnvelope, VersionedContractClass, VersionedHeader, VersionedTx};
 
 pub trait Key: Encode + Decode + Clone + std::fmt::Debug {}
 pub trait Value: Compress + Decompress + std::fmt::Debug {}
@@ -219,8 +218,9 @@ tables! {
     TxBlocks: (TxNumber) => BlockNumber,
     /// Stores the transaction's traces.
     TxTraces: (TxNumber) => TypedTransactionExecutionInfo,
-    /// Store transaction receipts
-    Receipts: (TxNumber) => Receipt,
+    /// Store transaction receipts as envelopes so table encoding can evolve independently from
+    /// the in-memory `Receipt` type.
+    Receipts: (TxNumber) => ReceiptEnvelope,
     /// Store compiled classes
     CompiledClassHashes: (ClassHash) => CompiledClassHash,
     /// Store contract classes according to its class hash
@@ -386,7 +386,7 @@ mod tests {
     use crate::models::trie::{
         TrieDatabaseKey, TrieDatabaseKeyType, TrieDatabaseValue, TrieHistoryEntry,
     };
-    use crate::models::{VersionedHeader, VersionedTx};
+    use crate::models::{ReceiptEnvelope, VersionedHeader, VersionedTx};
 
     macro_rules! assert_key_encode_decode {
 	    { $( ($name:ty, $key:expr) ),* } => {
@@ -454,13 +454,13 @@ mod tests {
             (ContractClassChange, ContractClassChange::default()),
             (BlockList, BlockList::default()),
             (ContractStorageEntry, ContractStorageEntry::default()),
-            (Receipt, Receipt::Invoke(InvokeTxReceipt {
+            (ReceiptEnvelope, ReceiptEnvelope::from(Receipt::Invoke(InvokeTxReceipt {
                 revert_error: None,
                 events: Vec::new(),
                 fee: Default::default(),
                 messages_sent: Vec::new(),
                 execution_resources: Default::default(),
-            })),
+            }))),
             (TrieDatabaseValue, TrieDatabaseValue::default()),
             (TrieHistoryEntry, TrieHistoryEntry {
                 value: TrieDatabaseValue::default(),

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -15,7 +15,7 @@ use katana_db::models::contract::{
 use katana_db::models::list::BlockList;
 use katana_db::models::stage::{ExecutionCheckpoint, PruningCheckpoint};
 use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
-use katana_db::models::{VersionedHeader, VersionedTx};
+use katana_db::models::{ReceiptEnvelope, VersionedHeader, VersionedTx};
 use katana_db::tables::{self, DupSort, Table};
 use katana_db::utils::KeyValue;
 use katana_primitives::block::{
@@ -605,8 +605,11 @@ impl<Tx: DbTx> TransactionTraceProvider for DbProvider<Tx> {
 impl<Tx: DbTx> ReceiptProvider for DbProvider<Tx> {
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         if let Some(num) = self.0.get::<tables::TxNumbers>(hash)? {
-            let receipt =
-                self.0.get::<tables::Receipts>(num)?.ok_or(ProviderError::MissingTxReceipt(num))?;
+            let receipt = self
+                .0
+                .get::<tables::Receipts>(num)?
+                .ok_or(ProviderError::MissingTxReceipt(num))
+                .map(Receipt::from)?;
 
             Ok(Some(receipt))
         } else {
@@ -624,7 +627,7 @@ impl<Tx: DbTx> ReceiptProvider for DbProvider<Tx> {
             let range = indices.tx_offset..indices.tx_offset + indices.tx_count;
             for i in range {
                 if let Some(receipt) = self.0.get::<tables::Receipts>(i)? {
-                    receipts.push(receipt);
+                    receipts.push(receipt.into());
                 }
             }
 
@@ -693,7 +696,9 @@ impl<Tx: DbTxMut> BlockWriter for DbProvider<Tx> {
         // Store transaction receipts
         for (i, receipt) in receipts.into_iter().enumerate() {
             let tx_number = tx_offset + i as u64;
-            self.0.put::<tables::Receipts>(tx_number, receipt)?;
+            // `Receipts` table stores a dedicated envelope so storage format can evolve without
+            // changing the in-memory `Receipt` type codec.
+            self.0.put::<tables::Receipts>(tx_number, ReceiptEnvelope::from(receipt))?;
         }
 
         // Store execution traces

--- a/docs/database.md
+++ b/docs/database.md
@@ -155,3 +155,7 @@ ClassDeclarationBlock ||--|| ClassDeclarations : "has"
 BlockNumbers ||--|| ClassDeclarations : ""
 StorageChangeSet }|--|{ StorageChangeHistory : "has"
 ```
+
+New receipt rows are stored as a receipt-specific envelope plus `zstd(postcard(receipt))`.
+Legacy rows without that envelope remain readable and are decoded as raw postcard bytes for
+backward compatibility.

--- a/docs/database.md
+++ b/docs/database.md
@@ -57,7 +57,7 @@ TxBlocks {
 
 Receipts {
     KEY TxNumber
-    VALUE Receipt
+    VALUE ReceiptEnvelope
 }
 
 CompiledClassHashes {
@@ -159,3 +159,25 @@ StorageChangeSet }|--|{ StorageChangeHistory : "has"
 New receipt rows are stored as a receipt-specific envelope plus `zstd(postcard(receipt))`.
 Legacy rows without that envelope remain readable and are decoded as raw postcard bytes for
 backward compatibility.
+
+## Envelope Header Convention
+
+When a table value needs format evolution without a full migration, use an explicit envelope
+header:
+
+`[magic:4][version:1][encoding:1][payload...]`
+
+The `magic` field convention for Katana DB envelopes is:
+
+- 4-byte uppercase ASCII.
+- First byte is `K` (Katana DB namespace).
+- Remaining 3 bytes identify the payload family.
+
+For receipts we use `KRCP` (`K` + `RCP`).
+
+Reader behavior for envelope-enabled values:
+
+- If magic matches, treat the row as enveloped and validate `version` + `encoding`.
+- If magic does not match, treat the row as legacy format.
+- If magic matches but metadata is unsupported/corrupt, return an error (do not fall back to
+  legacy decoding).


### PR DESCRIPTION
## Summary

- Store new `Receipts` rows as an explicit envelope plus `zstd(postcard(receipt))` while keeping reads compatible with legacy raw-postcard rows.
- Treat malformed enveloped rows as corruption instead of silently falling back to the legacy decoder.
- Add focused codec and `Receipts` table round-trip tests, and document the mixed-format receipt storage in `docs/database.md`.

## Compatibility
- No `db.version` bump in this phase.
- New Katana code can read existing databases that still contain legacy raw-postcard receipt rows.
- Older Katana binaries are not guaranteed to read databases after compressed receipt rows have been written.