### PR TITLE
feat(full-node): add `--sync.gateway` CLI flag for custom sync source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6261,6 +6261,7 @@ dependencies = [
  "strum 0.25.0",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -8,6 +8,7 @@ use katana_full_node::config::trie::TrieConfig;
 use katana_full_node::Network;
 use serde::{Deserialize, Serialize};
 use tracing::info;
+use url::Url;
 
 use crate::options::*;
 
@@ -64,6 +65,13 @@ pub struct FullNodeArgs {
     #[arg(long = "sync.tip")]
     #[arg(value_name = "BLOCK_NUMBER")]
     pub max_sync_tip: Option<u64>,
+
+    /// Custom feeder gateway base URL to sync from instead of the default
+    /// network gateway. Useful for syncing from another katana node's
+    /// feeder gateway.
+    #[arg(long = "sync.gateway")]
+    #[arg(value_name = "URL")]
+    pub sync_gateway: Option<Url>,
 }
 
 impl FullNodeArgs {
@@ -126,6 +134,7 @@ impl FullNodeArgs {
             gateway_api_key: self.gateway_api_key.clone(),
             trie: TrieConfig { compute: !self.trie.disable },
             max_sync_tip: self.max_sync_tip,
+            sync_gateway: self.sync_gateway.clone(),
         })
     }
 

--- a/crates/node/full/Cargo.toml
+++ b/crates/node/full/Cargo.toml
@@ -36,6 +36,7 @@ serde.workspace = true
 strum.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = [ "time" ] }
+url.workspace = true
 
 [features]
 cartridge = ["katana-node-config/cartridge", "katana-rpc-api/cartridge", "katana-rpc-server/cartridge"]

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -36,6 +36,7 @@ use katana_stage::blocks::BatchBlockDownloader;
 use katana_stage::{Blocks, Classes, StateTrie};
 use katana_tasks::TaskManager;
 use tracing::{error, info};
+use url::Url;
 
 use crate::pending::PreconfStateFactory;
 
@@ -82,6 +83,8 @@ pub struct Config {
     /// The maximum block number the pipeline will sync to. When set, the pipeline
     /// will stop syncing after reaching this block while the node remains running.
     pub max_sync_tip: Option<u64>,
+    /// Custom feeder gateway base URL to sync from instead of the default network gateway.
+    pub sync_gateway: Option<Url>,
 }
 
 #[derive(Debug)]
@@ -123,9 +126,15 @@ impl Node {
 
         // --- build gateway client
 
-        let gateway_client = match config.network {
-            Network::Mainnet => SequencerGateway::mainnet(),
-            Network::Sepolia => SequencerGateway::sepolia(),
+        let gateway_client = if let Some(ref base_url) = config.sync_gateway {
+            let gateway = base_url.join("gateway").expect("valid URL join");
+            let feeder_gateway = base_url.join("feeder_gateway").expect("valid URL join");
+            SequencerGateway::new(gateway, feeder_gateway)
+        } else {
+            match config.network {
+                Network::Mainnet => SequencerGateway::mainnet(),
+                Network::Sepolia => SequencerGateway::sepolia(),
+            }
         };
 
         let gateway_client = if let Some(ref key) = config.gateway_api_key {


### PR DESCRIPTION
Add a `--sync.gateway <URL>` flag that accepts a base URL (e.g., `http://localhost:5051/`) to sync from a custom feeder gateway instead of the hardcoded Starknet network endpoints. When provided, the gateway client is constructed by appending `gateway` and `feeder_gateway` paths to the base URL. The `--network` flag remains required for chain ID and chain spec selection. This enables syncing one katana full node from another katana node's feeder gateway server (`--gateway`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)