### PR TITLE
fix(sync): versioned block commitment reconstruction

### DIFF
--- a/crates/gateway/gateway-client/tests/fixtures/pre_0.7.0/block/mainnet_770.json
+++ b/crates/gateway/gateway-client/tests/fixtures/pre_0.7.0/block/mainnet_770.json
@@ -1,0 +1,1169 @@
+{
+  "status": "ACCEPTED_ON_L1",
+  "block_hash": "0x36f1a258d48bf335b9e167aca1c02d0936c818be3cb5d38b7f7001762779995",
+  "block_number": 770,
+  "parent_block_hash": "0x307688ef47c887ac46057ddfcbc2ede5b2068ab2e209e9c2d0d27c3b8c7b815",
+  "l1_da_mode": "CALLDATA",
+  "timestamp": 1642690775,
+  "sequencer_address": null,
+  "starknet_version": null,
+  "l2_gas_price": {
+    "price_in_fri": "0x1",
+    "price_in_wei": "0x1"
+  },
+  "l1_gas_price": {
+    "price_in_fri": "0x0",
+    "price_in_wei": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_fri": "0x1",
+    "price_in_wei": "0x1"
+  },
+  "event_commitment": "0x0",
+  "state_diff_commitment": null,
+  "state_root": "0xc342be5b351e4a33aa513ec19159c70f1a47be3a0753fed05dd81f7c812956",
+  "transaction_commitment": "0x0",
+  "receipt_commitment": null,
+  "transaction_receipts": [
+    {
+      "transaction_hash": "0x4bf1a0e49c2fa6f7ec35fcaeaa7752bc69fc2aeb21ad2f08a1b262739df8960",
+      "transaction_index": 0,
+      "execution_resources": {
+        "n_steps": 756,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 12,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 14,
+          "output_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x5e34f3fd0c87cae113440e2fe63e78715584e42dcf835fb174bd41288286eb7",
+      "transaction_index": 1,
+      "execution_resources": {
+        "n_steps": 756,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 12,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 14,
+          "output_builtin": 0,
+          "ecdsa_builtin": 1,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x224d89a31db8bb06414ec191ac62233e4cd1dbe4a1e5ed160b34f24cd4d29bc",
+      "transaction_index": 2,
+      "execution_resources": {
+        "n_steps": 752,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "range_check_builtin": 14,
+          "pedersen_builtin": 12,
+          "ecdsa_builtin": 1
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3600a54cbb53643258a635d81677b4b2ff7df0086c8362a4671670bc67432ba",
+      "transaction_index": 3,
+      "execution_resources": {
+        "n_steps": 169,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "output_builtin": 0,
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 7
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x2109f09befe6346246b29139241200fdfb7b7ba622b79df33d72817966a81ba",
+      "transaction_index": 4,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x339e343918115c233824c91f0d43a89f290d4c4b8303356fad6407c7c532669",
+      "transaction_index": 5,
+      "execution_resources": {
+        "n_steps": 756,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "range_check_builtin": 14,
+          "ecdsa_builtin": 1,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 12,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x1468abf1db88491fddd31444b253b6014f77fd8e8de1b8fe6e138c825ed7710",
+      "transaction_index": 6,
+      "execution_resources": {
+        "n_steps": 165,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "pedersen_builtin": 2,
+          "ec_op_builtin": 0,
+          "range_check_builtin": 7,
+          "bitwise_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x5febc13f3e8d076cdf0ffda9aa338bad88ea214fb20fac6b911e477d9a4ff7a",
+      "transaction_index": 7,
+      "execution_resources": {
+        "n_steps": 165,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "range_check_builtin": 7,
+          "pedersen_builtin": 2,
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x71d30108c793a932a07e0f3b22580677aef9c90eeab9255cc7a9e0fdf471deb",
+      "transaction_index": 8,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x5146b319e6667ac1508e37154be0e04a46e06e045fad7f0255b68fccd40be99",
+      "transaction_index": 9,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x1aaea9ca05870a9c1f69e8a6330d6eceb7f0923697a16949371a7f567c1d120",
+      "transaction_index": 10,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x279ae3406afcde653827a5f15428c5f50bb9d0f676fe197878b9709f08eb2f7",
+      "transaction_index": 11,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x30cac046e9f3aa14dcf66ad7ae957e5db2feeaa054ca7143f4262f5ca8029f5",
+      "transaction_index": 12,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x4dde4aecb520ab91c8bc84ed3ad9d33c5abd4d191f7d678f3d0a8e3284035e6",
+      "transaction_index": 13,
+      "execution_resources": {
+        "n_steps": 756,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 1,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 12,
+          "output_builtin": 0,
+          "range_check_builtin": 14,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x705823950b299e812fd7086b58b50c8d946c3946766e68ca245e678714dd86c",
+      "transaction_index": 14,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x79e4a5d2f12af9dc7255439ce8d1a2574d0c1a46cc30c4a336163c6b037677d",
+      "transaction_index": 15,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x34fea322712c52314f3ea953df3fc9503cd31218d5be319035a91831baa45e7",
+      "transaction_index": 16,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x44c7b67db3736a870f72291815efe33965ad433ac84c6924767b06943b6f33f",
+      "transaction_index": 17,
+      "execution_resources": {
+        "n_steps": 169,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 7,
+          "pedersen_builtin": 2,
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3b8b42ee1ad5424b8e946a11b11c1780a5e18f40eb7f7d8d0441cc7398c8d35",
+      "transaction_index": 18,
+      "execution_resources": {
+        "n_steps": 31,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [
+        {
+          "from_address": "0x513d3920359cf4f7cde6222bf85896b2d8ae1ed510954318078c5360a267c2a",
+          "to_address": "0xd9386fa59bf66f4a5b80ccc3f35bd2656c846fe2",
+          "payload": [
+            "0xc",
+            "0x22"
+          ]
+        }
+      ],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x760193ac76adabfdd30b0ff0f564099d2aa8face78e471c55cb0c0464647ffe",
+      "transaction_index": 19,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3e25ec120980def6ba45570d0b6bcbf8092cc2a3fbcf3e3a7cbf26367961793",
+      "transaction_index": 20,
+      "execution_resources": {
+        "n_steps": 939,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 14,
+          "output_builtin": 0,
+          "ecdsa_builtin": 1,
+          "range_check_builtin": 23,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x6b0a440a830a87beb7cb44e47239066e61fa0f139d10eb34309c824cfbf70b",
+      "transaction_index": 21,
+      "execution_resources": {
+        "n_steps": 178,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x1bd036e953cea3c636d68c736421917f717ec792551a919b8914546a9af25d8",
+      "transaction_index": 22,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x5bf505b4c052aece0ba3c1cb380b325723026956e78ac81b6c4c738b5925eec",
+      "transaction_index": 23,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x4080b7272db327d1f1a5e05e532e27f4a41e52d190a1b07af764d8b4638c240",
+      "transaction_index": 24,
+      "execution_resources": {
+        "n_steps": 238,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x41cce6b580af5c51355892093dece91c0cc21936e988b6dc5aa7e87ec340db7",
+      "transaction_index": 25,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x6762dec162255f8ff68242023f8023673f930533727d66cba28fdc1620509a",
+      "transaction_index": 26,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0xf75b73fb515e14843d39fded14ccc9ca260f129f1fd27c605f2705195fb3c1",
+      "transaction_index": 27,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x66de76bc398d20949de949a70e39598f176c3868bf2e8b8e0d4f8b7cefe1cd9",
+      "transaction_index": 28,
+      "execution_resources": {
+        "n_steps": 332,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [
+        {
+          "from_address": "0x7ead8012b2fa40f62ac28ffeed44e74336260cee7eeb7eec11728d5b6f90c83",
+          "to_address": "0x1",
+          "payload": [
+            "0xc",
+            "0x22"
+          ]
+        }
+      ],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    }
+  ],
+  "transactions": [
+    {
+      "transaction_hash": "0x4bf1a0e49c2fa6f7ec35fcaeaa7752bc69fc2aeb21ad2f08a1b262739df8960",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x54b70c1e3307b6b83dc8df73a662ae0e6da5a93ce924740fdb345771ceba3a1",
+        "0x8d9c8109b21e41377786c4adec67adefd17556d19cc73a5b60fd057be090a1"
+      ],
+      "contract_address": "0x43fcb46551d3192b3216af244650fbc9894f4835b00e571012429f0c2e39e0b",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x43fcb46551d3192b3216af244650fbc9894f4835b00e571012429f0c2e39e0b",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x5e34f3fd0c87cae113440e2fe63e78715584e42dcf835fb174bd41288286eb7",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x3a9353557dc35b9d39382f25912539d209e0e1dbb0ee16c862a30ae77c20683",
+        "0x26c7e8c81e7b0d291aee0960aa5731529458454a9426edcc23e036b16f8861e"
+      ],
+      "contract_address": "0x74db0f92866bd328ddc47e4f26ccde7b2a0b6b306b3aa1ea677a2692e775135",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x74db0f92866bd328ddc47e4f26ccde7b2a0b6b306b3aa1ea677a2692e775135",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x224d89a31db8bb06414ec191ac62233e4cd1dbe4a1e5ed160b34f24cd4d29bc",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0xb7f1c483087a95df6ccbd5160e3377283815040142e818a9c41abba4a2b418",
+        "0x6b8118843f76c9fdb3ebcc981186a8c140c32d82104cb0f4e3a155ec32aac7c"
+      ],
+      "contract_address": "0x1911c18fb00d3ae1160c8cd8fe40d8501aeaaaee5a0433e03f6dbee7d6fd881",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x1911c18fb00d3ae1160c8cd8fe40d8501aeaaaee5a0433e03f6dbee7d6fd881",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x3600a54cbb53643258a635d81677b4b2ff7df0086c8362a4671670bc67432ba",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x588b7763831d4228368d6b563b49de0e77072c0ce440ba5591bf90d620f4f14",
+      "entry_point_selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+      "calldata": [
+        "0x39f8bfb98d5f1fb7847327cbf9ff788d31c4f661d66a7ac37cd9294515a5e3b",
+        "0x2",
+        "0x6f7c02939fbad82214ec28657316be39e1e2bd7386103119b91d2b001c0d6f7",
+        "0x7672a9e39c042f3f10375ea472130428c3e8fb10ea0f0ec9ca6d49727895ce7"
+      ]
+    },
+    {
+      "transaction_hash": "0x2109f09befe6346246b29139241200fdfb7b7ba622b79df33d72817966a81ba",
+      "type": "DEPLOY",
+      "contract_address": "0xc113e90e3041af35b13c8c0b1e7291cbcedec85a1e4576fbdd180689dd656d",
+      "contract_address_salt": "0x4c423e82899c70e9bdc0870d86dc521a264735e88a7a930c7d8e3e400e4d6d9",
+      "constructor_calldata": [
+        "0x2375dd704d44101373d2f2da54d90843486e28ee1f1b4b103a619a2e4bc3e36",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x339e343918115c233824c91f0d43a89f290d4c4b8303356fad6407c7c532669",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x7f219cba8e6e16e39747efa54deb39937e64339f09085333575909ee6d1caf1",
+        "0x38b95639e387f79c0174ae460e24ffced992ec62639646c8727875949d6c6ec"
+      ],
+      "contract_address": "0x7f58f6780c254b8813971fd47deddb8c2fde1b02574583625e66effb47a108f",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x7f58f6780c254b8813971fd47deddb8c2fde1b02574583625e66effb47a108f",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x1468abf1db88491fddd31444b253b6014f77fd8e8de1b8fe6e138c825ed7710",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0xf7366277d85cfe73d28876e4bdf5d01b1ca56defba383873aa0a052d69a2ae",
+      "entry_point_selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+      "calldata": [
+        "0x4d270220bf03c841fca4b007ef22b58203c99c58f576b09df7b757543cba5e2",
+        "0x2",
+        "0x7dcafc83f4354fb5388c5cdac243b50396c3220c504cbe27d80a441c4f922a5",
+        "0x587a36c3d443554f4137d24b35b933fa9339c8919a5871c6e316a418556857d"
+      ]
+    },
+    {
+      "transaction_hash": "0x5febc13f3e8d076cdf0ffda9aa338bad88ea214fb20fac6b911e477d9a4ff7a",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0xf7366277d85cfe73d28876e4bdf5d01b1ca56defba383873aa0a052d69a2ae",
+      "entry_point_selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+      "calldata": [
+        "0x4d270220bf03c841fca4b007ef22b58203c99c58f576b09df7b757543cba5e2",
+        "0x2",
+        "0x7dcafc83f4354fb5388c5cdac243b50396c3220c504cbe27d80a441c4f922a5",
+        "0x4a825e08285ed4fdf566e843ab0b9a0d8a04cff553678f2ba340ba1d48b0675"
+      ]
+    },
+    {
+      "transaction_hash": "0x71d30108c793a932a07e0f3b22580677aef9c90eeab9255cc7a9e0fdf471deb",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x4b83aa7a6a98051ca78c63c0ace5ea8262f96273cf864488ea0d8bbf906e109",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x7f4b769ea078474bf6ace40d9a275fa4c9944ba766f661803f4c88fa2cc5bfa",
+        "0x20c1d0fa56a63de16006ad8a1953af34fa727c357fe782445a4599ebfbdc352"
+      ]
+    },
+    {
+      "transaction_hash": "0x5146b319e6667ac1508e37154be0e04a46e06e045fad7f0255b68fccd40be99",
+      "type": "DEPLOY",
+      "contract_address": "0xea8eb06b2150b0bcb79579a347031bd800e95f5498e21ae7a4f4f5c0bcf311",
+      "contract_address_salt": "0x303512abb43f0248615b0b1f8d046cdab52373a77fed2a35e29307ed898d2",
+      "constructor_calldata": [
+        "0x211d4ce8d85143ce598ce8bd69aaab9562d4d65f4d696f16cc255b82d294677",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x1aaea9ca05870a9c1f69e8a6330d6eceb7f0923697a16949371a7f567c1d120",
+      "type": "DEPLOY",
+      "contract_address": "0x5b6eafa479e671179798665504341695f4d0f5849c68ab800f70792a28bb135",
+      "contract_address_salt": "0x369ed141e5905c6b6c95b1a3acf6e2575161c313333fa9864be1ee92aee3cd2",
+      "constructor_calldata": [
+        "0x1db2479d6c518a92b71fa42c76d1cbab512858cec7e163d2d4cabaa488aa3fe",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x279ae3406afcde653827a5f15428c5f50bb9d0f676fe197878b9709f08eb2f7",
+      "type": "DEPLOY",
+      "contract_address": "0x6ca5c8e89f35402025042702d26fb9e5b5d9e1982d64fd6aa8a36ef4d476c10",
+      "contract_address_salt": "0x5712b3acb5fab80f7768b06c138b9a5754c6e6dff9bdce88d2b313467de1907",
+      "constructor_calldata": [
+        "0x1db2479d6c518a92b71fa42c76d1cbab512858cec7e163d2d4cabaa488aa3fe",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x30cac046e9f3aa14dcf66ad7ae957e5db2feeaa054ca7143f4262f5ca8029f5",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x41cc786ed6a17a18c533878c0937112ac0f9cd975be02e7f2b9b3153695984b",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x79d228161806e418ea79addae084c674bec80aa5879fd9bb377ad6ef837f15",
+        "0x4b6eaaac6f17fd75a8395922d3056cc66e99effb60569f64ec0ba17c9d42408"
+      ]
+    },
+    {
+      "transaction_hash": "0x4dde4aecb520ab91c8bc84ed3ad9d33c5abd4d191f7d678f3d0a8e3284035e6",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0xeeaaf10c1358b70d0e26e95e4ec4e70f45c09ae87c9b96896f80f88ec929a1",
+        "0x69e505581e0fda40b6f454a68c77624d13b7b9dc6d396d6a36b5d6cd51c3668"
+      ],
+      "contract_address": "0xca719515f31d49aa415c53e41eec64c0a80c5b3fb09286ef6960b6aef7a871",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0xca719515f31d49aa415c53e41eec64c0a80c5b3fb09286ef6960b6aef7a871",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x705823950b299e812fd7086b58b50c8d946c3946766e68ca245e678714dd86c",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x74ba0dedffe72a878afb897e29367d66f80d01bfe603c40e21db64f9c75c4e0",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x77f193e9440ad00e4df39c65d04580f3f8d96605e811f065f2adb1c24267759",
+        "0x4b6202dc1fbc7666e3f11f15956db9de9f0a2d26d784304435598ad63961a33"
+      ]
+    },
+    {
+      "transaction_hash": "0x79e4a5d2f12af9dc7255439ce8d1a2574d0c1a46cc30c4a336163c6b037677d",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x74ba0dedffe72a878afb897e29367d66f80d01bfe603c40e21db64f9c75c4e0",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x77f193e9440ad00e4df39c65d04580f3f8d96605e811f065f2adb1c24267759",
+        "0x46e28c32606aa9707f52e35430d52e05f1fcd63559e191c221231efb2cee0ca"
+      ]
+    },
+    {
+      "transaction_hash": "0x34fea322712c52314f3ea953df3fc9503cd31218d5be319035a91831baa45e7",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x2bc997afe44624f8ba780d316372408daad3c2c0b153891805526472521461b",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x6ba52d980a6afacc1978199c7b85e11ff08facf5214bb2f03a7809e29516649",
+        "0x562012fd073ed1d2941e907e404ea83a9d79a9816d3da62a2decd5041d2e00f"
+      ]
+    },
+    {
+      "transaction_hash": "0x44c7b67db3736a870f72291815efe33965ad433ac84c6924767b06943b6f33f",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x6803f100f306a992eed344cfa712470e57d28afe6c9508fe507f1a77c6de548",
+      "entry_point_selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+      "calldata": [
+        "0x574955fa12c7ae282b6fe55f2012ae73a4a3dc5e3977080ffe686e21d80aa0d",
+        "0x2",
+        "0x55ac5fdb722a5ce44d77a22f798b1967c51a776f4013751916b3cf319dd8b6f",
+        "0x18014cba05a5bea6661f4f70962417863249afff93d85dee776c8abdcb2fb1"
+      ]
+    },
+    {
+      "transaction_hash": "0x3b8b42ee1ad5424b8e946a11b11c1780a5e18f40eb7f7d8d0441cc7398c8d35",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x513d3920359cf4f7cde6222bf85896b2d8ae1ed510954318078c5360a267c2a",
+      "entry_point_selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+      "calldata": [
+        "0xd9386fa59bf66f4a5b80ccc3f35bd2656c846fe2"
+      ]
+    },
+    {
+      "transaction_hash": "0x760193ac76adabfdd30b0ff0f564099d2aa8face78e471c55cb0c0464647ffe",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0xebd953b5acc8997f86a756def2053ae8eb6fb65bab5e483fceb98d56ae4f41",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0xb22e7d10661c6cfeae79ed4b232fadb715be2ccb63c047d35ed4642ed239dc",
+        "0x5e1aa41fc0b23174b30467fac4aebae891b5166871cdac1221659849110949"
+      ]
+    },
+    {
+      "transaction_hash": "0x3e25ec120980def6ba45570d0b6bcbf8092cc2a3fbcf3e3a7cbf26367961793",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x47c2c393747fd391dcfd545f6cbb8f2cb5ac147c012d8472c7eb0c8df9fdc48",
+        "0x63d3b21477325f4e8bc950450f620ed5c5fc423ce83ccc7c3970e81b6169eb2"
+      ],
+      "contract_address": "0xca719515f31d49aa415c53e41eec64c0a80c5b3fb09286ef6960b6aef7a871",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+        "0x3",
+        "0xca719515f31d49aa415c53e41eec64c0a80c5b3fb09286ef6960b6aef7a871",
+        "0x56bc75e2d63100000",
+        "0x0",
+        "0x1"
+      ]
+    },
+    {
+      "transaction_hash": "0x6b0a440a830a87beb7cb44e47239066e61fa0f139d10eb34309c824cfbf70b",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x454ff8df1e49ef5ccbae1849f1c381a7ec8e352fa6468037d57bcc00d02413c",
+      "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+      "calldata": [
+        "0x68d9bcb43a723c4cf246fea12b8ebdb4e3d33dcb556d0ba7f5b97a61ef1ee09",
+        "0x6f4231f24d469d917bd74d617687c0b7909cce900b33f5eca3dfbf22a4f62a2"
+      ]
+    },
+    {
+      "transaction_hash": "0x1bd036e953cea3c636d68c736421917f717ec792551a919b8914546a9af25d8",
+      "type": "DEPLOY",
+      "contract_address": "0xdf489e5aaf101e700f36ad619396d9b955a1366ad7585951ba629c3b8d1d0f",
+      "contract_address_salt": "0xe8a792d7ff25da61b8f0502d86fd12ecb0617cf45caf6cbbf1b9703301ce80",
+      "constructor_calldata": [
+        "0x233400f8483ac4626474f16dd48308ccdcecd08f1faf8f49df4ef3c9e9e6ecf",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x5bf505b4c052aece0ba3c1cb380b325723026956e78ac81b6c4c738b5925eec",
+      "type": "DEPLOY",
+      "contract_address": "0x58a501df1cfe7ea850d34c30a97daea64f1776da3566f57c9c9d7613eb5d9b5",
+      "contract_address_salt": "0x4e99d21514b23a18ed798467d6eaed2c43cd0dc20d38e2408d6b28fc0287b49",
+      "constructor_calldata": [
+        "0x5c19506a001151c27892e70bd64ba015b37a2a4c36fc524878ae182a116ff4f",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x4080b7272db327d1f1a5e05e532e27f4a41e52d190a1b07af764d8b4638c240",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x388ba5bfe0fc9c18804af5aceaaca0dd54dfbb921ada791d1f8519c9732dd9f",
+      "entry_point_selector": "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+      "calldata": [
+        "0x4f735737e58129b70926b5f3b8fe1d25889094de925efb60beee93bac83ca97",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x41cce6b580af5c51355892093dece91c0cc21936e988b6dc5aa7e87ec340db7",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x72895488b4f947e5be617e26aca7a6e9dd065710856200eda364568bc94feef",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x4a03ef618bbf6a8eca341b8050e03af01214a9a5247fd1ff876fb2b4f83d743",
+        "0x20357def51d4980da499f720debaebbd9f60df5f1f70e4bf5b360f109bc7297"
+      ]
+    },
+    {
+      "transaction_hash": "0x6762dec162255f8ff68242023f8023673f930533727d66cba28fdc1620509a",
+      "type": "DEPLOY",
+      "contract_address": "0xb8ce5d5f34eec79857e32517692df672d412fd2bac1df1189161a99f24e90e",
+      "contract_address_salt": "0xdacd5999f5f79258dd5a33a0aafc49becfa5ea022f057517f869dd4e5c5d97",
+      "constructor_calldata": [
+        "0xe2533aac8903a3407313af0505b95bb9039aec74f601b888613c748719d547",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0xf75b73fb515e14843d39fded14ccc9ca260f129f1fd27c605f2705195fb3c1",
+      "type": "DEPLOY",
+      "contract_address": "0x2cd7d4fbca947b219a058638c677bb9e4041f8be885c30949df090cfb5da6d1",
+      "contract_address_salt": "0x1d23cff9bb2a3dcf371547c2f9ebb7912e9e83c710de7aa4b8db714ab185cf",
+      "constructor_calldata": [
+        "0x1f43e4ac18f196f2933ba7e7578935e481c5c9187d951d1687a9dde4d68f72d",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x66de76bc398d20949de949a70e39598f176c3868bf2e8b8e0d4f8b7cefe1cd9",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x7ead8012b2fa40f62ac28ffeed44e74336260cee7eeb7eec11728d5b6f90c83",
+      "entry_point_selector": "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+      "calldata": [
+        "0x256c6bd5e11045165b363ce43422fa310b42712c504291ebb9e691ba4071f5d",
+        "0x1"
+      ]
+    }
+  ]
+}

--- a/crates/gateway/gateway-client/tests/fixtures/pre_0.7.0/state_update/mainnet_770.json
+++ b/crates/gateway/gateway-client/tests/fixtures/pre_0.7.0/state_update/mainnet_770.json
@@ -1,0 +1,254 @@
+{
+  "block_hash": "0x36f1a258d48bf335b9e167aca1c02d0936c818be3cb5d38b7f7001762779995",
+  "new_root": "0xc342be5b351e4a33aa513ec19159c70f1a47be3a0753fed05dd81f7c812956",
+  "old_root": "0x5766b2cc9e13327938dc52e7b42b2ee3b0f0e451c99585908618d1afcf1c491",
+  "state_diff": {
+    "storage_diffs": {
+      "0xb8ce5d5f34eec79857e32517692df672d412fd2bac1df1189161a99f24e90e": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0xe2533aac8903a3407313af0505b95bb9039aec74f601b888613c748719d547"
+        }
+      ],
+      "0xc113e90e3041af35b13c8c0b1e7291cbcedec85a1e4576fbdd180689dd656d": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x2375dd704d44101373d2f2da54d90843486e28ee1f1b4b103a619a2e4bc3e36"
+        }
+      ],
+      "0xca719515f31d49aa415c53e41eec64c0a80c5b3fb09286ef6960b6aef7a871": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x2"
+        }
+      ],
+      "0xdf489e5aaf101e700f36ad619396d9b955a1366ad7585951ba629c3b8d1d0f": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x233400f8483ac4626474f16dd48308ccdcecd08f1faf8f49df4ef3c9e9e6ecf"
+        }
+      ],
+      "0xea8eb06b2150b0bcb79579a347031bd800e95f5498e21ae7a4f4f5c0bcf311": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x211d4ce8d85143ce598ce8bd69aaab9562d4d65f4d696f16cc255b82d294677"
+        }
+      ],
+      "0xebd953b5acc8997f86a756def2053ae8eb6fb65bab5e483fceb98d56ae4f41": [
+        {
+          "key": "0xb22e7d10661c6cfeae79ed4b232fadb715be2ccb63c047d35ed4642ed239dc",
+          "value": "0x5e1aa41fc0b23174b30467fac4aebae891b5166871cdac1221659849110949"
+        }
+      ],
+      "0xf7366277d85cfe73d28876e4bdf5d01b1ca56defba383873aa0a052d69a2ae": [
+        {
+          "key": "0x35a3ab71e9e107ea35dd118b87b7b7ef5d1a19511cc18f639a1d413bc192ce3",
+          "value": "0x7b95f907e86a9e5a7118b9b584876a072d864418a0997c4fb01488389f24549"
+        },
+        {
+          "key": "0x35a3ab71e9e107ea35dd118b87b7b7ef5d1a19511cc18f639a1d413bc192ce4",
+          "value": "0x22fc94cbfca2293d369eba8ee0c4ce081d3e9886edc000f286575e359e18bf1"
+        }
+      ],
+      "0x1911c18fb00d3ae1160c8cd8fe40d8501aeaaaee5a0433e03f6dbee7d6fd881": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ],
+      "0x256c6bd5e11045165b363ce43422fa310b42712c504291ebb9e691ba4071f5d": [
+        {
+          "key": "0x5",
+          "value": "0x22b"
+        }
+      ],
+      "0x2bc997afe44624f8ba780d316372408daad3c2c0b153891805526472521461b": [
+        {
+          "key": "0x6ba52d980a6afacc1978199c7b85e11ff08facf5214bb2f03a7809e29516649",
+          "value": "0x562012fd073ed1d2941e907e404ea83a9d79a9816d3da62a2decd5041d2e00f"
+        }
+      ],
+      "0x2cd7d4fbca947b219a058638c677bb9e4041f8be885c30949df090cfb5da6d1": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x1f43e4ac18f196f2933ba7e7578935e481c5c9187d951d1687a9dde4d68f72d"
+        }
+      ],
+      "0x388ba5bfe0fc9c18804af5aceaaca0dd54dfbb921ada791d1f8519c9732dd9f": [
+        {
+          "key": "0x5",
+          "value": "0x64"
+        }
+      ],
+      "0x41cc786ed6a17a18c533878c0937112ac0f9cd975be02e7f2b9b3153695984b": [
+        {
+          "key": "0x79d228161806e418ea79addae084c674bec80aa5879fd9bb377ad6ef837f15",
+          "value": "0x4b6eaaac6f17fd75a8395922d3056cc66e99effb60569f64ec0ba17c9d42408"
+        }
+      ],
+      "0x43fcb46551d3192b3216af244650fbc9894f4835b00e571012429f0c2e39e0b": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ],
+      "0x454ff8df1e49ef5ccbae1849f1c381a7ec8e352fa6468037d57bcc00d02413c": [
+        {
+          "key": "0x6f4231f24d469d917bd74d617687c0b7909cce900b33f5eca3dfbf22a4f62a2",
+          "value": "0x7c7"
+        }
+      ],
+      "0x4b83aa7a6a98051ca78c63c0ace5ea8262f96273cf864488ea0d8bbf906e109": [
+        {
+          "key": "0x7f4b769ea078474bf6ace40d9a275fa4c9944ba766f661803f4c88fa2cc5bfa",
+          "value": "0x20c1d0fa56a63de16006ad8a1953af34fa727c357fe782445a4599ebfbdc352"
+        }
+      ],
+      "0x4f735737e58129b70926b5f3b8fe1d25889094de925efb60beee93bac83ca97": [
+        {
+          "key": "0x5",
+          "value": "0x0"
+        }
+      ],
+      "0x588b7763831d4228368d6b563b49de0e77072c0ce440ba5591bf90d620f4f14": [
+        {
+          "key": "0x5f0a76562e3b27adce624e812687ea5fbcde6d1541d83d29f7bb97b8c9922e5",
+          "value": "0x6f7c02939fbad82214ec28657316be39e1e2bd7386103119b91d2b001c0d6f7"
+        },
+        {
+          "key": "0x5f0a76562e3b27adce624e812687ea5fbcde6d1541d83d29f7bb97b8c9922e6",
+          "value": "0x7672a9e39c042f3f10375ea472130428c3e8fb10ea0f0ec9ca6d49727895ce7"
+        }
+      ],
+      "0x58a501df1cfe7ea850d34c30a97daea64f1776da3566f57c9c9d7613eb5d9b5": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x5c19506a001151c27892e70bd64ba015b37a2a4c36fc524878ae182a116ff4f"
+        }
+      ],
+      "0x5b6eafa479e671179798665504341695f4d0f5849c68ab800f70792a28bb135": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x1db2479d6c518a92b71fa42c76d1cbab512858cec7e163d2d4cabaa488aa3fe"
+        }
+      ],
+      "0x6803f100f306a992eed344cfa712470e57d28afe6c9508fe507f1a77c6de548": [
+        {
+          "key": "0x743c0e7a924d3be4b077b20fdf6aff2d606773067a808f414a69e2682b11302",
+          "value": "0x55ac5fdb722a5ce44d77a22f798b1967c51a776f4013751916b3cf319dd8b6f"
+        },
+        {
+          "key": "0x743c0e7a924d3be4b077b20fdf6aff2d606773067a808f414a69e2682b11303",
+          "value": "0x18014cba05a5bea6661f4f70962417863249afff93d85dee776c8abdcb2fb1"
+        }
+      ],
+      "0x68d9bcb43a723c4cf246fea12b8ebdb4e3d33dcb556d0ba7f5b97a61ef1ee09": [
+        {
+          "key": "0x6f4231f24d469d917bd74d617687c0b7909cce900b33f5eca3dfbf22a4f62a2",
+          "value": "0x7e5"
+        }
+      ],
+      "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75": [
+        {
+          "key": "0x59e989e478206ac25a2c175260f135cf3f055d50e648115588f95119752cb71",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x166675975a44e3fb677a399c31079e2febaae8318b3da883aca22845cce333d",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x48a922781d41a8a1a2fc759b3ee870f67e0e2db8aa7253566009428c0df4ef2",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x7ca3466dd308704ba9751d1c1657fc29038a926a6a3532ba12aa60c50102536",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x636aa5687d2bb79acd6dc52c711df8449b979228550fb63853d87bd6faa613f",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x1557182e4359a1f0c6301278e8f5b35a776ab58d39892581e357578fb287836",
+          "value": "0xefcfc0f5d3c5899de11c4f6bd18de54e"
+        }
+      ],
+      "0x6ca5c8e89f35402025042702d26fb9e5b5d9e1982d64fd6aa8a36ef4d476c10": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x1db2479d6c518a92b71fa42c76d1cbab512858cec7e163d2d4cabaa488aa3fe"
+        }
+      ],
+      "0x72895488b4f947e5be617e26aca7a6e9dd065710856200eda364568bc94feef": [
+        {
+          "key": "0x4a03ef618bbf6a8eca341b8050e03af01214a9a5247fd1ff876fb2b4f83d743",
+          "value": "0x20357def51d4980da499f720debaebbd9f60df5f1f70e4bf5b360f109bc7297"
+        }
+      ],
+      "0x74ba0dedffe72a878afb897e29367d66f80d01bfe603c40e21db64f9c75c4e0": [
+        {
+          "key": "0x77f193e9440ad00e4df39c65d04580f3f8d96605e811f065f2adb1c24267759",
+          "value": "0x46e28c32606aa9707f52e35430d52e05f1fcd63559e191c221231efb2cee0ca"
+        }
+      ],
+      "0x74db0f92866bd328ddc47e4f26ccde7b2a0b6b306b3aa1ea677a2692e775135": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ],
+      "0x7ead8012b2fa40f62ac28ffeed44e74336260cee7eeb7eec11728d5b6f90c83": [
+        {
+          "key": "0x5",
+          "value": "0x65"
+        }
+      ],
+      "0x7f58f6780c254b8813971fd47deddb8c2fde1b02574583625e66effb47a108f": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ]
+    },
+    "deployed_contracts": [
+      {
+        "address": "0x2cd7d4fbca947b219a058638c677bb9e4041f8be885c30949df090cfb5da6d1",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x6ca5c8e89f35402025042702d26fb9e5b5d9e1982d64fd6aa8a36ef4d476c10",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0xb8ce5d5f34eec79857e32517692df672d412fd2bac1df1189161a99f24e90e",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0xdf489e5aaf101e700f36ad619396d9b955a1366ad7585951ba629c3b8d1d0f",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x5b6eafa479e671179798665504341695f4d0f5849c68ab800f70792a28bb135",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0xea8eb06b2150b0bcb79579a347031bd800e95f5498e21ae7a4f4f5c0bcf311",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x58a501df1cfe7ea850d34c30a97daea64f1776da3566f57c9c9d7613eb5d9b5",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0xc113e90e3041af35b13c8c0b1e7291cbcedec85a1e4576fbdd180689dd656d",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      }
+    ],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "nonces": {},
+    "replaced_classes": [],
+    "migrated_compiled_classes": []
+  }
+}

--- a/crates/gateway/gateway-server/src/handlers.rs
+++ b/crates/gateway/gateway-server/src/handlers.rs
@@ -95,6 +95,7 @@ where
                         state_root: Some(block.header.state_root),
                         timestamp: block.header.timestamp,
                         transaction_commitment: Some(block.header.transactions_commitment),
+                        state_diff_length: Some(block.header.state_diff_length),
                         state_diff_commitment: Some(block.header.state_diff_commitment),
                         parent_block_hash: block.header.parent_hash,
                         starknet_version: Some(block.header.starknet_version.to_string()),

--- a/crates/gateway/gateway-types/src/lib.rs
+++ b/crates/gateway/gateway-types/src/lib.rs
@@ -133,6 +133,8 @@ pub struct Block {
     #[serde(default)]
     pub state_diff_commitment: Option<Felt>,
     #[serde(default)]
+    pub state_diff_length: Option<u32>,
+    #[serde(default)]
     pub state_root: Option<Felt>,
     #[serde(default)]
     pub transaction_commitment: Option<Felt>,

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -28,8 +28,14 @@ impl StarknetVersion {
     /// so this is unambiguous.
     pub const UNVERSIONED: Self = Self::new([0, 0, 0, 0]);
 
+    /// Starknet version 0.7.0.
     pub const V0_7_0: Self = Self::new([0, 7, 0, 0]);
+    /// Starknet version 0.11.1.
+    pub const V0_11_1: Self = Self::new([0, 11, 1, 0]);
+    /// Starknet version 0.13.2.
     pub const V0_13_2: Self = Self::new([0, 13, 2, 0]);
+    /// Starknet version 0.13.4.
+    pub const V0_13_4: Self = Self::new([0, 13, 4, 0]);
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -309,7 +309,7 @@ fn compute_transaction_commitment(transactions: &[TxWithHash], version: Starknet
 /// Computes the versioned transaction-commitment leaf for a single transaction.
 fn calculate_transaction_commitment_leaf(tx: &TxWithHash, version: StarknetVersion) -> Felt {
     if version < STARKNET_VERSION_0_11_1 {
-        let tx_signature = transaction_signature(&tx.transaction);
+        let tx_signature = transaction_signature_pre_0_11_1(&tx.transaction);
         let signature_hash = Pedersen::hash_array(tx_signature);
 
         Pedersen::hash(&tx.hash, &signature_hash)
@@ -330,6 +330,15 @@ fn calculate_transaction_commitment_leaf(tx: &TxWithHash, version: StarknetVersi
         }
 
         Poseidon::hash_array(&elements)
+    }
+}
+
+fn transaction_signature_pre_0_11_1(transaction: &Tx) -> &[Felt] {
+    match transaction {
+        Tx::Invoke(InvokeTx::V0(tx)) => &tx.signature,
+        Tx::Invoke(InvokeTx::V1(tx)) => &tx.signature,
+        Tx::Invoke(InvokeTx::V3(tx)) => &tx.signature,
+        Tx::Declare(_) | Tx::Deploy(_) | Tx::DeployAccount(_) | Tx::L1Handler(_) => &[],
     }
 }
 

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -95,13 +95,21 @@
 //! * <https://github.com/starkware-libs/sequencer/blob/e3be9f1a0f3514e989f5b6d753022f6ef7bf5b1d/crates/starknet_api/src/block_hash/block_hash_calculator.rs#L219-L256>
 //! * <https://github.com/starkware-libs/sequencer/blob/e3be9f1a0f3514e989f5b6d753022f6ef7bf5b1d/crates/starknet_api/src/block_hash/block_hash_calculator.rs#L383-L409>
 
-use katana_primitives::block::Header;
+use katana_primitives::block::{Header, SealedBlock};
 use katana_primitives::cairo::ShortString;
 use katana_primitives::chain::ChainId;
+use katana_primitives::receipt::{Event, Receipt};
+use katana_primitives::state::{compute_state_diff_hash, StateUpdates};
+use katana_primitives::transaction::{DeclareTx, DeployAccountTx, InvokeTx, Tx, TxWithHash};
+use katana_primitives::utils::starknet_keccak;
 use katana_primitives::version::StarknetVersion;
 use katana_primitives::Felt;
+use katana_trie::compute_merkle_root;
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
+
+const STARKNET_VERSION_0_11_1: StarknetVersion = StarknetVersion::new([0, 11, 1, 0]);
+const STARKNET_VERSION_0_13_4: StarknetVersion = StarknetVersion::new([0, 13, 4, 0]);
 
 /// Computes the block hash for a header, dispatching to the correct algorithm based
 /// on the block's `starknet_version`.
@@ -238,15 +246,247 @@ fn compute_hash_post_0_13_4(header: &Header, version_str: &str) -> Felt {
     ])
 }
 
+/// Computes block commitments that some synced block sources omit from the header.
+///
+/// Version gates:
+/// - Transaction commitment: reconstructed for any version when the header field is zero.
+/// - Event commitment: reconstructed for any version when the header field is zero.
+/// - State diff commitment and length: only meaningful from `0.13.2` onward.
+/// - Receipt commitment: only meaningful from `0.13.2` onward.
+pub(crate) fn compute_missing_commitments(
+    block: &mut SealedBlock,
+    receipts: &[Receipt],
+    state_updates: &StateUpdates,
+) {
+    let version = block.header.starknet_version;
+
+    if block.header.transactions_commitment == Felt::ZERO {
+        block.header.transactions_commitment = compute_transaction_commitment(&block.body, version);
+    }
+
+    if block.header.events_commitment == Felt::ZERO {
+        block.header.events_commitment = compute_event_commitment(&block.body, receipts, version);
+    }
+
+    // Post-0.13.2 block hashes include `state_diff_length` and `state_diff_commitment`.
+    // The commitment itself is the canonical Poseidon hash implemented in
+    // `katana_primitives::state::compute_state_diff_hash`.
+    if version >= StarknetVersion::V0_13_2
+        && (block.header.state_diff_length == 0 || block.header.state_diff_commitment == Felt::ZERO)
+    {
+        block.header.state_diff_length =
+            u32::try_from(state_updates.len()).expect("state diff length overflow");
+        block.header.state_diff_commitment = compute_state_diff_hash(state_updates.clone());
+    }
+
+    if version >= StarknetVersion::V0_13_2 && block.header.receipts_commitment == Felt::ZERO {
+        block.header.receipts_commitment = compute_receipt_commitment(&block.body, receipts);
+    }
+}
+
+/// Computes the transaction commitment root for a block.
+///
+/// The root is always a height-64 Patricia Merkle tree keyed by transaction index.
+/// The leaf algorithm depends on Starknet version:
+/// - `< 0.11.1`: Pedersen root and Pedersen leaf; only invoke transactions carry signatures.
+/// - `0.11.1 .. 0.13.2`: Pedersen root and Pedersen leaf; declare and deploy-account signatures are
+///   also part of the leaf.
+/// - `0.13.2 .. 0.13.4`: Poseidon root and Poseidon leaf; empty signatures are encoded as `[0]`.
+/// - `>= 0.13.4`: Poseidon root and Poseidon leaf; empty signatures remain empty.
+fn compute_transaction_commitment(transactions: &[TxWithHash], version: StarknetVersion) -> Felt {
+    let leaves = transactions
+        .iter()
+        .map(|tx| calculate_transaction_commitment_leaf(tx, version))
+        .collect::<Vec<_>>();
+
+    if version < StarknetVersion::V0_13_2 {
+        compute_merkle_root::<Pedersen>(&leaves).unwrap()
+    } else {
+        compute_merkle_root::<Poseidon>(&leaves).unwrap()
+    }
+}
+
+/// Computes the versioned transaction-commitment leaf for a single transaction.
+fn calculate_transaction_commitment_leaf(tx: &TxWithHash, version: StarknetVersion) -> Felt {
+    if version < STARKNET_VERSION_0_11_1 {
+        let tx_signature = transaction_signature(&tx.transaction);
+        let signature_hash = Pedersen::hash_array(tx_signature);
+
+        Pedersen::hash(&tx.hash, &signature_hash)
+    } else if version < StarknetVersion::V0_13_2 {
+        let tx_signature = transaction_signature(&tx.transaction);
+        let signature_hash = Pedersen::hash_array(tx_signature);
+
+        Pedersen::hash(&tx.hash, &signature_hash)
+    } else {
+        let signature = transaction_signature(&tx.transaction);
+        let mut elements = Vec::with_capacity(signature.len() + 1);
+        elements.push(tx.hash);
+
+        if version < STARKNET_VERSION_0_13_4 && signature.is_empty() {
+            elements.push(Felt::ZERO);
+        } else {
+            elements.extend(signature.iter().copied());
+        }
+
+        Poseidon::hash_array(&elements)
+    }
+}
+
+fn transaction_signature(transaction: &Tx) -> &[Felt] {
+    match transaction {
+        Tx::Invoke(InvokeTx::V0(tx)) => &tx.signature,
+        Tx::Invoke(InvokeTx::V1(tx)) => &tx.signature,
+        Tx::Invoke(InvokeTx::V3(tx)) => &tx.signature,
+        Tx::Declare(DeclareTx::V0(tx)) => &tx.signature,
+        Tx::Declare(DeclareTx::V1(tx)) => &tx.signature,
+        Tx::Declare(DeclareTx::V2(tx)) => &tx.signature,
+        Tx::Declare(DeclareTx::V3(tx)) => &tx.signature,
+        Tx::DeployAccount(DeployAccountTx::V1(tx)) => &tx.signature,
+        Tx::DeployAccount(DeployAccountTx::V3(tx)) => &tx.signature,
+        Tx::Deploy(_) | Tx::L1Handler(_) => &[],
+    }
+}
+
+/// Computes the receipt commitment root for post-`0.13.2` blocks.
+///
+/// The root is a height-64 Poseidon Patricia tree keyed by transaction index.
+/// Each leaf is:
+///
+/// ```text
+/// Poseidon(
+///     tx_hash,
+///     actual_fee,
+///     messages_hash,
+///     starknet_keccak(revert_reason) | 0,
+///     0,              // l2 gas, kept zero for the historical block hash formula
+///     l1_gas,
+///     l1_data_gas,
+/// )
+/// ```
+fn compute_receipt_commitment(transactions: &[TxWithHash], receipts: &[Receipt]) -> Felt {
+    let leaves = transactions
+        .iter()
+        .zip(receipts.iter())
+        .map(|(tx, receipt)| calculate_receipt_commitment_leaf(receipt, tx.hash))
+        .collect::<Vec<_>>();
+
+    compute_merkle_root::<Poseidon>(&leaves).unwrap()
+}
+
+/// Computes the receipt-commitment leaf used from `0.13.2` onward.
+fn calculate_receipt_commitment_leaf(receipt: &Receipt, tx_hash: Felt) -> Felt {
+    let resources = receipt.resources_used();
+
+    Poseidon::hash_array(&[
+        tx_hash,
+        receipt.fee().overall_fee.into(),
+        calculate_messages_to_l1_hash(receipt),
+        receipt
+            .revert_reason()
+            .map(|reason| starknet_keccak(reason.as_bytes()))
+            .unwrap_or(Felt::ZERO),
+        Felt::ZERO,
+        Felt::from(resources.total_gas_consumed.l1_gas),
+        Felt::from(resources.total_gas_consumed.l1_data_gas),
+    ])
+}
+
+/// Computes the flattened Poseidon hash of all L2-to-L1 messages in a receipt.
+///
+/// The sequence is:
+/// `[message_count, from, to, payload_len, payload..., from, to, payload_len, payload..., ...]`.
+fn calculate_messages_to_l1_hash(receipt: &Receipt) -> Felt {
+    let mut elements: Vec<Felt> = Vec::new();
+
+    elements.push(receipt.messages_sent().len().into());
+
+    for message in receipt.messages_sent() {
+        elements.push(message.from_address.into());
+        elements.push(message.to_address);
+        elements.push(message.payload.len().into());
+
+        for payload in &message.payload {
+            elements.push(*payload);
+        }
+    }
+
+    Poseidon::hash_array(&elements)
+}
+
+/// Computes the event commitment root for a block.
+///
+/// The root is a height-64 Patricia tree keyed by event index:
+/// - `< 0.13.2`: Pedersen root over Pedersen event leaves.
+/// - `>= 0.13.2`: Poseidon root over Poseidon event leaves that also include the transaction hash.
+fn compute_event_commitment(
+    transactions: &[TxWithHash],
+    receipts: &[Receipt],
+    version: StarknetVersion,
+) -> Felt {
+    let leaves = transactions
+        .iter()
+        .zip(receipts.iter())
+        .flat_map(|(tx, receipt)| {
+            receipt
+                .events()
+                .iter()
+                .map(move |event| calculate_event_commitment_leaf(event, tx.hash, version))
+        })
+        .collect::<Vec<_>>();
+
+    if version < StarknetVersion::V0_13_2 {
+        compute_merkle_root::<Pedersen>(&leaves).unwrap()
+    } else {
+        compute_merkle_root::<Poseidon>(&leaves).unwrap()
+    }
+}
+
+/// Computes the versioned event-commitment leaf for a single event.
+///
+/// Versions:
+/// - `< 0.13.2`: `Pedersen(from_address, Pedersen(keys), Pedersen(data))`
+/// - `>= 0.13.2`: Poseidon chain hash of `[from_address, tx_hash, len(keys), keys..., len(data),
+///   data...]`
+fn calculate_event_commitment_leaf(event: &Event, tx_hash: Felt, version: StarknetVersion) -> Felt {
+    if version < StarknetVersion::V0_13_2 {
+        let keys_hash = Pedersen::hash_array(&event.keys);
+        let data_hash = Pedersen::hash_array(&event.data);
+
+        Pedersen::hash_array(&[event.from_address.into(), keys_hash, data_hash])
+    } else {
+        let mut elements: Vec<Felt> = Vec::new();
+        elements.push(event.from_address.into());
+        elements.push(tx_hash);
+        elements.push(event.keys.len().into());
+
+        for key in &event.keys {
+            elements.push(*key);
+        }
+
+        elements.push(event.data.len().into());
+
+        for data in &event.data {
+            elements.push(*data);
+        }
+
+        Poseidon::hash_array(&elements)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use katana_gateway_types::{Block, ConfirmedStateUpdate, StateUpdate, StateUpdateWithBlock};
     use katana_primitives::block::{GasPrices, Header};
     use katana_primitives::chain::ChainId;
     use katana_primitives::da::L1DataAvailabilityMode;
+    use katana_primitives::transaction::{DeployTx, InvokeTxV0, Tx, TxWithHash};
     use katana_primitives::version::StarknetVersion;
     use katana_primitives::Felt;
+    use starknet_types_core::hash::{Pedersen, StarkHash};
 
-    use super::compute_hash;
+    use super::{calculate_transaction_commitment_leaf, compute_hash, compute_missing_commitments};
+    use crate::blocks::BlockData;
 
     /// Parses a gateway block fixture JSON and returns a (Header, expected_block_hash) pair.
     ///
@@ -430,5 +670,220 @@ mod tests {
         let (header, expected) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::MAINNET);
         assert_eq!(hash, expected, "block 2238855 (v0.14.0) hash mismatch");
+    }
+
+    #[test]
+    fn pre_0_11_1_non_invoke_transactions_use_the_empty_signature_hash() {
+        let tx_hash = Felt::from_hex("0x1234").unwrap();
+        let tx = TxWithHash {
+            hash: tx_hash,
+            transaction: Tx::Deploy(DeployTx {
+                contract_address: Felt::ZERO,
+                contract_address_salt: Felt::ZERO,
+                constructor_calldata: Vec::new(),
+                class_hash: Felt::ZERO,
+                version: Felt::ZERO,
+            }),
+        };
+
+        let expected = Pedersen::hash(&tx_hash, &Pedersen::hash_array(&[]));
+        let actual = calculate_transaction_commitment_leaf(&tx, StarknetVersion::UNVERSIONED);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn pre_0_11_1_invoke_transactions_hash_the_signature() {
+        let tx_hash = Felt::from_hex("0x5678").unwrap();
+        let signature = vec![Felt::ONE, Felt::TWO, Felt::THREE];
+        let tx = TxWithHash {
+            hash: tx_hash,
+            transaction: Tx::Invoke(katana_primitives::transaction::InvokeTx::V0(InvokeTxV0 {
+                signature: signature.clone(),
+                ..Default::default()
+            })),
+        };
+
+        let expected = Pedersen::hash(&tx_hash, &Pedersen::hash_array(&signature));
+        let actual = calculate_transaction_commitment_leaf(&tx, StarknetVersion::UNVERSIONED);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reconstructs_missing_commitments_for_0_13_0_block() {
+        let (mut block_data, block_fixture) = block_data_from_split_fixtures(
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/0.13.0/block/mainnet_550000.json"
+            )),
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/0.13.0/state_update/mainnet_550000.json"
+            )),
+        );
+
+        block_data.block.block.header.transactions_commitment = Felt::ZERO;
+        block_data.block.block.header.events_commitment = Felt::ZERO;
+
+        compute_missing_commitments(
+            &mut block_data.block.block,
+            &block_data.receipts,
+            &block_data.state_updates.state_updates,
+        );
+
+        assert_eq!(
+            block_data.block.block.header.transactions_commitment,
+            felt_field_from_block_fixture(&block_fixture, "transaction_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.events_commitment,
+            felt_field_from_block_fixture(&block_fixture, "event_commitment")
+        );
+    }
+
+    #[test]
+    fn reconstructs_missing_commitments_for_0_13_2_block() {
+        let (mut block_data, block_fixture) = block_data_from_split_fixtures(
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/0.13.2/block/sepolia_integration_35748.json"
+            )),
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/0.13.2/state_update/sepolia_integration_35748.json"
+            )),
+        );
+
+        block_data.block.block.header.transactions_commitment = Felt::ZERO;
+        block_data.block.block.header.events_commitment = Felt::ZERO;
+        block_data.block.block.header.receipts_commitment = Felt::ZERO;
+        block_data.block.block.header.state_diff_length = 0;
+        block_data.block.block.header.state_diff_commitment = Felt::ZERO;
+
+        compute_missing_commitments(
+            &mut block_data.block.block,
+            &block_data.receipts,
+            &block_data.state_updates.state_updates,
+        );
+
+        assert_eq!(
+            block_data.block.block.header.transactions_commitment,
+            felt_field_from_block_fixture(&block_fixture, "transaction_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.events_commitment,
+            felt_field_from_block_fixture(&block_fixture, "event_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.receipts_commitment,
+            felt_field_from_block_fixture(&block_fixture, "receipt_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.state_diff_commitment,
+            felt_field_from_block_fixture(&block_fixture, "state_diff_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.state_diff_length,
+            u32_field_from_block_fixture(&block_fixture, "state_diff_length")
+        );
+    }
+
+    #[test]
+    fn reconstructs_missing_commitments_for_0_13_4_block() {
+        let (mut block_data, block_fixture) = block_data_from_split_fixtures(
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/0.13.4/block/sepolia_integration_63881.json"
+            )),
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/0.13.4/state_update/sepolia_integration_63881.json"
+            )),
+        );
+
+        block_data.block.block.header.transactions_commitment = Felt::ZERO;
+        block_data.block.block.header.events_commitment = Felt::ZERO;
+        block_data.block.block.header.receipts_commitment = Felt::ZERO;
+        block_data.block.block.header.state_diff_length = 0;
+        block_data.block.block.header.state_diff_commitment = Felt::ZERO;
+
+        compute_missing_commitments(
+            &mut block_data.block.block,
+            &block_data.receipts,
+            &block_data.state_updates.state_updates,
+        );
+
+        assert_eq!(
+            block_data.block.block.header.transactions_commitment,
+            felt_field_from_block_fixture(&block_fixture, "transaction_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.events_commitment,
+            felt_field_from_block_fixture(&block_fixture, "event_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.receipts_commitment,
+            felt_field_from_block_fixture(&block_fixture, "receipt_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.state_diff_commitment,
+            felt_field_from_block_fixture(&block_fixture, "state_diff_commitment")
+        );
+        assert_eq!(
+            block_data.block.block.header.state_diff_length,
+            u32_field_from_block_fixture(&block_fixture, "state_diff_length")
+        );
+    }
+
+    fn block_data_from_split_fixtures(
+        block_json: &str,
+        state_update_json: &str,
+    ) -> (BlockData, serde_json::Value) {
+        let block_fixture = parse_block_fixture(block_json);
+        let mut block_for_parse = block_fixture.clone();
+        normalize_legacy_block_fixture(&mut block_for_parse);
+        let block = serde_json::from_value::<Block>(block_for_parse).unwrap();
+        let state_update = serde_json::from_str::<ConfirmedStateUpdate>(state_update_json).unwrap();
+        let block_data = BlockData::from(StateUpdateWithBlock {
+            block,
+            state_update: StateUpdate::Confirmed(state_update),
+        });
+
+        (block_data, block_fixture)
+    }
+
+    fn parse_block_fixture(json: &str) -> serde_json::Value {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn normalize_legacy_block_fixture(block: &mut serde_json::Value) {
+        let Some(receipts) =
+            block.get_mut("transaction_receipts").and_then(serde_json::Value::as_array_mut)
+        else {
+            return;
+        };
+
+        for receipt in receipts {
+            let Some(total_gas_consumed) = receipt
+                .get_mut("execution_resources")
+                .and_then(|resources| resources.get_mut("total_gas_consumed"))
+                .and_then(serde_json::Value::as_object_mut)
+            else {
+                continue;
+            };
+
+            total_gas_consumed
+                .entry("l2_gas".to_owned())
+                .or_insert_with(|| serde_json::Value::from(0));
+        }
+    }
+
+    fn felt_field_from_block_fixture(block: &serde_json::Value, field: &str) -> Felt {
+        Felt::from_hex(block[field].as_str().unwrap()).unwrap()
+    }
+
+    fn u32_field_from_block_fixture(block: &serde_json::Value, field: &str) -> u32 {
+        block[field].as_u64().unwrap().try_into().unwrap()
     }
 }

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -720,6 +720,36 @@ mod tests {
     }
 
     #[test]
+    fn reconstructs_missing_commitments_for_unversioned_mainnet_770() {
+        let (mut block_data, ..) = block_data_from_split_fixtures(
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/pre_0.7.0/block/mainnet_770.json"
+            )),
+            include_str!(concat!(
+                "../../../../gateway/gateway-client/tests/fixtures",
+                "/pre_0.7.0/state_update/mainnet_770.json"
+            )),
+        );
+
+        block_data.block.block.header.transactions_commitment = Felt::ZERO;
+        block_data.block.block.header.events_commitment = Felt::ZERO;
+
+        compute_missing_commitments(
+            &mut block_data.block.block,
+            &block_data.receipts,
+            &block_data.state_updates.state_updates,
+        );
+
+        assert_eq!(
+            block_data.block.block.header.transactions_commitment,
+            Felt::from_hex("0x51aad3267df44940cbdf4054b5a4e32ed0ba5e9ef02d9f15010374e3649dcc4",)
+                .unwrap()
+        );
+        assert_eq!(block_data.block.block.header.events_commitment, Felt::ZERO);
+    }
+
+    #[test]
     fn reconstructs_missing_commitments_for_0_13_0_block() {
         let (mut block_data, block_fixture) = block_data_from_split_fixtures(
             include_str!(concat!(

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -108,9 +108,6 @@ use katana_trie::compute_merkle_root;
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
 
-const STARKNET_VERSION_0_11_1: StarknetVersion = StarknetVersion::new([0, 11, 1, 0]);
-const STARKNET_VERSION_0_13_4: StarknetVersion = StarknetVersion::new([0, 13, 4, 0]);
-
 /// Computes the block hash for a header, dispatching to the correct algorithm based
 /// on the block's `starknet_version`.
 ///
@@ -122,7 +119,7 @@ pub fn compute_hash(header: &Header, chain_id: &ChainId) -> Felt {
         compute_hash_pre_0_7(header, chain_id)
     } else if header.starknet_version < StarknetVersion::V0_13_2 {
         compute_hash_pre_0_13_2(header)
-    } else if header.starknet_version < StarknetVersion::new([0, 13, 4, 0]) {
+    } else if header.starknet_version < StarknetVersion::V0_13_4 {
         compute_hash_post_0_13_2(header, &version_str)
     } else {
         compute_hash_post_0_13_4(header, &version_str)
@@ -248,7 +245,7 @@ fn compute_hash_post_0_13_4(header: &Header, version_str: &str) -> Felt {
 
 /// Computes block commitments that some synced block sources omit from the header.
 ///
-/// Version gates:
+/// Version gates:-
 /// - Transaction commitment: reconstructed for any version when the header field is zero.
 /// - Event commitment: reconstructed for any version when the header field is zero.
 /// - State diff commitment and length: only meaningful from `0.13.2` onward.
@@ -268,18 +265,22 @@ pub(crate) fn compute_missing_commitments(
         block.header.events_commitment = compute_event_commitment(&block.body, receipts, version);
     }
 
+    // The rest of the commitments are only meaningful from 0.13.2 onward.
+    if version < StarknetVersion::V0_13_2 {
+        return;
+    }
+
     // Post-0.13.2 block hashes include `state_diff_length` and `state_diff_commitment`.
     // The commitment itself is the canonical Poseidon hash implemented in
     // `katana_primitives::state::compute_state_diff_hash`.
-    if version >= StarknetVersion::V0_13_2
-        && (block.header.state_diff_length == 0 || block.header.state_diff_commitment == Felt::ZERO)
-    {
-        block.header.state_diff_length =
-            u32::try_from(state_updates.len()).expect("state diff length overflow");
+    if block.header.state_diff_length == 0 || block.header.state_diff_commitment == Felt::ZERO {
+        let state_diff_length = state_updates.len();
+        block.header.state_diff_length = u32::try_from(state_diff_length).unwrap();
         block.header.state_diff_commitment = compute_state_diff_hash(state_updates.clone());
     }
 
-    if version >= StarknetVersion::V0_13_2 && block.header.receipts_commitment == Felt::ZERO {
+    // event commitment is not computed in <= 0.13.2 blocks, so we can safely skip this
+    if block.header.receipts_commitment == Felt::ZERO {
         block.header.receipts_commitment = compute_receipt_commitment(&block.body, receipts);
     }
 }
@@ -308,12 +309,7 @@ fn compute_transaction_commitment(transactions: &[TxWithHash], version: Starknet
 
 /// Computes the versioned transaction-commitment leaf for a single transaction.
 fn calculate_transaction_commitment_leaf(tx: &TxWithHash, version: StarknetVersion) -> Felt {
-    if version < STARKNET_VERSION_0_11_1 {
-        let tx_signature = transaction_signature_pre_0_11_1(&tx.transaction);
-        let signature_hash = Pedersen::hash_array(tx_signature);
-
-        Pedersen::hash(&tx.hash, &signature_hash)
-    } else if version < StarknetVersion::V0_13_2 {
+    if version < StarknetVersion::V0_13_2 {
         let tx_signature = transaction_signature(&tx.transaction);
         let signature_hash = Pedersen::hash_array(tx_signature);
 
@@ -323,22 +319,13 @@ fn calculate_transaction_commitment_leaf(tx: &TxWithHash, version: StarknetVersi
         let mut elements = Vec::with_capacity(signature.len() + 1);
         elements.push(tx.hash);
 
-        if version < STARKNET_VERSION_0_13_4 && signature.is_empty() {
+        if version < StarknetVersion::V0_13_4 && signature.is_empty() {
             elements.push(Felt::ZERO);
         } else {
             elements.extend(signature.iter().copied());
         }
 
         Poseidon::hash_array(&elements)
-    }
-}
-
-fn transaction_signature_pre_0_11_1(transaction: &Tx) -> &[Felt] {
-    match transaction {
-        Tx::Invoke(InvokeTx::V0(tx)) => &tx.signature,
-        Tx::Invoke(InvokeTx::V1(tx)) => &tx.signature,
-        Tx::Invoke(InvokeTx::V3(tx)) => &tx.signature,
-        Tx::Declare(_) | Tx::Deploy(_) | Tx::DeployAccount(_) | Tx::L1Handler(_) => &[],
     }
 }
 
@@ -386,18 +373,19 @@ fn compute_receipt_commitment(transactions: &[TxWithHash], receipts: &[Receipt])
 /// Computes the receipt-commitment leaf used from `0.13.2` onward.
 fn calculate_receipt_commitment_leaf(receipt: &Receipt, tx_hash: Felt) -> Felt {
     let resources = receipt.resources_used();
+    let revert_reason = receipt
+        .revert_reason()
+        .map(|reason| starknet_keccak(reason.as_bytes()))
+        .unwrap_or(Felt::ZERO);
 
     Poseidon::hash_array(&[
         tx_hash,
         receipt.fee().overall_fee.into(),
         calculate_messages_to_l1_hash(receipt),
-        receipt
-            .revert_reason()
-            .map(|reason| starknet_keccak(reason.as_bytes()))
-            .unwrap_or(Felt::ZERO),
+        revert_reason,
         Felt::ZERO,
-        Felt::from(resources.total_gas_consumed.l1_gas),
-        Felt::from(resources.total_gas_consumed.l1_data_gas),
+        resources.total_gas_consumed.l1_gas.into(),
+        resources.total_gas_consumed.l1_data_gas.into(),
     ])
 }
 
@@ -488,14 +476,19 @@ mod tests {
     use katana_gateway_types::{Block, ConfirmedStateUpdate, StateUpdate, StateUpdateWithBlock};
     use katana_primitives::block::{GasPrices, Header};
     use katana_primitives::chain::ChainId;
-    use katana_primitives::da::L1DataAvailabilityMode;
-    use katana_primitives::transaction::{DeployTx, InvokeTxV0, Tx, TxWithHash};
     use katana_primitives::version::StarknetVersion;
-    use katana_primitives::Felt;
-    use starknet_types_core::hash::{Pedersen, StarkHash};
+    use katana_primitives::{felt, Felt};
+    use num_traits::ToPrimitive;
 
-    use super::{calculate_transaction_commitment_leaf, compute_hash, compute_missing_commitments};
+    use super::{compute_hash, compute_missing_commitments};
     use crate::blocks::BlockData;
+
+    /// Shorthand for including a gateway test fixture file at compile time.
+    macro_rules! fixture {
+        ($path:expr) => {
+            include_str!(concat!("../../../../gateway/gateway-client/tests/fixtures/", $path))
+        };
+    }
 
     /// Parses a gateway block fixture JSON and returns a (Header, expected_block_hash) pair.
     ///
@@ -504,104 +497,54 @@ mod tests {
         json: &str,
         version_override: Option<StarknetVersion>,
     ) -> (Header, Felt) {
-        let v: serde_json::Value = serde_json::from_str(json).unwrap();
+        let mut value = serde_json::from_str::<serde_json::Value>(json).unwrap();
+        normalize_legacy_block_fixture(&mut value);
+        let block = serde_json::from_value::<Block>(value).unwrap();
 
-        let block_hash = Felt::from_hex(v["block_hash"].as_str().unwrap()).unwrap();
+        let block_hash = block.block_hash.unwrap();
 
-        let parent_hash = Felt::from_hex(
-            v.get("parent_block_hash").or_else(|| v.get("parent_hash")).unwrap().as_str().unwrap(),
-        )
-        .unwrap();
-
-        let number = v["block_number"].as_u64().unwrap_or(0);
-        let state_root = felt_or_zero(&v, "state_root");
-        let timestamp = v["timestamp"].as_u64().unwrap();
-
-        let sequencer_address = felt_or_zero(&v, "sequencer_address");
-        let transaction_commitment = felt_or_zero(&v, "transaction_commitment");
-        let event_commitment = felt_or_zero(&v, "event_commitment");
-        let state_diff_commitment = felt_or_zero(&v, "state_diff_commitment");
-        let receipts_commitment = felt_or_zero(&v, "receipt_commitment");
-
-        let state_diff_length =
-            v.get("state_diff_length").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-
-        let transaction_count = v["transactions"].as_array().unwrap().len() as u32;
-
-        // Count total events from transaction_receipts.
-        let events_count = v
-            .get("transaction_receipts")
-            .and_then(|r| r.as_array())
-            .map(|receipts| {
-                receipts
-                    .iter()
-                    .filter_map(|r| r.get("events"))
-                    .filter_map(|e| e.as_array())
-                    .map(|e| e.len() as u32)
-                    .sum()
-            })
-            .unwrap_or(0);
-
-        let l1_da_mode = match v["l1_da_mode"].as_str().unwrap_or("CALLDATA") {
-            "BLOB" => L1DataAvailabilityMode::Blob,
-            _ => L1DataAvailabilityMode::Calldata,
-        };
+        let transaction_count = block.transactions.len() as u32;
+        let events_count: u32 =
+            block.transaction_receipts.iter().map(|r| r.body.events.len() as u32).sum();
 
         let starknet_version = version_override.unwrap_or_else(|| {
-            v.get("starknet_version")
-                .and_then(|s| s.as_str())
+            block
+                .starknet_version
+                .as_deref()
                 .filter(|s| !s.is_empty())
                 .map(|s| StarknetVersion::parse(s).unwrap())
                 .unwrap_or(StarknetVersion::UNVERSIONED)
         });
 
-        let l1_gas_prices = parse_gas_prices(&v["l1_gas_price"]);
-        let l1_data_gas_prices = parse_gas_prices(&v["l1_data_gas_price"]);
-        let l2_gas_prices =
-            v.get("l2_gas_price").map(parse_gas_prices).unwrap_or(GasPrices::default());
-
         let header = Header {
-            number,
-            timestamp,
-            state_root,
-            l1_da_mode,
-            events_count,
             transaction_count,
-            state_diff_length,
-            l1_gas_prices,
-            l1_data_gas_prices,
-            l2_gas_prices,
+            events_count,
             starknet_version,
-            parent_hash: parent_hash.into(),
-            sequencer_address: sequencer_address.into(),
-            transactions_commitment: transaction_commitment,
-            events_commitment: event_commitment,
-            state_diff_commitment,
-            receipts_commitment,
+            timestamp: block.timestamp,
+            l1_da_mode: block.l1_da_mode,
+            parent_hash: block.parent_block_hash,
+            number: block.block_number.unwrap_or_default(),
+            state_root: block.state_root.unwrap_or_default(),
+            sequencer_address: block.sequencer_address.unwrap_or_default(),
+            transactions_commitment: block.transaction_commitment.unwrap_or_default(),
+            events_commitment: block.event_commitment.unwrap_or_default(),
+            state_diff_commitment: block.state_diff_commitment.unwrap_or_default(),
+            receipts_commitment: block.receipt_commitment.unwrap_or_default(),
+            state_diff_length: block.state_diff_length.unwrap_or_default(),
+            l1_gas_prices: to_gas_prices(block.l1_gas_price),
+            l1_data_gas_prices: to_gas_prices(block.l1_data_gas_price),
+            l2_gas_prices: to_gas_prices(block.l2_gas_price),
         };
 
         (header, block_hash)
     }
 
-    fn felt_or_zero(v: &serde_json::Value, key: &str) -> Felt {
-        v.get(key)
-            .and_then(|f| f.as_str())
-            .map(|s| Felt::from_hex(s).unwrap())
-            .unwrap_or(Felt::ZERO)
-    }
-
-    /// Parses a gas price object `{ "price_in_wei": "0x...", "price_in_fri": "0x..." }`
-    /// into `GasPrices`, replacing zero values with 1 (matching `extract_block_data`).
-    fn parse_gas_prices(v: &serde_json::Value) -> GasPrices {
-        let wei = hex_to_u128(v["price_in_wei"].as_str().unwrap());
-        let fri = hex_to_u128(v["price_in_fri"].as_str().unwrap());
-        let wei = if wei == 0 { 1 } else { wei };
-        let fri = if fri == 0 { 1 } else { fri };
-        unsafe { GasPrices::new_unchecked(wei, fri) }
-    }
-
-    fn hex_to_u128(s: &str) -> u128 {
-        u128::from_str_radix(s.trim_start_matches("0x"), 16).unwrap()
+    fn to_gas_prices(prices: starknet::core::types::ResourcePrice) -> GasPrices {
+        let eth = prices.price_in_wei.to_u128().expect("valid u128");
+        let strk = prices.price_in_fri.to_u128().expect("valid u128");
+        let eth = if eth == 0 { 1 } else { eth };
+        let strk = if strk == 0 { 1 } else { strk };
+        unsafe { GasPrices::new_unchecked(eth, strk) }
     }
 
     // NOTE: Pre-0.7 (block 0) and 0.7.0 (block 2240) are not tested because
@@ -612,126 +555,65 @@ mod tests {
     /// Block 65000 — version 0.11.1, Pedersen with real event commitments.
     #[test]
     fn block_hash_mainnet_65000_v0_11_1() {
-        let json = include_str!(concat!(
-            "../../../../gateway/gateway-client/tests/fixtures",
-            "/0.11.1/block/mainnet_65000.json"
-        ));
-        let (header, expected) = header_from_fixture(json, None);
+        let json = fixture!("0.11.1/block/mainnet_65000.json");
+        let (header, expected_hash) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::MAINNET);
-        assert_eq!(hash, expected, "block 65000 (v0.11.1) hash mismatch");
+        assert_eq!(hash, expected_hash, "block 65000 (v0.11.1) hash mismatch");
     }
 
     /// Block 550000 — version 0.13.0, last Pedersen-era version before Poseidon switch.
     #[test]
     fn block_hash_mainnet_550000_v0_13_0() {
-        let json = include_str!(concat!(
-            "../../../../gateway/gateway-client/tests/fixtures",
-            "/0.13.0/block/mainnet_550000.json"
-        ));
-        let (header, expected) = header_from_fixture(json, None);
+        let json = fixture!("0.13.0/block/mainnet_550000.json");
+        let (header, expected_hash) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::MAINNET);
-        assert_eq!(hash, expected, "block 550000 (v0.13.0) hash mismatch");
+        assert_eq!(hash, expected_hash, "block 550000 (v0.13.0) hash mismatch");
     }
 
     /// Sepolia integration block 35748 — version 0.13.2, Poseidon v0.
     #[test]
     fn block_hash_sepolia_35748_v0_13_2() {
-        let json = include_str!(concat!(
-            "../../../../gateway/gateway-client/tests/fixtures",
-            "/0.13.2/block/sepolia_integration_35748.json"
-        ));
-        let (header, expected) = header_from_fixture(json, None);
+        let json = fixture!("0.13.2/block/sepolia_integration_35748.json");
+        let (header, expected_hash) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::SEPOLIA);
-        assert_eq!(hash, expected, "sepolia block 35748 (v0.13.2) hash mismatch");
+        assert_eq!(hash, expected_hash, "sepolia block 35748 (v0.13.2) hash mismatch");
     }
 
     /// Sepolia integration block 63881 — version 0.13.4, Poseidon v1.
     #[test]
     fn block_hash_sepolia_63881_v0_13_4() {
-        let json = include_str!(concat!(
-            "../../../../gateway/gateway-client/tests/fixtures",
-            "/0.13.4/block/sepolia_integration_63881.json"
-        ));
-        let (header, expected) = header_from_fixture(json, None);
+        let json = fixture!("0.13.4/block/sepolia_integration_63881.json");
+        let (header, expected_hash) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::SEPOLIA);
-        assert_eq!(hash, expected, "sepolia block 63881 (v0.13.4) hash mismatch");
+        assert_eq!(hash, expected_hash, "sepolia block 63881 (v0.13.4) hash mismatch");
     }
 
     /// Sepolia block 2473486 — version 0.14.0, Poseidon v1 (sepolia).
     #[test]
     fn block_hash_sepolia_2473486_v0_14_0() {
-        let json = include_str!(concat!(
-            "../../../../gateway/gateway-client/tests/fixtures",
-            "/0.14.0/block/sepolia_2473486.json"
-        ));
-        let (header, expected) = header_from_fixture(json, None);
+        let json = fixture!("0.14.0/block/sepolia_2473486.json");
+        let (header, expected_hash) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::SEPOLIA);
-        assert_eq!(hash, expected, "sepolia block 2473486 (v0.14.0) hash mismatch");
+        assert_eq!(hash, expected_hash, "sepolia block 2473486 (v0.14.0) hash mismatch");
     }
 
     /// Block 2238855 — version 0.14.0, Poseidon v1 with consolidated gas prices.
     #[test]
     fn block_hash_mainnet_2238855_v0_14_0() {
-        let json = include_str!(concat!(
-            "../../../../gateway/gateway-client/tests/fixtures",
-            "/0.14.0/block/mainnet_2238855.json"
-        ));
-        let (header, expected) = header_from_fixture(json, None);
+        let json = fixture!("0.14.0/block/mainnet_2238855.json");
+        let (header, expected_hash) = header_from_fixture(json, None);
         let hash = compute_hash(&header, &ChainId::MAINNET);
-        assert_eq!(hash, expected, "block 2238855 (v0.14.0) hash mismatch");
-    }
-
-    #[test]
-    fn pre_0_11_1_non_invoke_transactions_use_the_empty_signature_hash() {
-        let tx_hash = Felt::from_hex("0x1234").unwrap();
-        let tx = TxWithHash {
-            hash: tx_hash,
-            transaction: Tx::Deploy(DeployTx {
-                contract_address: Felt::ZERO,
-                contract_address_salt: Felt::ZERO,
-                constructor_calldata: Vec::new(),
-                class_hash: Felt::ZERO,
-                version: Felt::ZERO,
-            }),
-        };
-
-        let expected = Pedersen::hash(&tx_hash, &Pedersen::hash_array(&[]));
-        let actual = calculate_transaction_commitment_leaf(&tx, StarknetVersion::UNVERSIONED);
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn pre_0_11_1_invoke_transactions_hash_the_signature() {
-        let tx_hash = Felt::from_hex("0x5678").unwrap();
-        let signature = vec![Felt::ONE, Felt::TWO, Felt::THREE];
-        let tx = TxWithHash {
-            hash: tx_hash,
-            transaction: Tx::Invoke(katana_primitives::transaction::InvokeTx::V0(InvokeTxV0 {
-                signature: signature.clone(),
-                ..Default::default()
-            })),
-        };
-
-        let expected = Pedersen::hash(&tx_hash, &Pedersen::hash_array(&signature));
-        let actual = calculate_transaction_commitment_leaf(&tx, StarknetVersion::UNVERSIONED);
-
-        assert_eq!(actual, expected);
+        assert_eq!(hash, expected_hash, "block 2238855 (v0.14.0) hash mismatch");
     }
 
     #[test]
     fn reconstructs_missing_commitments_for_unversioned_mainnet_770() {
-        let (mut block_data, ..) = block_data_from_split_fixtures(
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/pre_0.7.0/block/mainnet_770.json"
-            )),
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/pre_0.7.0/state_update/mainnet_770.json"
-            )),
+        let (mut block_data, _) = block_data_from_split_fixtures(
+            fixture!("pre_0.7.0/block/mainnet_770.json"),
+            fixture!("pre_0.7.0/state_update/mainnet_770.json"),
         );
 
+        // reset commitments that may be ommitted by the download source
         block_data.block.block.header.transactions_commitment = Felt::ZERO;
         block_data.block.block.header.events_commitment = Felt::ZERO;
 
@@ -743,25 +625,19 @@ mod tests {
 
         assert_eq!(
             block_data.block.block.header.transactions_commitment,
-            Felt::from_hex("0x51aad3267df44940cbdf4054b5a4e32ed0ba5e9ef02d9f15010374e3649dcc4",)
-                .unwrap()
+            felt!("0x51aad3267df44940cbdf4054b5a4e32ed0ba5e9ef02d9f15010374e3649dcc4")
         );
         assert_eq!(block_data.block.block.header.events_commitment, Felt::ZERO);
     }
 
     #[test]
     fn reconstructs_missing_commitments_for_0_13_0_block() {
-        let (mut block_data, block_fixture) = block_data_from_split_fixtures(
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/0.13.0/block/mainnet_550000.json"
-            )),
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/0.13.0/state_update/mainnet_550000.json"
-            )),
+        let (mut block_data, expected) = block_data_from_split_fixtures(
+            fixture!("0.13.0/block/mainnet_550000.json"),
+            fixture!("0.13.0/state_update/mainnet_550000.json"),
         );
 
+        // reset commitments that may be ommitted by the download source
         block_data.block.block.header.transactions_commitment = Felt::ZERO;
         block_data.block.block.header.events_commitment = Felt::ZERO;
 
@@ -773,27 +649,19 @@ mod tests {
 
         assert_eq!(
             block_data.block.block.header.transactions_commitment,
-            felt_field_from_block_fixture(&block_fixture, "transaction_commitment")
+            expected.transactions_commitment
         );
-        assert_eq!(
-            block_data.block.block.header.events_commitment,
-            felt_field_from_block_fixture(&block_fixture, "event_commitment")
-        );
+        assert_eq!(block_data.block.block.header.events_commitment, expected.events_commitment);
     }
 
     #[test]
     fn reconstructs_missing_commitments_for_0_13_2_block() {
-        let (mut block_data, block_fixture) = block_data_from_split_fixtures(
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/0.13.2/block/sepolia_integration_35748.json"
-            )),
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/0.13.2/state_update/sepolia_integration_35748.json"
-            )),
+        let (mut block_data, expected) = block_data_from_split_fixtures(
+            fixture!("0.13.2/block/sepolia_integration_35748.json"),
+            fixture!("0.13.2/state_update/sepolia_integration_35748.json"),
         );
 
+        // reset all the commitments that may be ommitted by the sync source
         block_data.block.block.header.transactions_commitment = Felt::ZERO;
         block_data.block.block.header.events_commitment = Felt::ZERO;
         block_data.block.block.header.receipts_commitment = Felt::ZERO;
@@ -808,39 +676,25 @@ mod tests {
 
         assert_eq!(
             block_data.block.block.header.transactions_commitment,
-            felt_field_from_block_fixture(&block_fixture, "transaction_commitment")
+            expected.transactions_commitment
         );
-        assert_eq!(
-            block_data.block.block.header.events_commitment,
-            felt_field_from_block_fixture(&block_fixture, "event_commitment")
-        );
-        assert_eq!(
-            block_data.block.block.header.receipts_commitment,
-            felt_field_from_block_fixture(&block_fixture, "receipt_commitment")
-        );
+        assert_eq!(block_data.block.block.header.events_commitment, expected.events_commitment);
+        assert_eq!(block_data.block.block.header.receipts_commitment, expected.receipts_commitment);
         assert_eq!(
             block_data.block.block.header.state_diff_commitment,
-            felt_field_from_block_fixture(&block_fixture, "state_diff_commitment")
+            expected.state_diff_commitment
         );
-        assert_eq!(
-            block_data.block.block.header.state_diff_length,
-            u32_field_from_block_fixture(&block_fixture, "state_diff_length")
-        );
+        assert_eq!(block_data.block.block.header.state_diff_length, expected.state_diff_length);
     }
 
     #[test]
     fn reconstructs_missing_commitments_for_0_13_4_block() {
-        let (mut block_data, block_fixture) = block_data_from_split_fixtures(
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/0.13.4/block/sepolia_integration_63881.json"
-            )),
-            include_str!(concat!(
-                "../../../../gateway/gateway-client/tests/fixtures",
-                "/0.13.4/state_update/sepolia_integration_63881.json"
-            )),
+        let (mut block_data, expected) = block_data_from_split_fixtures(
+            fixture!("0.13.4/block/sepolia_integration_63881.json"),
+            fixture!("0.13.4/state_update/sepolia_integration_63881.json"),
         );
 
+        // reset commitments that may be ommitted by the download source
         block_data.block.block.header.transactions_commitment = Felt::ZERO;
         block_data.block.block.header.events_commitment = Felt::ZERO;
         block_data.block.block.header.receipts_commitment = Felt::ZERO;
@@ -855,45 +709,35 @@ mod tests {
 
         assert_eq!(
             block_data.block.block.header.transactions_commitment,
-            felt_field_from_block_fixture(&block_fixture, "transaction_commitment")
+            expected.transactions_commitment
         );
-        assert_eq!(
-            block_data.block.block.header.events_commitment,
-            felt_field_from_block_fixture(&block_fixture, "event_commitment")
-        );
-        assert_eq!(
-            block_data.block.block.header.receipts_commitment,
-            felt_field_from_block_fixture(&block_fixture, "receipt_commitment")
-        );
+        assert_eq!(block_data.block.block.header.events_commitment, expected.events_commitment);
+        assert_eq!(block_data.block.block.header.receipts_commitment, expected.receipts_commitment);
         assert_eq!(
             block_data.block.block.header.state_diff_commitment,
-            felt_field_from_block_fixture(&block_fixture, "state_diff_commitment")
+            expected.state_diff_commitment
         );
-        assert_eq!(
-            block_data.block.block.header.state_diff_length,
-            u32_field_from_block_fixture(&block_fixture, "state_diff_length")
-        );
+        assert_eq!(block_data.block.block.header.state_diff_length, expected.state_diff_length);
     }
 
+    /// Parses block and state update fixture JSON into `BlockData` and the expected `Header`
+    /// (with all commitment fields populated from the fixture).
     fn block_data_from_split_fixtures(
         block_json: &str,
         state_update_json: &str,
-    ) -> (BlockData, serde_json::Value) {
-        let block_fixture = parse_block_fixture(block_json);
-        let mut block_for_parse = block_fixture.clone();
-        normalize_legacy_block_fixture(&mut block_for_parse);
-        let block = serde_json::from_value::<Block>(block_for_parse).unwrap();
+    ) -> (BlockData, Header) {
+        let (expected_header, _) = header_from_fixture(block_json, None);
+
+        let mut value = serde_json::from_str::<serde_json::Value>(block_json).unwrap();
+        normalize_legacy_block_fixture(&mut value);
+        let block = serde_json::from_value::<Block>(value).unwrap();
         let state_update = serde_json::from_str::<ConfirmedStateUpdate>(state_update_json).unwrap();
         let block_data = BlockData::from(StateUpdateWithBlock {
             block,
             state_update: StateUpdate::Confirmed(state_update),
         });
 
-        (block_data, block_fixture)
-    }
-
-    fn parse_block_fixture(json: &str) -> serde_json::Value {
-        serde_json::from_str(json).unwrap()
+        (block_data, expected_header)
     }
 
     fn normalize_legacy_block_fixture(block: &mut serde_json::Value) {
@@ -916,13 +760,5 @@ mod tests {
                 .entry("l2_gas".to_owned())
                 .or_insert_with(|| serde_json::Value::from(0));
         }
-    }
-
-    fn felt_field_from_block_fixture(block: &serde_json::Value, field: &str) -> Felt {
-        Felt::from_hex(block[field].as_str().unwrap()).unwrap()
-    }
-
-    fn u32_field_from_block_fixture(block: &serde_json::Value, field: &str) -> u32 {
-        block[field].as_u64().unwrap().try_into().unwrap()
     }
 }

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -1,14 +1,9 @@
 use futures::future::BoxFuture;
-use katana_primitives::block::SealedBlock;
 use katana_primitives::chain::ChainId;
-use katana_primitives::receipt::{Receipt, ReceiptWithTxHash};
-use katana_primitives::version::StarknetVersion;
 use katana_primitives::Felt;
 use katana_provider::api::block::{BlockHashProvider, BlockWriter};
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderError, ProviderFactory};
-use katana_trie::compute_merkle_root;
 use rayon::prelude::*;
-use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
 use tracing::{error, info_span, warn, Instrument};
 
 use crate::{
@@ -110,15 +105,22 @@ where
 
             // Phase 1: Compute commitments and verify hashes in parallel.
             // These are CPU-bound hash computations with no inter-block dependencies.
-            let chain_id = self.chain_id;
             let mut blocks = blocks;
-
             blocks.par_iter_mut().for_each(|block_data| {
                 let block_number = block_data.block.block.header.number;
 
-                compute_missing_commitments(&mut block_data.block.block, &block_data.receipts);
+                // Compute missing commitments for older blocks where the source
+                // doesn't include them in the block header.
+                hash::compute_missing_commitments(
+                    &mut block_data.block.block,
+                    &block_data.receipts,
+                    &block_data.state_updates.state_updates,
+                );
 
-                let computed_hash = hash::compute_hash(&block_data.block.block.header, &chain_id);
+                // Verify the block hash matches what we compute locally.
+                let computed_hash =
+                    hash::compute_hash(&block_data.block.block.header, &self.chain_id);
+
                 if computed_hash != block_data.block.block.hash {
                     warn!(
                         block = %block_number,
@@ -181,77 +183,4 @@ pub enum Error {
          computed hash {computed:#x}"
     )]
     BlockHashMismatch { block_num: u64, expected: Felt, computed: Felt },
-}
-
-/// Computes missing block commitments that older blocks don't include.
-///
-/// For blocks before 0.13.2, the source may return zero for transaction and event
-/// commitments - which is the case for the Starknet feeder gateway. For receipt commitment, the
-/// source may not include it at all for older blocks. This function computes them locally so that
-/// block hash verification can succeed.
-fn compute_missing_commitments(block: &mut SealedBlock, receipts: &[Receipt]) {
-    let version = block.header.starknet_version;
-
-    // Transaction commitment: older blocks (pre-0.7 and 0.7.0) return zero from the gateway.
-    // Pre-0.13.2 uses Pedersen, post-0.13.2 uses Poseidon.
-    if block.header.transactions_commitment == Felt::ZERO {
-        let tx_hashes: Vec<Felt> = block.body.iter().map(|t| t.hash).collect();
-        block.header.transactions_commitment = if version < StarknetVersion::V0_13_2 {
-            compute_merkle_root::<Pedersen>(&tx_hashes).unwrap()
-        } else {
-            compute_merkle_root::<Poseidon>(&tx_hashes).unwrap()
-        };
-    }
-
-    // Event commitment: older blocks return zero from the gateway.
-    // Pre-0.13.2 uses Pedersen, post-0.13.2 uses Poseidon (and includes tx_hash in leaf).
-    if block.header.events_commitment == Felt::ZERO {
-        let event_hashes: Vec<Felt> = if version < StarknetVersion::V0_13_2 {
-            receipts
-                .iter()
-                .flat_map(|r| {
-                    r.events().iter().map(|event| {
-                        let keys_hash = Pedersen::hash_array(&event.keys);
-                        let data_hash = Pedersen::hash_array(&event.data);
-                        Pedersen::hash_array(&[event.from_address.into(), keys_hash, data_hash])
-                    })
-                })
-                .collect()
-        } else {
-            receipts
-                .iter()
-                .zip(block.body.iter())
-                .flat_map(|(receipt, tx)| {
-                    receipt.events().iter().map(move |event| {
-                        let keys_hash = Poseidon::hash_array(&event.keys);
-                        let data_hash = Poseidon::hash_array(&event.data);
-                        Poseidon::hash_array(&[
-                            tx.hash,
-                            event.from_address.into(),
-                            keys_hash,
-                            data_hash,
-                        ])
-                    })
-                })
-                .collect()
-        };
-
-        block.header.events_commitment = if version < StarknetVersion::V0_13_2 {
-            compute_merkle_root::<Pedersen>(&event_hashes).unwrap()
-        } else {
-            compute_merkle_root::<Poseidon>(&event_hashes).unwrap()
-        };
-    }
-
-    // Receipt commitment: only used in post-0.13.2 block hashes. The source may not
-    // include it, so we compute it when missing.
-    if block.header.receipts_commitment == Felt::ZERO && version >= StarknetVersion::V0_13_2 {
-        let receipt_hashes: Vec<Felt> = receipts
-            .iter()
-            .zip(block.body.iter())
-            .map(|(receipt, tx)| ReceiptWithTxHash::new(tx.hash, receipt.clone()).compute_hash())
-            .collect();
-        block.header.receipts_commitment =
-            compute_merkle_root::<Poseidon>(&receipt_hashes).unwrap();
-    }
 }

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -4,8 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use katana_gateway_client::Client as SequencerGateway;
 use katana_gateway_types::{
-    Block, BlockStatus, ConfirmedStateUpdate, ErrorCode, GatewayError, StateDiff, StateUpdate,
-    StateUpdateWithBlock,
+    Block, BlockStatus, ConfirmedStateUpdate, StateDiff, StateUpdate, StateUpdateWithBlock,
 };
 use katana_primitives::block::{
     BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -196,6 +196,7 @@ fn create_downloaded_block_with_parent(
             receipt_commitment: Some(Felt::ZERO),
             event_commitment: Some(Felt::ZERO),
             state_diff_commitment: Some(Felt::ZERO),
+            state_diff_length: None,
             state_root: Some(Felt::ZERO),
         },
         state_update: StateUpdate::Confirmed(ConfirmedStateUpdate {


### PR DESCRIPTION
This updates the sync blocks stage to rebuild transaction, event, receipt, and state-diff commitments using the version-specific Starknet formulas.
