### PR TITLE
fix(gateway): get block hash directly from db

### DIFF
--- a/crates/gateway/gateway-server/src/handlers.rs
+++ b/crates/gateway/gateway-server/src/handlers.rs
@@ -9,7 +9,9 @@ use katana_pool_api::TransactionPool;
 use katana_primitives::block::{BlockHash, BlockIdOrTag, BlockNumber};
 use katana_primitives::class::{ClassHash, CompiledClass, ContractClassCompilationError};
 use katana_provider::{ProviderFactory, ProviderRO, ProviderRW};
-use katana_provider_api::block::{BlockIdReader, BlockProvider, BlockStatusProvider};
+use katana_provider_api::block::{
+    BlockHashProvider, BlockIdReader, BlockProvider, BlockStatusProvider,
+};
 use katana_provider_api::transaction::ReceiptProvider;
 use katana_rpc_api::error::starknet::StarknetApiError;
 use katana_rpc_server::starknet::{PendingBlockProvider, StarknetApi};
@@ -57,6 +59,7 @@ where
                 let provider = this.storage().provider();
 
                 if let Some(num) = provider.convert_block_id(id)? {
+                    let block_hash = provider.block_hash_by_num(num)?.unwrap();
                     let block = provider.block(num.into())?.unwrap();
                     let receipts = provider.receipts_by_block(num.into())?.unwrap();
                     let status = provider.block_status(num.into())?.unwrap();
@@ -78,8 +81,6 @@ where
                             ConfirmedReceipt { transaction_hash, transaction_index, body }
                         })
                         .collect::<Vec<ConfirmedReceipt>>();
-
-                    let block_hash = block.header.compute_hash();
 
                     Ok(Some(Block {
                         transactions,

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -122,8 +122,8 @@ where
                 if computed_hash != block.block.hash {
                     warn!(
                         block = %block_number,
-                        expected = %block.block.hash,
-                        computed = %computed_hash,
+                        expected = %format!("{:#x}", block.block.hash),
+                        computed = %format!("{:#x}", computed_hash),
                         "Block hash mismatch"
                     );
                 }


### PR DESCRIPTION
Currently, the gateway server recomputes the block hash on every `/get_block` request. The `Header::compute_hash` call (i.e.,e `block.header.compute_hash()`) perform hash computation using the latest Starknet version supported by Katana - it doesn't perform versioned hash computation as seen in #474 .

The solution is to simply fetch the block hash from the database directly i.e., `BlockHashes` table.