### PR TITLE
feat(db): add `zstd` compression to `Transactions` table

### DIFF
--- a/crates/storage/db/src/models/envelope.rs
+++ b/crates/storage/db/src/models/envelope.rs
@@ -21,16 +21,38 @@ pub trait EnvelopePayload: Serialize + DeserializeOwned + Debug + Clone + Partia
     fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError>;
 }
 
-/// Generic compressed envelope.
+/// Generic compressed envelope for on-disk table values.
+///
+/// Wraps a payload `T` with a fixed 6-byte header so that encoding can evolve
+/// independently from the in-memory types. Rows written before the envelope
+/// existed (legacy rows) are detected by the absence of the magic prefix and
+/// decoded via [`EnvelopePayload::from_legacy_bytes`].
+///
+/// # Wire format
 ///
 /// ```text
 /// +---------+-----------+------------+-------------------------------+
 /// | magic   | version   | encoding   | payload                       |
 /// | 4 bytes | 1 byte    | 1 byte     | variable length               |
 /// +---------+-----------+------------+-------------------------------+
-/// | MAGIC   | 0x01      | 0x01       | zstd(postcard(T))             |
-/// +---------+-----------+------------+-------------------------------+
 /// ```
+///
+/// **Magic** (bytes 0–3): A 4-byte ASCII tag unique to each payload type
+/// (e.g. `KRCP` for receipts, `KTXN` for transactions). Used to distinguish
+/// envelope-encoded rows from legacy rows during decompression.
+///
+/// **Format version** (byte 4): Schema version of the envelope layout itself.
+/// Currently `0x01`. A reader that encounters a higher version will reject the
+/// row, ensuring forward-incompatible changes are caught early.
+///
+/// **Encoding** (byte 5): Identifies the compression algorithm applied to the
+/// serialized payload.
+///   - `0x01` — zstd (default level, no dictionary).
+///   - `0x02` — reserved for zstd with a shared dictionary.
+///
+/// **Payload** (bytes 6..): The inner value serialized with
+/// [postcard](https://docs.rs/postcard) and then compressed according to the
+/// encoding byte.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Envelope<T: EnvelopePayload> {
     pub inner: T,

--- a/crates/storage/db/src/models/envelope.rs
+++ b/crates/storage/db/src/models/envelope.rs
@@ -1,0 +1,179 @@
+use std::fmt::Debug;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::codecs::{Compress, Decompress};
+use crate::error::CodecError;
+
+const FORMAT_VERSION: u8 = 1;
+const ENCODING_ZSTD: u8 = 1;
+const HEADER_LEN: usize = 4 + 2; // magic (4) + version (1) + encoding (1)
+
+/// Trait for types that can be stored in a compressed envelope.
+pub trait EnvelopePayload: Serialize + DeserializeOwned + Debug + Clone + PartialEq + Eq {
+    /// 4-byte magic identifier for this payload type.
+    const MAGIC: &[u8; 4];
+    /// Human-readable name for error messages.
+    const NAME: &str;
+
+    /// Try to deserialize from legacy (pre-envelope) bytes.
+    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError>;
+}
+
+/// Generic compressed envelope.
+///
+/// ```text
+/// +---------+-----------+------------+-------------------------------+
+/// | magic   | version   | encoding   | payload                       |
+/// | 4 bytes | 1 byte    | 1 byte     | variable length               |
+/// +---------+-----------+------------+-------------------------------+
+/// | MAGIC   | 0x01      | 0x01       | zstd(postcard(T))             |
+/// +---------+-----------+------------+-------------------------------+
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Envelope<T: EnvelopePayload> {
+    pub inner: T,
+}
+
+impl<T: EnvelopePayload> From<T> for Envelope<T> {
+    fn from(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: EnvelopePayload> Compress for Envelope<T> {
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
+        let serialized =
+            postcard::to_stdvec(&self.inner).map_err(|e| CodecError::Compress(e.to_string()))?;
+        let compressed = zstd::encode_all(serialized.as_slice(), 0)
+            .map_err(|e| CodecError::Compress(e.to_string()))?;
+
+        let mut encoded = Vec::with_capacity(HEADER_LEN + compressed.len());
+        encoded.extend_from_slice(T::MAGIC);
+        encoded.push(FORMAT_VERSION);
+        encoded.push(ENCODING_ZSTD);
+        encoded.extend_from_slice(&compressed);
+
+        Ok(encoded)
+    }
+}
+
+impl<T: EnvelopePayload> Decompress for Envelope<T> {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+
+        if bytes.starts_with(T::MAGIC) {
+            if bytes.len() < HEADER_LEN {
+                return Err(CodecError::Decompress(format!("Incomplete {} envelope", T::NAME)));
+            }
+
+            let version = bytes[T::MAGIC.len()];
+            if version != FORMAT_VERSION {
+                return Err(CodecError::Decompress(format!(
+                    "Unsupported {} encoding version: {version}",
+                    T::NAME
+                )));
+            }
+
+            let encoding = bytes[T::MAGIC.len() + 1];
+            if encoding != ENCODING_ZSTD {
+                return Err(CodecError::Decompress(format!(
+                    "Unsupported {} encoding: {encoding}",
+                    T::NAME
+                )));
+            }
+
+            let serialized = zstd::decode_all(&bytes[HEADER_LEN..])
+                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+            let inner = postcard::from_bytes(&serialized)
+                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+            Ok(Self { inner })
+        } else {
+            T::from_legacy_bytes(bytes).map(|inner| Self { inner })
+        }
+    }
+}
+
+pub type TxEnvelope = Envelope<crate::models::versioned::transaction::VersionedTx>;
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestPayload {
+        data: String,
+    }
+
+    impl EnvelopePayload for TestPayload {
+        const MAGIC: &[u8; 4] = b"TEST";
+        const NAME: &str = "test";
+
+        fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
+            postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))
+        }
+    }
+
+    fn sample_payload() -> TestPayload {
+        TestPayload { data: "hello world".into() }
+    }
+
+    #[test]
+    fn envelope_roundtrip() {
+        let payload = sample_payload();
+        let envelope = Envelope::from(payload.clone());
+
+        let compressed = envelope.compress().expect("compress");
+        assert_eq!(&compressed[..4], b"TEST");
+        assert_eq!(compressed[4], FORMAT_VERSION);
+        assert_eq!(compressed[5], ENCODING_ZSTD);
+
+        let decompressed = Envelope::<TestPayload>::decompress(compressed).expect("decompress");
+        assert_eq!(decompressed.inner, payload);
+    }
+
+    #[test]
+    fn envelope_decompresses_legacy_bytes() {
+        let payload = sample_payload();
+        let legacy = postcard::to_stdvec(&payload).expect("serialize");
+
+        let decompressed = Envelope::<TestPayload>::decompress(legacy).expect("decompress");
+        assert_eq!(decompressed.inner, payload);
+    }
+
+    #[test]
+    fn envelope_rejects_unknown_version() {
+        let mut encoded = b"TEST".to_vec();
+        encoded.push(FORMAT_VERSION + 1);
+        encoded.push(ENCODING_ZSTD);
+
+        let err = Envelope::<TestPayload>::decompress(encoded).expect_err("must reject");
+        assert!(matches!(err, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn envelope_rejects_unknown_encoding() {
+        let mut encoded = b"TEST".to_vec();
+        encoded.push(FORMAT_VERSION);
+        encoded.push(ENCODING_ZSTD + 1);
+
+        let err = Envelope::<TestPayload>::decompress(encoded).expect_err("must reject");
+        assert!(matches!(err, CodecError::Decompress(_)));
+    }
+
+    #[test]
+    fn envelope_rejects_corrupt_payload() {
+        let mut encoded = b"TEST".to_vec();
+        encoded.push(FORMAT_VERSION);
+        encoded.push(ENCODING_ZSTD);
+        encoded.extend_from_slice(&[1, 2, 3, 4]);
+
+        let err = Envelope::<TestPayload>::decompress(encoded).expect_err("must reject");
+        assert!(matches!(err, CodecError::Decompress(_)));
+    }
+}

--- a/crates/storage/db/src/models/envelope.rs
+++ b/crates/storage/db/src/models/envelope.rs
@@ -10,6 +10,53 @@ const FORMAT_VERSION: u8 = 1;
 const ENCODING_ZSTD: u8 = 1;
 const HEADER_LEN: usize = 4 + 2; // magic (4) + version (1) + encoding (1)
 
+/// Concrete error type for envelope compress/decompress operations.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum EnvelopeError {
+    /// The envelope header is present but truncated (fewer than [`HEADER_LEN`] bytes).
+    #[error("incomplete {name} envelope: expected at least {expected} bytes, got {actual}")]
+    IncompleteHeader { name: &'static str, expected: usize, actual: usize },
+
+    /// The format version byte is not recognised by this build.
+    #[error("unsupported {name} envelope version: {version}")]
+    UnsupportedVersion { name: &'static str, version: u8 },
+
+    /// The encoding byte is not recognised by this build.
+    #[error("unsupported {name} envelope encoding: {encoding}")]
+    UnsupportedEncoding { name: &'static str, encoding: u8 },
+
+    /// `postcard` serialization failed during compression.
+    #[error("failed to serialize {name} payload: {reason}")]
+    Serialize { name: &'static str, reason: String },
+
+    /// `postcard` deserialization failed after decompression.
+    #[error("failed to deserialize {name} payload: {reason}")]
+    Deserialize { name: &'static str, reason: String },
+
+    /// `zstd` compression failed.
+    #[error("failed to zstd-compress {name} payload: {reason}")]
+    ZstdCompress { name: &'static str, reason: String },
+
+    /// `zstd` decompression failed (corrupt or truncated data).
+    #[error("failed to zstd-decompress {name} payload: {reason}")]
+    ZstdDecompress { name: &'static str, reason: String },
+
+    /// Legacy (pre-envelope) deserialization failed.
+    #[error("failed to decode legacy {name} bytes: {reason}")]
+    LegacyDecode { name: &'static str, reason: String },
+}
+
+impl From<EnvelopeError> for CodecError {
+    fn from(err: EnvelopeError) -> Self {
+        match &err {
+            EnvelopeError::Serialize { .. } | EnvelopeError::ZstdCompress { .. } => {
+                CodecError::Compress(err.to_string())
+            }
+            _ => CodecError::Decompress(err.to_string()),
+        }
+    }
+}
+
 /// Trait for types that can be stored in a compressed envelope.
 pub trait EnvelopePayload: Serialize + DeserializeOwned + Debug + Clone + PartialEq + Eq {
     /// 4-byte magic identifier for this payload type.
@@ -18,7 +65,7 @@ pub trait EnvelopePayload: Serialize + DeserializeOwned + Debug + Clone + Partia
     const NAME: &str;
 
     /// Try to deserialize from legacy (pre-envelope) bytes.
-    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError>;
+    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, EnvelopeError>;
 }
 
 /// Generic compressed envelope for on-disk table values.
@@ -64,14 +111,13 @@ impl<T: EnvelopePayload> From<T> for Envelope<T> {
     }
 }
 
-impl<T: EnvelopePayload> Compress for Envelope<T> {
-    type Compressed = Vec<u8>;
+impl<T: EnvelopePayload> Envelope<T> {
+    pub(crate) fn do_compress(self) -> Result<Vec<u8>, EnvelopeError> {
+        let serialized = postcard::to_stdvec(&self.inner)
+            .map_err(|e| EnvelopeError::Serialize { name: T::NAME, reason: e.to_string() })?;
 
-    fn compress(self) -> Result<Self::Compressed, CodecError> {
-        let serialized =
-            postcard::to_stdvec(&self.inner).map_err(|e| CodecError::Compress(e.to_string()))?;
         let compressed = zstd::encode_all(serialized.as_slice(), 0)
-            .map_err(|e| CodecError::Compress(e.to_string()))?;
+            .map_err(|e| EnvelopeError::ZstdCompress { name: T::NAME, reason: e.to_string() })?;
 
         let mut encoded = Vec::with_capacity(HEADER_LEN + compressed.len());
         encoded.extend_from_slice(T::MAGIC);
@@ -81,41 +127,52 @@ impl<T: EnvelopePayload> Compress for Envelope<T> {
 
         Ok(encoded)
     }
-}
 
-impl<T: EnvelopePayload> Decompress for Envelope<T> {
-    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
-        let bytes = bytes.as_ref();
-
+    pub(crate) fn do_decompress(bytes: &[u8]) -> Result<Self, EnvelopeError> {
         if bytes.starts_with(T::MAGIC) {
             if bytes.len() < HEADER_LEN {
-                return Err(CodecError::Decompress(format!("Incomplete {} envelope", T::NAME)));
+                return Err(EnvelopeError::IncompleteHeader {
+                    name: T::NAME,
+                    expected: HEADER_LEN,
+                    actual: bytes.len(),
+                });
             }
 
             let version = bytes[T::MAGIC.len()];
             if version != FORMAT_VERSION {
-                return Err(CodecError::Decompress(format!(
-                    "Unsupported {} encoding version: {version}",
-                    T::NAME
-                )));
+                return Err(EnvelopeError::UnsupportedVersion { name: T::NAME, version });
             }
 
             let encoding = bytes[T::MAGIC.len() + 1];
             if encoding != ENCODING_ZSTD {
-                return Err(CodecError::Decompress(format!(
-                    "Unsupported {} encoding: {encoding}",
-                    T::NAME
-                )));
+                return Err(EnvelopeError::UnsupportedEncoding { name: T::NAME, encoding });
             }
 
-            let serialized = zstd::decode_all(&bytes[HEADER_LEN..])
-                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+            let serialized = zstd::decode_all(&bytes[HEADER_LEN..]).map_err(|e| {
+                EnvelopeError::ZstdDecompress { name: T::NAME, reason: e.to_string() }
+            })?;
+
             let inner = postcard::from_bytes(&serialized)
-                .map_err(|e| CodecError::Decompress(e.to_string()))?;
+                .map_err(|e| EnvelopeError::Deserialize { name: T::NAME, reason: e.to_string() })?;
+
             Ok(Self { inner })
         } else {
             T::from_legacy_bytes(bytes).map(|inner| Self { inner })
         }
+    }
+}
+
+impl<T: EnvelopePayload> Compress for Envelope<T> {
+    type Compressed = Vec<u8>;
+
+    fn compress(self) -> Result<Self::Compressed, CodecError> {
+        self.do_compress().map_err(Into::into)
+    }
+}
+
+impl<T: EnvelopePayload> Decompress for Envelope<T> {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        Self::do_decompress(bytes.as_ref()).map_err(Into::into)
     }
 }
 
@@ -136,8 +193,11 @@ mod tests {
         const MAGIC: &[u8; 4] = b"TEST";
         const NAME: &str = "test";
 
-        fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
-            postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))
+        fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, EnvelopeError> {
+            postcard::from_bytes(bytes).map_err(|e| EnvelopeError::LegacyDecode {
+                name: Self::NAME,
+                reason: e.to_string(),
+            })
         }
     }
 
@@ -174,8 +234,8 @@ mod tests {
         encoded.push(FORMAT_VERSION + 1);
         encoded.push(ENCODING_ZSTD);
 
-        let err = Envelope::<TestPayload>::decompress(encoded).expect_err("must reject");
-        assert!(matches!(err, CodecError::Decompress(_)));
+        let err = Envelope::<TestPayload>::do_decompress(&encoded).expect_err("must reject");
+        assert!(matches!(err, EnvelopeError::UnsupportedVersion { version: 2, .. }));
     }
 
     #[test]
@@ -184,8 +244,8 @@ mod tests {
         encoded.push(FORMAT_VERSION);
         encoded.push(ENCODING_ZSTD + 1);
 
-        let err = Envelope::<TestPayload>::decompress(encoded).expect_err("must reject");
-        assert!(matches!(err, CodecError::Decompress(_)));
+        let err = Envelope::<TestPayload>::do_decompress(&encoded).expect_err("must reject");
+        assert!(matches!(err, EnvelopeError::UnsupportedEncoding { encoding: 2, .. }));
     }
 
     #[test]
@@ -195,7 +255,15 @@ mod tests {
         encoded.push(ENCODING_ZSTD);
         encoded.extend_from_slice(&[1, 2, 3, 4]);
 
-        let err = Envelope::<TestPayload>::decompress(encoded).expect_err("must reject");
-        assert!(matches!(err, CodecError::Decompress(_)));
+        let err = Envelope::<TestPayload>::do_decompress(&encoded).expect_err("must reject");
+        assert!(matches!(err, EnvelopeError::ZstdDecompress { .. }));
+    }
+
+    #[test]
+    fn envelope_rejects_incomplete_header() {
+        let encoded = b"TEST".to_vec(); // magic only, missing version + encoding
+
+        let err = Envelope::<TestPayload>::do_decompress(&encoded).expect_err("must reject");
+        assert!(matches!(err, EnvelopeError::IncompleteHeader { expected: 6, actual: 4, .. }));
     }
 }

--- a/crates/storage/db/src/models/mod.rs
+++ b/crates/storage/db/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod block;
 pub mod class;
 pub mod contract;
+pub mod envelope;
 pub mod list;
 pub mod receipt;
 pub mod stage;
@@ -9,6 +10,7 @@ pub mod trie;
 
 pub mod versioned;
 
+pub use envelope::TxEnvelope;
 pub use receipt::ReceiptEnvelope;
 pub use versioned::block::VersionedHeader;
 pub use versioned::class::VersionedContractClass;

--- a/crates/storage/db/src/models/mod.rs
+++ b/crates/storage/db/src/models/mod.rs
@@ -10,7 +10,7 @@ pub mod trie;
 
 pub mod versioned;
 
-pub use envelope::TxEnvelope;
+pub use envelope::{EnvelopeError, TxEnvelope};
 pub use receipt::ReceiptEnvelope;
 pub use versioned::block::VersionedHeader;
 pub use versioned::class::VersionedContractClass;

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -1,14 +1,14 @@
 use katana_primitives::receipt::Receipt;
 
-use crate::error::CodecError;
-use crate::models::envelope::{Envelope, EnvelopePayload};
+use crate::models::envelope::{Envelope, EnvelopeError, EnvelopePayload};
 
 impl EnvelopePayload for Receipt {
     const MAGIC: &[u8; 4] = b"KRCP";
     const NAME: &str = "receipt";
 
-    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
-        postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))
+    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, EnvelopeError> {
+        postcard::from_bytes(bytes)
+            .map_err(|e| EnvelopeError::LegacyDecode { name: Self::NAME, reason: e.to_string() })
     }
 }
 
@@ -28,7 +28,7 @@ mod tests {
     use super::ReceiptEnvelope;
     use crate::abstraction::{Database, DbTx, DbTxMut};
     use crate::codecs::{Compress, Decompress};
-    use crate::error::CodecError;
+    use crate::models::envelope::EnvelopeError;
     use crate::{tables, Db};
 
     fn sample_receipt() -> Receipt {
@@ -74,8 +74,8 @@ mod tests {
         encoded.push(2); // bad version
         encoded.push(1);
 
-        let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject version");
-        assert!(matches!(error, CodecError::Decompress(_)));
+        let error = ReceiptEnvelope::do_decompress(&encoded).expect_err("must reject version");
+        assert!(matches!(error, EnvelopeError::UnsupportedVersion { version: 2, .. }));
     }
 
     #[test]
@@ -84,8 +84,8 @@ mod tests {
         encoded.push(1);
         encoded.push(2); // bad encoding
 
-        let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject encoding");
-        assert!(matches!(error, CodecError::Decompress(_)));
+        let error = ReceiptEnvelope::do_decompress(&encoded).expect_err("must reject encoding");
+        assert!(matches!(error, EnvelopeError::UnsupportedEncoding { encoding: 2, .. }));
     }
 
     #[test]
@@ -95,8 +95,9 @@ mod tests {
         encoded.push(1);
         encoded.extend_from_slice(&[1, 2, 3, 4]);
 
-        let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject corrupt payload");
-        assert!(matches!(error, CodecError::Decompress(_)));
+        let error =
+            ReceiptEnvelope::do_decompress(&encoded).expect_err("must reject corrupt payload");
+        assert!(matches!(error, EnvelopeError::ZstdDecompress { .. }));
     }
 
     #[test]

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -1,104 +1,23 @@
 use katana_primitives::receipt::Receipt;
 
-use crate::codecs::{Compress, Decompress};
 use crate::error::CodecError;
+use crate::models::envelope::{Envelope, EnvelopePayload};
 
-/// On-disk representation for `Receipts` table values.
-///
-/// This wrapper keeps table-specific encoding concerns (envelope header, compression
-/// algorithm, and backward-compatibility fallbacks) out of `Receipt` itself.
-///
-/// New rows are written as `envelope + zstd(postcard(receipt))`.
-/// Rows without the envelope are treated as legacy postcard-only bytes.
-///
-/// ```text
-/// +---------+-----------+------------+--------------------------+
-/// | magic   | version   | encoding   | payload                  |
-/// | 4 bytes | 1 byte    | 1 byte     | variable length          |
-/// +---------+-----------+------------+--------------------------+
-/// | "KRCP"  | 0x01      | 0x01       | zstd(postcard(receipt))  |
-/// +---------+-----------+------------+--------------------------+
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReceiptEnvelope {
-    pub receipt: Receipt,
-}
+impl EnvelopePayload for Receipt {
+    const MAGIC: &[u8; 4] = b"KRCP";
+    const NAME: &str = "receipt";
 
-// 4-byte ASCII magic used to identify a Katana receipt envelope.
-// Convention: `K` + 3-byte payload identifier, so future table envelopes can follow the same
-// recognizable, debuggable namespace pattern.
-const RECEIPT_MAGIC: &[u8; 4] = b"KRCP";
-const RECEIPT_FORMAT_VERSION: u8 = 1;
-const RECEIPT_ENCODING_ZSTD: u8 = 1;
-// Encoding `2` is reserved for zstd + dictionary support.
-const RECEIPT_HEADER_LEN: usize = RECEIPT_MAGIC.len() + 2;
-
-impl From<Receipt> for ReceiptEnvelope {
-    fn from(receipt: Receipt) -> Self {
-        Self { receipt }
+    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
+        postcard::from_bytes(bytes).map_err(|e| CodecError::Decompress(e.to_string()))
     }
 }
+
+/// On-disk representation for `Receipts` table values.
+pub type ReceiptEnvelope = Envelope<Receipt>;
 
 impl From<ReceiptEnvelope> for Receipt {
     fn from(value: ReceiptEnvelope) -> Self {
-        value.receipt
-    }
-}
-
-impl Compress for ReceiptEnvelope {
-    type Compressed = Vec<u8>;
-
-    fn compress(self) -> Result<Self::Compressed, CodecError> {
-        let serialized =
-            postcard::to_stdvec(&self.receipt).map_err(|e| CodecError::Compress(e.to_string()))?;
-        let compressed = zstd::encode_all(serialized.as_slice(), 0)
-            .map_err(|e| CodecError::Compress(e.to_string()))?;
-
-        // The envelope allows multiple receipt encodings to coexist over time.
-        let mut encoded = Vec::with_capacity(RECEIPT_HEADER_LEN + compressed.len());
-        encoded.extend_from_slice(RECEIPT_MAGIC);
-        encoded.push(RECEIPT_FORMAT_VERSION);
-        encoded.push(RECEIPT_ENCODING_ZSTD);
-        encoded.extend_from_slice(&compressed);
-
-        Ok(encoded)
-    }
-}
-
-impl Decompress for ReceiptEnvelope {
-    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
-        let bytes = bytes.as_ref();
-
-        if bytes.starts_with(RECEIPT_MAGIC) {
-            if bytes.len() < RECEIPT_HEADER_LEN {
-                return Err(CodecError::Decompress("Incomplete receipt envelope".into()));
-            }
-
-            let version = bytes[RECEIPT_MAGIC.len()];
-            if version != RECEIPT_FORMAT_VERSION {
-                return Err(CodecError::Decompress(format!(
-                    "Unsupported receipt encoding version: {version}"
-                )));
-            }
-
-            let encoding = bytes[RECEIPT_MAGIC.len() + 1];
-            if encoding != RECEIPT_ENCODING_ZSTD {
-                return Err(CodecError::Decompress(format!(
-                    "Unsupported receipt encoding: {encoding}"
-                )));
-            }
-
-            let serialized = zstd::decode_all(&bytes[RECEIPT_HEADER_LEN..])
-                .map_err(|e| CodecError::Decompress(e.to_string()))?;
-            let receipt = postcard::from_bytes(&serialized)
-                .map_err(|e| CodecError::Decompress(e.to_string()))?;
-            Ok(Self { receipt })
-        } else {
-            // Databases created before receipt compression stored raw postcard bytes.
-            postcard::from_bytes::<Receipt>(bytes)
-                .map(|receipt| Self { receipt })
-                .map_err(|e| CodecError::Decompress(e.to_string()))
-        }
+        value.inner
     }
 }
 
@@ -106,11 +25,9 @@ impl Decompress for ReceiptEnvelope {
 mod tests {
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
 
-    use super::{
-        Compress, Decompress, ReceiptEnvelope, RECEIPT_ENCODING_ZSTD, RECEIPT_FORMAT_VERSION,
-        RECEIPT_MAGIC,
-    };
+    use super::ReceiptEnvelope;
     use crate::abstraction::{Database, DbTx, DbTxMut};
+    use crate::codecs::{Compress, Decompress};
     use crate::error::CodecError;
     use crate::{tables, Db};
 
@@ -130,9 +47,9 @@ mod tests {
         let envelope = ReceiptEnvelope::from(receipt.clone());
 
         let compressed = envelope.compress().expect("failed to compress receipt envelope");
-        assert_eq!(&compressed[..RECEIPT_MAGIC.len()], RECEIPT_MAGIC);
-        assert_eq!(compressed[RECEIPT_MAGIC.len()], RECEIPT_FORMAT_VERSION);
-        assert_eq!(compressed[RECEIPT_MAGIC.len() + 1], RECEIPT_ENCODING_ZSTD);
+        assert_eq!(&compressed[..4], b"KRCP");
+        assert_eq!(compressed[4], 1); // FORMAT_VERSION
+        assert_eq!(compressed[5], 1); // ENCODING_ZSTD
 
         let decompressed =
             ReceiptEnvelope::decompress(compressed).expect("failed to decompress receipt envelope");
@@ -153,9 +70,9 @@ mod tests {
 
     #[test]
     fn receipt_envelope_rejects_unknown_version() {
-        let mut encoded = RECEIPT_MAGIC.to_vec();
-        encoded.push(RECEIPT_FORMAT_VERSION + 1);
-        encoded.push(RECEIPT_ENCODING_ZSTD);
+        let mut encoded = b"KRCP".to_vec();
+        encoded.push(2); // bad version
+        encoded.push(1);
 
         let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject version");
         assert!(matches!(error, CodecError::Decompress(_)));
@@ -163,9 +80,9 @@ mod tests {
 
     #[test]
     fn receipt_envelope_rejects_unknown_encoding() {
-        let mut encoded = RECEIPT_MAGIC.to_vec();
-        encoded.push(RECEIPT_FORMAT_VERSION);
-        encoded.push(RECEIPT_ENCODING_ZSTD + 1);
+        let mut encoded = b"KRCP".to_vec();
+        encoded.push(1);
+        encoded.push(2); // bad encoding
 
         let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject encoding");
         assert!(matches!(error, CodecError::Decompress(_)));
@@ -173,9 +90,9 @@ mod tests {
 
     #[test]
     fn receipt_envelope_rejects_corrupt_zstd_payload() {
-        let mut encoded = RECEIPT_MAGIC.to_vec();
-        encoded.push(RECEIPT_FORMAT_VERSION);
-        encoded.push(RECEIPT_ENCODING_ZSTD);
+        let mut encoded = b"KRCP".to_vec();
+        encoded.push(1);
+        encoded.push(1);
         encoded.extend_from_slice(&[1, 2, 3, 4]);
 
         let error = ReceiptEnvelope::decompress(encoded).expect_err("must reject corrupt payload");

--- a/crates/storage/db/src/models/versioned/transaction/mod.rs
+++ b/crates/storage/db/src/models/versioned/transaction/mod.rs
@@ -1,8 +1,8 @@
 use katana_primitives::transaction::Tx;
 use serde::{Deserialize, Serialize};
 
-use crate::codecs::{Compress, Decompress};
 use crate::error::CodecError;
+use crate::models::envelope::EnvelopePayload;
 
 mod v6;
 
@@ -19,22 +19,15 @@ impl From<Tx> for VersionedTx {
     }
 }
 
-impl Compress for VersionedTx {
-    type Compressed = Vec<u8>;
-    fn compress(self) -> Result<Self::Compressed, CodecError> {
-        postcard::to_stdvec(&self).map_err(|e| CodecError::Compress(e.to_string()))
-    }
-}
+impl EnvelopePayload for VersionedTx {
+    const MAGIC: &[u8; 4] = b"KTXN";
+    const NAME: &str = "transaction";
 
-impl Decompress for VersionedTx {
-    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
-        let bytes = bytes.as_ref();
-
+    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
         if let Ok(tx) = postcard::from_bytes::<Self>(bytes) {
             return Ok(tx);
         }
 
-        // Try deserializing as V7 first, then fall back to V6
         if let Ok(transaction) = postcard::from_bytes::<Tx>(bytes) {
             return Ok(Self::V7(transaction));
         }

--- a/crates/storage/db/src/models/versioned/transaction/mod.rs
+++ b/crates/storage/db/src/models/versioned/transaction/mod.rs
@@ -1,8 +1,7 @@
 use katana_primitives::transaction::Tx;
 use serde::{Deserialize, Serialize};
 
-use crate::error::CodecError;
-use crate::models::envelope::EnvelopePayload;
+use crate::models::envelope::{EnvelopeError, EnvelopePayload};
 
 mod v6;
 
@@ -23,7 +22,7 @@ impl EnvelopePayload for VersionedTx {
     const MAGIC: &[u8; 4] = b"KTXN";
     const NAME: &str = "transaction";
 
-    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
+    fn from_legacy_bytes(bytes: &[u8]) -> Result<Self, EnvelopeError> {
         if let Ok(tx) = postcard::from_bytes::<Self>(bytes) {
             return Ok(tx);
         }
@@ -36,9 +35,10 @@ impl EnvelopePayload for VersionedTx {
             return Ok(Self::V6(transaction));
         }
 
-        Err(CodecError::Decompress(
-            "failed to deserialize versioned transaction: unknown format".to_string(),
-        ))
+        Err(EnvelopeError::LegacyDecode {
+            name: Self::NAME,
+            reason: "unknown transaction format".to_string(),
+        })
     }
 }
 

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -12,7 +12,7 @@ use crate::models::list::BlockList;
 use crate::models::stage::{ExecutionCheckpoint, PruningCheckpoint, StageId};
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 use crate::models::trie::{TrieDatabaseKey, TrieDatabaseValue, TrieHistoryEntry};
-use crate::models::{ReceiptEnvelope, VersionedContractClass, VersionedHeader, VersionedTx};
+use crate::models::{ReceiptEnvelope, TxEnvelope, VersionedContractClass, VersionedHeader};
 
 pub trait Key: Encode + Decode + Clone + std::fmt::Debug {}
 pub trait Value: Compress + Decompress + std::fmt::Debug {}
@@ -213,7 +213,7 @@ tables! {
     /// Transaction hash based on its number
     TxHashes: (TxNumber) => TxHash,
     /// Store canonical transactions
-    Transactions: (TxNumber) => VersionedTx,
+    Transactions: (TxNumber) => TxEnvelope,
     /// Stores the block number of a transaction.
     TxBlocks: (TxNumber) => BlockNumber,
     /// Stores the transaction's traces.
@@ -386,7 +386,7 @@ mod tests {
     use crate::models::trie::{
         TrieDatabaseKey, TrieDatabaseKeyType, TrieDatabaseValue, TrieHistoryEntry,
     };
-    use crate::models::{ReceiptEnvelope, VersionedHeader, VersionedTx};
+    use crate::models::{ReceiptEnvelope, TxEnvelope, VersionedHeader, VersionedTx};
 
     macro_rules! assert_key_encode_decode {
 	    { $( ($name:ty, $key:expr) ),* } => {
@@ -441,7 +441,7 @@ mod tests {
             (StoredBlockBodyIndices, StoredBlockBodyIndices::default()),
             (TxNumber, 77),
             (TxHash, felt!("0x123456789")),
-            (VersionedTx, VersionedTx::from(Tx::Invoke(InvokeTx::V1(Default::default())))),
+            (TxEnvelope, TxEnvelope::from(VersionedTx::from(Tx::Invoke(InvokeTx::V1(Default::default()))))),
             (BlockNumber, 99),
             (TypedTransactionExecutionInfo, TypedTransactionExecutionInfo::default()),
             (CompiledClassHash, felt!("211")),

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -15,7 +15,7 @@ use katana_db::models::contract::{
 use katana_db::models::list::BlockList;
 use katana_db::models::stage::{ExecutionCheckpoint, PruningCheckpoint};
 use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
-use katana_db::models::{ReceiptEnvelope, VersionedHeader, VersionedTx};
+use katana_db::models::{ReceiptEnvelope, TxEnvelope, VersionedHeader, VersionedTx};
 use katana_db::tables::{self, DupSort, Table};
 use katana_db::utils::KeyValue;
 use katana_primitives::block::{
@@ -417,8 +417,8 @@ impl<Tx: DbTx> TransactionProvider for DbProvider<Tx> {
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
         if let Some(num) = self.0.get::<tables::TxNumbers>(hash)? {
             let res = self.0.get::<tables::Transactions>(num)?;
-            let transaction = res.ok_or(ProviderError::MissingTx(num))?;
-            Ok(Some(TxWithHash { hash, transaction: transaction.into() }))
+            let envelope = res.ok_or(ProviderError::MissingTx(num))?;
+            Ok(Some(TxWithHash { hash, transaction: envelope.inner.into() }))
         } else {
             Ok(None)
         }
@@ -440,10 +440,10 @@ impl<Tx: DbTx> TransactionProvider for DbProvider<Tx> {
         let mut transactions = Vec::with_capacity(total as usize);
 
         for i in range {
-            if let Some(transaction) = self.0.get::<tables::Transactions>(i)? {
+            if let Some(envelope) = self.0.get::<tables::Transactions>(i)? {
                 let res = self.0.get::<tables::TxHashes>(i)?;
                 let hash = res.ok_or(ProviderError::MissingTxHash(i))?;
-                transactions.push(TxWithHash { hash, transaction: transaction.into() });
+                transactions.push(TxWithHash { hash, transaction: envelope.inner.into() });
             };
         }
 
@@ -481,9 +481,9 @@ impl<Tx: DbTx> TransactionProvider for DbProvider<Tx> {
                 let hash = res.ok_or(ProviderError::MissingTxHash(num))?;
 
                 let res = self.0.get::<tables::Transactions>(num)?;
-                let transaction = res.ok_or(ProviderError::MissingTx(num))?;
+                let envelope = res.ok_or(ProviderError::MissingTx(num))?;
 
-                Ok(Some(TxWithHash { hash, transaction: transaction.into() }))
+                Ok(Some(TxWithHash { hash, transaction: envelope.inner.into() }))
             }
 
             _ => Ok(None),
@@ -689,7 +689,7 @@ impl<Tx: DbTxMut> BlockWriter for DbProvider<Tx> {
             self.0.put::<tables::TxBlocks>(tx_number, block_number)?;
             self.0.put::<tables::Transactions>(
                 tx_number,
-                VersionedTx::from(transaction.transaction),
+                TxEnvelope::from(VersionedTx::from(transaction.transaction)),
             )?;
         }
 


### PR DESCRIPTION
Extracts the envelope logic introduced in #465 for `ReceiptEnvelope` into a generic `Envelope<T>` parameterized by an `EnvelopePayload` trait, then applies the same zstd compression to the `Transactions` table via a new `TxEnvelope` type alias.

Each payload type supplies a 4-byte magic (`KRCP` for receipts, `KTXN` for transactions), a human-readable name for error messages, and a `from_legacy_bytes` function for backward-compatible deserialization of pre-envelope rows. The shared `Compress`/`Decompress` impls handle the header, zstd encode/decode, version/encoding validation, and legacy fallback.

The `Transactions` table value type changes from `VersionedTx` to `TxEnvelope`. Existing uncompressed rows are transparently decoded via the legacy fallback in `VersionedTx::from_legacy_bytes`, so no migration is needed. However, any code that reads directly from the `Transactions` table outside of the provider (eg. custom tooling) will need to update to handle `TxEnvelope` instead of bare `VersionedTx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)