### PR TITLE
feat(sync): add `--sync.tip` CLI flag to cap sync target block

### DIFF
--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -59,11 +59,11 @@ pub struct FullNodeArgs {
     #[command(flatten)]
     pub pruning: PruningOptions,
 
-    /// Sync up to this block number and then stop syncing.
-    /// The node will remain running with RPC available after reaching this block.
+    /// The maximum block number to sync to. Once reached, the pipeline stops
+    /// syncing but the node and RPC server remain running.
     #[arg(long = "sync.tip")]
     #[arg(value_name = "BLOCK_NUMBER")]
-    pub sync_tip: Option<u64>,
+    pub max_sync_tip: Option<u64>,
 }
 
 impl FullNodeArgs {
@@ -125,7 +125,7 @@ impl FullNodeArgs {
             network: self.network,
             gateway_api_key: self.gateway_api_key.clone(),
             trie: TrieConfig { compute: !self.trie.disable },
-            sync_tip: self.sync_tip,
+            max_sync_tip: self.max_sync_tip,
         })
     }
 

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -58,6 +58,12 @@ pub struct FullNodeArgs {
 
     #[command(flatten)]
     pub pruning: PruningOptions,
+
+    /// Sync up to this block number and then stop syncing.
+    /// The node will remain running with RPC available after reaching this block.
+    #[arg(long = "sync.tip")]
+    #[arg(value_name = "BLOCK_NUMBER")]
+    pub sync_tip: Option<u64>,
 }
 
 impl FullNodeArgs {
@@ -119,6 +125,7 @@ impl FullNodeArgs {
             network: self.network,
             gateway_api_key: self.gateway_api_key.clone(),
             trie: TrieConfig { compute: !self.trie.disable },
+            sync_tip: self.sync_tip,
         })
     }
 

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -79,8 +79,9 @@ pub struct Config {
     pub network: Network,
     pub trie: TrieConfig,
     pub gateway: Option<GatewayConfig>,
-    /// If set, the pipeline will stop syncing after reaching this block number.
-    pub sync_tip: Option<u64>,
+    /// The maximum block number the pipeline will sync to. When set, the pipeline
+    /// will stop syncing after reaching this block while the node remains running.
+    pub max_sync_tip: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -144,7 +145,7 @@ impl Node {
 
         // Configure pipeline
         pipeline.set_config(PipelineConfig {
-            sync_tip: config.sync_tip,
+            max_sync_tip: config.max_sync_tip,
             pruning: config.pruning.clone(),
         });
 

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -67,7 +67,7 @@ pub enum Network {
     Sepolia,
 }
 
-pub use katana_pipeline::PruningConfig;
+pub use katana_pipeline::{PipelineConfig, PruningConfig};
 
 #[derive(Debug)]
 pub struct Config {
@@ -79,6 +79,8 @@ pub struct Config {
     pub network: Network,
     pub trie: TrieConfig,
     pub gateway: Option<GatewayConfig>,
+    /// If set, the pipeline will stop syncing after reaching this block number.
+    pub sync_tip: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -140,8 +142,11 @@ impl Node {
 
         let (mut pipeline, pipeline_handle) = Pipeline::new(storage_provider.clone(), 256);
 
-        // Configure pruning
-        pipeline.set_pruning_config(config.pruning.clone());
+        // Configure pipeline
+        pipeline.set_config(PipelineConfig {
+            sync_tip: config.sync_tip,
+            pruning: config.pruning.clone(),
+        });
 
         let chain_id = match config.network {
             Network::Mainnet => katana_primitives::chain::ChainId::MAINNET,

--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -229,6 +229,15 @@ impl PruningConfig {
     }
 }
 
+/// Configuration for the pipeline.
+#[derive(Debug, Clone, Default)]
+pub struct PipelineConfig {
+    /// If set, the pipeline will stop syncing after reaching this block number.
+    pub sync_tip: Option<BlockNumber>,
+    /// Pruning configuration.
+    pub pruning: PruningConfig,
+}
+
 /// Syncing pipeline.
 ///
 /// The pipeline drives the execution of stages, running each stage to completion in the order they
@@ -252,7 +261,7 @@ pub struct Pipeline {
     block_tx: watch::Sender<Option<BlockNumber>>,
     tip: Option<BlockNumber>,
     metrics: PipelineMetrics,
-    pruning_config: PruningConfig,
+    config: PipelineConfig,
 }
 
 impl Pipeline {
@@ -279,21 +288,19 @@ impl Pipeline {
             chunk_size,
             tip: None,
             metrics: PipelineMetrics::new(),
-            pruning_config: PruningConfig::default(),
+            config: PipelineConfig::default(),
         };
         (pipeline, handle)
     }
 
-    /// Sets the pruning configuration for the pipeline.
-    ///
-    /// This controls how and when historical state is pruned during synchronization.
-    pub fn set_pruning_config(&mut self, config: PruningConfig) {
-        self.pruning_config = config;
+    /// Sets the pipeline configuration.
+    pub fn set_config(&mut self, config: PipelineConfig) {
+        self.config = config;
     }
 
-    /// Returns the current pruning configuration.
-    pub fn pruning_config(&self) -> &PruningConfig {
-        &self.pruning_config
+    /// Returns the current pipeline configuration.
+    pub fn config(&self) -> &PipelineConfig {
+        &self.config
     }
 
     /// Adds a new stage to the end of the pipeline.
@@ -479,14 +486,14 @@ impl Pipeline {
                 continue;
             };
 
-            let prune_input = PruneInput::new(tip, self.pruning_config.distance, prune_checkpoint);
+            let prune_input = PruneInput::new(tip, self.config.pruning.distance, prune_checkpoint);
 
             let Some(range) = prune_input.prune_range() else {
                 info!(target: "pipeline", "Skipping stage - nothing to prune (already caught up).");
                 continue;
             };
 
-            info!(target: "pipeline", distance = ?self.pruning_config.distance, from = range.start, to = range.end, "Pruning stage.");
+            info!(target: "pipeline", distance = ?self.config.pruning.distance, from = range.start, to = range.end, "Pruning stage.");
 
             let span_inner = enter.exit();
             let PruneOutput { pruned_count } = stage
@@ -530,7 +537,7 @@ impl Pipeline {
                 let _ = self.block_tx.send(Some(last_block_processed));
 
                 // Run pruning if enabled
-                if self.pruning_config.is_enabled() {
+                if self.config.pruning.is_enabled() {
                     self.prune().await?;
                 }
 
@@ -547,9 +554,16 @@ impl Pipeline {
 
                 match *self.cmd_rx.borrow_and_update() {
                     Some(PipelineCommand::SetTip(new_tip)) => {
-                        info!(target: "pipeline", tip = %new_tip, "A new tip has been set.");
-                        self.tip = Some(new_tip);
-                        self.metrics.set_sync_target(new_tip);
+                        let effective_tip = match self.config.sync_tip {
+                            Some(max) if new_tip > max => {
+                                info!(target: "pipeline", tip = %new_tip, max = %max, "Capping tip to configured sync tip.");
+                                max
+                            }
+                            _ => new_tip,
+                        };
+                        info!(target: "pipeline", tip = %effective_tip, "A new tip has been set.");
+                        self.tip = Some(effective_tip);
+                        self.metrics.set_sync_target(effective_tip);
                     }
 
                     Some(PipelineCommand::Stop) => break,
@@ -584,7 +598,7 @@ impl core::fmt::Debug for Pipeline {
             .field("command", &self.cmd_rx)
             .field("provider", &self.storage_provider)
             .field("chunk_size", &self.chunk_size)
-            .field("pruning_config", &self.pruning_config)
+            .field("config", &self.config)
             .field("stages", &self.stages.iter().map(|s| s.id()).collect::<Vec<_>>())
             .finish_non_exhaustive()
     }

--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -232,8 +232,10 @@ impl PruningConfig {
 /// Configuration for the pipeline.
 #[derive(Debug, Clone, Default)]
 pub struct PipelineConfig {
-    /// If set, the pipeline will stop syncing after reaching this block number.
-    pub sync_tip: Option<BlockNumber>,
+    /// The maximum block number the pipeline will sync to. When set, any tip updates beyond
+    /// this value are capped to it. Once the pipeline reaches this block, it will idle without
+    /// processing further blocks, while the node and RPC server remain running.
+    pub max_sync_tip: Option<BlockNumber>,
     /// Pruning configuration.
     pub pruning: PruningConfig,
 }
@@ -559,7 +561,7 @@ impl Pipeline {
 
                 match *self.cmd_rx.borrow_and_update() {
                     Some(PipelineCommand::SetTip(new_tip)) => {
-                        let effective_tip = match self.config.sync_tip {
+                        let effective_tip = match self.config.max_sync_tip {
                             Some(max) if new_tip > max => {
                                 info!(target: "pipeline", tip = %new_tip, max = %max, "Capping tip to configured sync tip.");
                                 max

--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -303,6 +303,11 @@ impl Pipeline {
         &self.config
     }
 
+    /// Sets the pruning configuration for the pipeline.
+    pub fn set_pruning_config(&mut self, config: PruningConfig) {
+        self.config.pruning = config;
+    }
+
     /// Adds a new stage to the end of the pipeline.
     ///
     /// Stages are executed in the order they are added.

--- a/crates/sync/pipeline/tests/pipeline.rs
+++ b/crates/sync/pipeline/tests/pipeline.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use futures::future::BoxFuture;
-use katana_pipeline::Pipeline;
+use katana_pipeline::{Pipeline, PipelineConfig};
 use katana_primitives::block::BlockNumber;
 use katana_provider::api::stage::StageCheckpointProvider;
 use katana_provider::test_utils::test_provider;
@@ -1272,4 +1272,153 @@ async fn prune_empty_pipeline_succeeds() {
     // No stages added
     let result = pipeline.prune().await;
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn run_caps_tip_when_sync_tip_configured() {
+    let provider_factory = test_provider();
+    let (mut pipeline, handle) = Pipeline::new(provider_factory.clone(), 100);
+
+    let stage = TrackingStage::new("Stage1");
+    let stage_clone = stage.clone();
+
+    pipeline.add_stage(stage);
+
+    // Configure the pipeline to stop syncing at block 50
+    pipeline.set_config(PipelineConfig { sync_tip: Some(50), ..Default::default() });
+
+    let mut blocks = handle.subscribe_blocks();
+
+    // Set a tip beyond the configured sync_tip
+    handle.set_tip(200);
+
+    let task_handle = tokio::spawn(async move { pipeline.run().await });
+
+    // Wait until the pipeline has processed up to block 50
+    loop {
+        match blocks.changed().await {
+            Ok(Some(block)) if block >= 50 => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    // Give a brief moment for the pipeline to settle (it should be idle now, not syncing further)
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    handle.stop();
+
+    let result = task_handle.await.unwrap();
+    assert!(result.is_ok());
+
+    // The stage should have been executed with a capped tip of 50, not 200
+    let execs = stage_clone.executions();
+    assert_eq!(execs.len(), 1);
+    assert_eq!(execs[0].from, 0);
+    assert_eq!(execs[0].to, 50);
+
+    // Checkpoint should be at 50
+    assert_eq!(provider_factory.provider_mut().execution_checkpoint("Stage1").unwrap(), Some(50));
+}
+
+#[tokio::test]
+async fn run_ignores_tips_beyond_configured_sync_tip() {
+    let provider_factory = test_provider();
+    let (mut pipeline, handle) = Pipeline::new(provider_factory.clone(), 100);
+
+    let stage = TrackingStage::new("Stage1");
+    let stage_clone = stage.clone();
+
+    pipeline.add_stage(stage);
+
+    // Configure sync tip at block 30
+    pipeline.set_config(PipelineConfig { sync_tip: Some(30), ..Default::default() });
+
+    let mut blocks = handle.subscribe_blocks();
+
+    // Set initial tip within configured sync_tip
+    handle.set_tip(20);
+
+    let task_handle = tokio::spawn(async move { pipeline.run().await });
+
+    // Wait for block 20
+    loop {
+        match blocks.changed().await {
+            Ok(Some(block)) if block >= 20 => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    // Now set a new tip beyond the sync_tip — should be capped to 30
+    handle.set_tip(500);
+
+    // Wait for block 30
+    loop {
+        match blocks.changed().await {
+            Ok(Some(block)) if block >= 30 => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    handle.stop();
+
+    let result = task_handle.await.unwrap();
+    assert!(result.is_ok());
+
+    let execs = stage_clone.executions();
+    assert_eq!(execs.len(), 2);
+
+    // First execution: 0 to 20
+    assert_eq!(execs[0].from, 0);
+    assert_eq!(execs[0].to, 20);
+
+    // Second execution: 21 to 30 (capped from 500)
+    assert_eq!(execs[1].from, 21);
+    assert_eq!(execs[1].to, 30);
+
+    assert_eq!(provider_factory.provider_mut().execution_checkpoint("Stage1").unwrap(), Some(30));
+}
+
+#[tokio::test]
+async fn run_without_sync_tip_does_not_cap() {
+    let provider_factory = test_provider();
+    let (mut pipeline, handle) = Pipeline::new(provider_factory.clone(), 100);
+
+    let stage = TrackingStage::new("Stage1");
+    let stage_clone = stage.clone();
+
+    pipeline.add_stage(stage);
+
+    // No sync_tip configured (default)
+    let mut blocks = handle.subscribe_blocks();
+    handle.set_tip(200);
+
+    let task_handle = tokio::spawn(async move { pipeline.run().await });
+
+    loop {
+        match blocks.changed().await {
+            Ok(Some(block)) if block >= 200 => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    handle.stop();
+
+    let result = task_handle.await.unwrap();
+    assert!(result.is_ok());
+
+    // Should process all the way to 200 without capping
+    let execs = stage_clone.executions();
+    assert_eq!(execs.len(), 2);
+    assert_eq!(execs[0].from, 0);
+    assert_eq!(execs[0].to, 100);
+    assert_eq!(execs[1].from, 101);
+    assert_eq!(execs[1].to, 200);
+
+    assert_eq!(provider_factory.provider_mut().execution_checkpoint("Stage1").unwrap(), Some(200));
 }

--- a/crates/sync/pipeline/tests/pipeline.rs
+++ b/crates/sync/pipeline/tests/pipeline.rs
@@ -1285,7 +1285,7 @@ async fn run_caps_tip_when_sync_tip_configured() {
     pipeline.add_stage(stage);
 
     // Configure the pipeline to stop syncing at block 50
-    pipeline.set_config(PipelineConfig { sync_tip: Some(50), ..Default::default() });
+    pipeline.set_config(PipelineConfig { max_sync_tip: Some(50), ..Default::default() });
 
     let mut blocks = handle.subscribe_blocks();
 
@@ -1332,7 +1332,7 @@ async fn run_ignores_tips_beyond_configured_sync_tip() {
     pipeline.add_stage(stage);
 
     // Configure sync tip at block 30
-    pipeline.set_config(PipelineConfig { sync_tip: Some(30), ..Default::default() });
+    pipeline.set_config(PipelineConfig { max_sync_tip: Some(30), ..Default::default() });
 
     let mut blocks = handle.subscribe_blocks();
 


### PR DESCRIPTION
Adds a `--sync.tip <BLOCK_NUMBER>` flag to the full node CLI that tells the pipeline to stop syncing once it reaches the specified block number. 

This is mainly useful during development and debugging when you need to sync to a specific block and then inspect the synced state via RPC without the pipeline continuing to advance. The chain tip watcher continues running normally but the pipeline caps the effective tip so it idles once the target is reached. 

Internally this introduces a `PipelineConfig` struct that wraps the existing `PruningConfig` alongside the new sync tip option, keeping the pipeline's configuration in one place.