### PR TITLE
feat(db): backfill receipts from pre-envelope era

### DIFF
--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -280,35 +280,6 @@ mod tests {
     }
 
     #[test]
-    fn write_open_bumps_version_file_to_latest() {
-        let path = tempfile::tempdir().unwrap();
-        Db::new(path.path()).unwrap();
-
-        create_db_version_file(path.path(), MIN_OPENABLE_DB_VERSION).unwrap();
-
-        let db = Db::open(path.path()).unwrap();
-        let actual_version = get_db_version(path.path()).unwrap();
-
-        assert_eq!(db.version(), LATEST_DB_VERSION);
-        assert_eq!(actual_version, LATEST_DB_VERSION);
-    }
-
-    #[test]
-    fn read_only_open_preserves_older_version() {
-        let path = tempfile::tempdir().unwrap();
-        Db::new(path.path()).unwrap();
-
-        create_db_version_file(path.path(), MIN_OPENABLE_DB_VERSION).unwrap();
-
-        let db = Db::open_ro(path.path()).unwrap();
-        let actual_version = get_db_version(path.path()).unwrap();
-
-        assert_eq!(db.version(), MIN_OPENABLE_DB_VERSION);
-        assert_eq!(actual_version, MIN_OPENABLE_DB_VERSION);
-        assert!(db.require_migration());
-    }
-
-    #[test]
     fn open_rejects_version_below_supported_floor() {
         let path = tempfile::tempdir().unwrap();
         Db::new(path.path()).unwrap();
@@ -316,8 +287,18 @@ mod tests {
         create_db_version_file(path.path(), Version::new(MIN_OPENABLE_DB_VERSION.value() - 1))
             .unwrap();
 
+        let found = Version::new(MIN_OPENABLE_DB_VERSION.value() - 1);
         let err = Db::open_ro(path.path()).unwrap_err();
-        assert!(err.to_string().contains("is not supported"));
+
+        let expected = format!(
+            "Database version {found} is not supported. Latest supported version is {latest}, \
+             minimum openable version is {minimum_openable}.",
+            found = found,
+            latest = LATEST_DB_VERSION,
+            minimum_openable = MIN_OPENABLE_DB_VERSION,
+        );
+        let err_msg = format!("{err:#}");
+        assert!(err_msg.contains(&expected), "error: {err_msg}");
     }
 
     #[test]

--- a/crates/storage/db/src/migration.rs
+++ b/crates/storage/db/src/migration.rs
@@ -3,13 +3,16 @@ use std::collections::BTreeMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use katana_primitives::block::BlockNumber;
 use katana_primitives::contract::{StorageKey, StorageValue};
+use katana_primitives::receipt::Receipt;
 use katana_primitives::state::StateUpdates;
+use katana_primitives::transaction::TxNumber;
 
 use crate::abstraction::{Database, DbCursor, DbDupSortCursor, DbTx, DbTxMut};
 use crate::error::DatabaseError;
 use crate::models::class::MigratedCompiledClassHash;
 use crate::models::contract::{ContractClassChange, ContractClassChangeType};
 use crate::models::storage::ContractStorageEntry;
+use crate::models::ReceiptEnvelope;
 use crate::version::{self, Version, LATEST_DB_VERSION};
 use crate::{tables, Db};
 
@@ -43,6 +46,10 @@ const BATCH_SIZE: u64 = 1000;
 /// The schema changes as well as the version bump were introduced in this PR: <https://github.com/dojoengine/katana/pull/470>
 const STATE_UPDATES_TABLE_VERSION: Version = Version::new(9);
 
+/// The database version below which receipts are stored as raw postcard bytes (legacy
+/// `Receipt` codec) and need to be re-encoded into the [`ReceiptEnvelope`] format.
+const RECEIPT_ENVELOPE_VERSION: Version = Version::new(9);
+
 /// Runs all applicable database migrations based on the on-disk version at open time.
 ///
 /// Each migration path has its own version threshold. Only migrations whose version
@@ -59,15 +66,19 @@ impl<'a> Migration<'a> {
 
     /// Returns `true` if any migration path needs to be run.
     pub fn is_needed(&self) -> bool {
-        self.needs_state_update_backfill()
+        self.needs_state_update_backfill() || self.needs_receipt_envelope_backfill()
     }
 
-    /// Runs all pending migrations in order.
+    /// Runs the migration process.
     pub fn run(&self) -> Result<(), MigrationError> {
         eprintln!("[Migrating] Starting migration");
 
         if self.needs_state_update_backfill() {
             self.backfill_state_updates()?;
+        }
+
+        if self.needs_receipt_envelope_backfill() {
+            self.backfill_receipt_envelopes()?;
         }
 
         // Update the on-disk version file to the latest version.
@@ -85,6 +96,13 @@ impl<'a> Migration<'a> {
     /// index tables.
     pub(crate) fn needs_state_update_backfill(&self) -> bool {
         self.db.version() < STATE_UPDATES_TABLE_VERSION
+    }
+
+    /// Databases opened with a version below [`RECEIPT_ENVELOPE_VERSION`] may contain
+    /// receipts stored as raw postcard bytes (the legacy `Receipt` codec). These need to be
+    /// re-encoded into the [`ReceiptEnvelope`] format.
+    pub(crate) fn needs_receipt_envelope_backfill(&self) -> bool {
+        self.db.version() < RECEIPT_ENVELOPE_VERSION
     }
 
     /// Backfills the `BlockStateUpdates` table by reconstructing state updates from the legacy
@@ -149,6 +167,95 @@ impl<'a> Migration<'a> {
         }
 
         pb.finish_with_message(format!("[Migrating] Migrated {blocks_to_migrate} blocks"));
+
+        Ok(())
+    }
+
+    /// Re-encodes every row in the `Receipts` table from legacy raw-postcard bytes into the
+    /// [`ReceiptEnvelope`] format.
+    ///
+    /// Reads rows through [`LegacyReceipts`] (the old `Receipt` postcard codec) and writes
+    /// them back through [`tables::Receipts`] (the new `ReceiptEnvelope` codec).
+    ///
+    /// Processes entries in batches for crash recovery.
+    pub(crate) fn backfill_receipt_envelopes(&self) -> Result<(), MigrationError> {
+        /// Shadow table definition that reads from the physical `Receipts` table using the legacy
+        /// `Receipt` (raw postcard) codec instead of `ReceiptEnvelope`.
+        #[derive(Debug)]
+        struct LegacyReceipts;
+
+        impl tables::Table for LegacyReceipts {
+            const NAME: &'static str = tables::Receipts::NAME;
+            type Key = TxNumber;
+            type Value = Receipt;
+        }
+
+        let db = self.db;
+
+        let total_entries = db.view(|tx| tx.entries::<LegacyReceipts>())? as u64;
+
+        if total_entries == 0 {
+            eprintln!("[Migrating] \x1b[1;33mReceipts\x1b[0m table is empty, nothing to migrate.");
+            return Ok(());
+        }
+
+        let pb = ProgressBar::new(total_entries);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "[Migrating] \x1b[1;33mReceipts\x1b[0m {bar:40.cyan/blue} {pos}/{len} \
+                     receipts [{elapsed_precise}] {per_sec}",
+                )
+                .expect("valid format"),
+        );
+
+        let mut migrated: u64 = 0;
+        let mut batch_start_key: Option<u64> = Some(0);
+
+        while let Some(start_key) = batch_start_key {
+            // Phase 1: Read a batch using the legacy Receipt codec.
+            let batch: Vec<(u64, Receipt)> = {
+                let tx = db.tx()?;
+                let mut cursor = tx.cursor::<LegacyReceipts>()?;
+                let walker = cursor.walk(Some(start_key))?;
+
+                let mut entries = Vec::new();
+                for result in walker {
+                    let (tx_number, receipt) = result?;
+                    entries.push((tx_number, receipt));
+                    if entries.len() as u64 >= BATCH_SIZE {
+                        break;
+                    }
+                }
+
+                tx.commit()?;
+                entries
+            };
+
+            let current_batch_size = batch.len() as u64;
+            let is_last_batch = current_batch_size < BATCH_SIZE;
+
+            if is_last_batch {
+                batch_start_key = None;
+            } else if let Some((last_key, _)) = batch.last() {
+                batch_start_key = Some(last_key + 1);
+            } else {
+                batch_start_key = None;
+            }
+
+            // Phase 2: Write back as ReceiptEnvelope.
+            db.update(|tx| {
+                for (tx_number, receipt) in batch {
+                    tx.put::<tables::Receipts>(tx_number, ReceiptEnvelope::from(receipt))?;
+                }
+                Ok(())
+            })?;
+
+            migrated += current_batch_size;
+            pb.set_position(migrated);
+        }
+
+        pb.finish_with_message(format!("[Migrating] Re-encoded {migrated} receipts"));
 
         Ok(())
     }

--- a/crates/storage/db/src/migration.rs
+++ b/crates/storage/db/src/migration.rs
@@ -195,7 +195,10 @@ impl<'a> Migration<'a> {
         let total_entries = db.view(|tx| tx.entries::<LegacyReceipts>())? as u64;
 
         if total_entries == 0 {
-            eprintln!("[Migrating] \x1b[1;33mReceipts         \x1b[0m table is empty, nothing to migrate.");
+            eprintln!(
+                "[Migrating] \x1b[1;33mReceipts         \x1b[0m table is empty, nothing to \
+                 migrate."
+            );
             return Ok(());
         }
 

--- a/crates/storage/db/src/migration.rs
+++ b/crates/storage/db/src/migration.rs
@@ -142,7 +142,7 @@ impl<'a> Migration<'a> {
             ProgressStyle::default_bar()
                 .template(
                     "[Migrating] \x1b[1;33mBlockStateUpdates\x1b[0m {bar:40.cyan/blue} \
-                     {pos}/{len} blocks [{elapsed_precise}] {per_sec}",
+                     {pos}/{len} blocks   [{elapsed_precise}] {per_sec}",
                 )
                 .expect("valid format"),
         );
@@ -195,7 +195,7 @@ impl<'a> Migration<'a> {
         let total_entries = db.view(|tx| tx.entries::<LegacyReceipts>())? as u64;
 
         if total_entries == 0 {
-            eprintln!("[Migrating] \x1b[1;33mReceipts\x1b[0m table is empty, nothing to migrate.");
+            eprintln!("[Migrating] \x1b[1;33mReceipts         \x1b[0m table is empty, nothing to migrate.");
             return Ok(());
         }
 
@@ -203,8 +203,8 @@ impl<'a> Migration<'a> {
         pb.set_style(
             ProgressStyle::default_bar()
                 .template(
-                    "[Migrating] \x1b[1;33mReceipts\x1b[0m {bar:40.cyan/blue} {pos}/{len} \
-                     receipts [{elapsed_precise}] {per_sec}",
+                    "[Migrating] \x1b[1;33mReceipts         \x1b[0m {bar:40.cyan/blue} \
+                     {pos}/{len} receipts [{elapsed_precise}] {per_sec}",
                 )
                 .expect("valid format"),
         );

--- a/crates/storage/db/src/models/envelope.rs
+++ b/crates/storage/db/src/models/envelope.rs
@@ -55,9 +55,9 @@ pub enum EnvelopeError {
     #[error("failed to zstd-decompress {name} payload: {reason}")]
     ZstdDecompress { name: &'static str, reason: String },
 
-    /// Legacy (pre-envelope) deserialization failed.
-    #[error("failed to decode legacy {name} bytes: {reason}")]
-    LegacyDecode { name: &'static str, reason: String },
+    /// The first bytes do not match the expected magic prefix for this envelope type.
+    #[error("{name} envelope magic mismatch: expected {expected:?}, got {actual:?}")]
+    InvalidMagic { name: &'static str, expected: &'static [u8; 4], actual: Vec<u8> },
 }
 
 impl From<EnvelopeError> for CodecError {
@@ -82,9 +82,7 @@ pub trait EnvelopePayload: Compress + Decompress + Debug + Clone + PartialEq + E
 /// Generic compressed envelope for on-disk table values.
 ///
 /// Wraps a payload `T` with a fixed 8-byte header so that encoding can evolve
-/// independently from the in-memory types. Rows written before the envelope
-/// existed (legacy rows) are detected by the absence of the magic prefix and
-/// decoded via [`EnvelopePayload::from_legacy_bytes`].
+/// independently from the in-memory types.
 ///
 /// # Wire format (v1)
 ///
@@ -122,11 +120,11 @@ pub trait EnvelopePayload: Compress + Decompress + Debug + Clone + PartialEq + E
 /// The inner value serialized by the payload's own `to_bytes` method, then optionally compressed
 /// according to the encoding byte.
 ///
-/// ## Backward Compatibility
+/// ## Legacy Data
 ///
-/// Envelope will fallback to decode the payload as the inner type directly if the magic bytes
-/// do not match the expected value. This allows newer clients to read older pre-envelope data
-/// without requiring a database migration.
+/// Pre-envelope rows (raw postcard bytes without a magic prefix) are **not** handled by the
+/// envelope codec. They must be migrated to envelope format before they can be read.
+/// See [`Migration::backfill_receipt_envelopes`](crate::migration::Migration::backfill_receipt_envelopes).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Envelope<T: EnvelopePayload> {
     pub inner: T,
@@ -159,9 +157,11 @@ impl<T: EnvelopePayload> Envelope<T> {
 
     fn do_decompress(bytes: &[u8]) -> Result<Self, EnvelopeError> {
         if !bytes.starts_with(T::MAGIC) {
-            return T::decompress(bytes)
-                .map(|inner| Self { inner })
-                .map_err(|e| EnvelopeError::LegacyDecode { name: T::NAME, reason: e.to_string() });
+            return Err(EnvelopeError::InvalidMagic {
+                name: T::NAME,
+                expected: T::MAGIC,
+                actual: bytes.get(..4).unwrap_or(bytes).to_vec(),
+            });
         }
 
         if bytes.len() < ENVELOPE_HEADER_LEN {
@@ -292,12 +292,12 @@ mod tests {
     }
 
     #[test]
-    fn envelope_decompresses_legacy_bytes() {
+    fn envelope_rejects_legacy_bytes() {
         let payload = small_payload();
         let legacy = payload.data.as_bytes().to_vec();
 
-        let decompressed = Envelope::<TestPayload>::decompress(legacy).expect("decompress");
-        assert_eq!(decompressed.inner, payload);
+        let err = Envelope::<TestPayload>::do_decompress(&legacy).expect_err("must reject");
+        assert!(matches!(err, EnvelopeError::InvalidMagic { .. }));
     }
 
     #[test]

--- a/crates/storage/db/src/models/receipt.rs
+++ b/crates/storage/db/src/models/receipt.rs
@@ -51,14 +51,12 @@ mod tests {
     }
 
     #[test]
-    fn receipt_envelope_decompresses_legacy_postcard_bytes() {
+    fn receipt_envelope_rejects_legacy_postcard_bytes() {
         let receipt = sample_receipt();
         let legacy = postcard::to_stdvec(&receipt).expect("failed to serialize legacy receipt");
 
-        let decompressed =
-            ReceiptEnvelope::decompress(legacy).expect("failed to read legacy receipt");
-
-        assert_eq!(decompressed, ReceiptEnvelope::from(receipt));
+        ReceiptEnvelope::decompress(legacy)
+            .expect_err("legacy postcard bytes must not be accepted by envelope codec");
     }
 
     #[test]

--- a/crates/storage/db/tests/migration.rs
+++ b/crates/storage/db/tests/migration.rs
@@ -1,13 +1,27 @@
 use katana_db::abstraction::{Database, DbTx, DbTxMut};
+use katana_db::codecs::Compress;
 use katana_db::migration::Migration;
 use katana_db::models::class::MigratedCompiledClassHash;
 use katana_db::models::contract::ContractClassChange;
 use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey};
 use katana_db::version::{create_db_version_file, get_db_version, Version, LATEST_DB_VERSION};
 use katana_db::{tables, Db};
+use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
 use katana_primitives::state::StateUpdates;
+use katana_primitives::transaction::TxNumber;
 use katana_primitives::{ContractAddress, Felt};
 use katana_utils::arbitrary;
+
+/// Shadow table that maps to the physical `Receipts` table but uses the legacy
+/// raw-postcard `Receipt` codec as the value type (instead of `ReceiptEnvelope`).
+#[derive(Debug)]
+struct LegacyReceipts;
+
+impl tables::Table for LegacyReceipts {
+    const NAME: &'static str = tables::Receipts::NAME;
+    type Key = TxNumber;
+    type Value = Receipt;
+}
 
 /// Creates a DB at version 8 (before BlockStateUpdates was introduced) so that
 /// `Migration::is_needed()` returns true.
@@ -310,4 +324,145 @@ fn migration_not_needed_after_successful_run() {
     // Reopen the DB — should no longer need migration
     let db2 = Db::open_no_sync(dir.path()).unwrap();
     assert!(!Migration::new(&db2).is_needed());
+}
+
+// ---------------------------------------------------------------------------
+// Receipt envelope migration tests
+// ---------------------------------------------------------------------------
+
+fn sample_receipt(id: u64) -> Receipt {
+    Receipt::Invoke(InvokeTxReceipt {
+        revert_error: if id % 2 == 0 { None } else { Some(format!("revert-{id}")) },
+        events: Vec::new(),
+        fee: Default::default(),
+        messages_sent: Vec::new(),
+        execution_resources: Default::default(),
+    })
+}
+
+/// Write receipts using the legacy raw-postcard codec, run migration, then verify
+/// they can be read back through the new `ReceiptEnvelope` codec.
+#[test]
+fn receipt_migration_converts_legacy_to_envelope() {
+    let (db, _dir) = create_old_version_db();
+
+    // Need at least one block hash so the state-update backfill doesn't skip entirely.
+    {
+        let tx = db.tx_mut().unwrap();
+        tx.put::<tables::BlockHashes>(0u64, arbitrary!(Felt)).unwrap();
+        tx.commit().unwrap();
+    }
+
+    let receipts: Vec<Receipt> = (0..5).map(sample_receipt).collect();
+
+    // Write receipts using the legacy codec (raw postcard).
+    {
+        let tx = db.tx_mut().unwrap();
+        for (i, receipt) in receipts.iter().enumerate() {
+            tx.put::<LegacyReceipts>(i as u64, receipt.clone()).unwrap();
+        }
+        tx.commit().unwrap();
+    }
+
+    // Sanity: reading through the envelope codec should fail before migration
+    // because the raw postcard bytes don't start with the KRCP magic.
+    {
+        let tx = db.tx().unwrap();
+        let result = tx.get::<tables::Receipts>(0u64);
+        assert!(result.is_err(), "envelope codec should reject legacy postcard bytes");
+        tx.commit().unwrap();
+    }
+
+    Migration::new(&db).run().unwrap();
+
+    // After migration, every receipt should be readable through the envelope codec.
+    {
+        let tx = db.tx().unwrap();
+        for (i, expected) in receipts.iter().enumerate() {
+            let envelope = tx
+                .get::<tables::Receipts>(i as u64)
+                .expect("read should succeed")
+                .expect("entry should exist");
+            assert_eq!(&envelope.inner, expected, "receipt {i} mismatch");
+        }
+        tx.commit().unwrap();
+    }
+}
+
+/// An empty Receipts table should not cause the migration to fail.
+#[test]
+fn receipt_migration_empty_table_is_noop() {
+    let (db, _dir) = create_old_version_db();
+
+    Migration::new(&db).run().unwrap();
+
+    let tx = db.tx().unwrap();
+    let count = tx.entries::<tables::Receipts>().unwrap();
+    tx.commit().unwrap();
+    assert_eq!(count, 0);
+}
+
+/// Verify that migrated receipts are stored in the envelope wire format
+/// (first 4 bytes == KRCP magic).
+#[test]
+fn receipt_migration_produces_envelope_wire_format() {
+    let (db, _dir) = create_old_version_db();
+
+    {
+        let tx = db.tx_mut().unwrap();
+        tx.put::<tables::BlockHashes>(0u64, arbitrary!(Felt)).unwrap();
+        tx.put::<LegacyReceipts>(0u64, sample_receipt(0)).unwrap();
+        tx.commit().unwrap();
+    }
+
+    Migration::new(&db).run().unwrap();
+
+    // Read the migrated value back through the envelope codec and re-compress
+    // to inspect the wire format.
+    let tx = db.tx().unwrap();
+    let envelope = tx.get::<tables::Receipts>(0u64).unwrap().unwrap();
+    tx.commit().unwrap();
+
+    let bytes = envelope.compress().expect("compress");
+    assert_eq!(&bytes[..4], b"KRCP", "migrated receipt should have KRCP magic prefix");
+}
+
+/// Migration with more receipts than a single batch (BATCH_SIZE = 1000) to exercise
+/// the batching loop.
+#[test]
+fn receipt_migration_handles_multiple_batches() {
+    let (db, _dir) = create_old_version_db();
+
+    let num_receipts: u64 = 1500;
+
+    {
+        let tx = db.tx_mut().unwrap();
+        tx.put::<tables::BlockHashes>(0u64, arbitrary!(Felt)).unwrap();
+        for i in 0..num_receipts {
+            tx.put::<LegacyReceipts>(i, sample_receipt(i)).unwrap();
+        }
+        tx.commit().unwrap();
+    }
+
+    Migration::new(&db).run().unwrap();
+
+    let tx = db.tx().unwrap();
+    let count = tx.entries::<tables::Receipts>().unwrap();
+    tx.commit().unwrap();
+    assert_eq!(count, num_receipts as usize);
+
+    // Spot check first, last, and a middle entry.
+    let tx = db.tx().unwrap();
+    for i in [0, 749, num_receipts - 1] {
+        let envelope = tx.get::<tables::Receipts>(i).unwrap().unwrap();
+        assert_eq!(envelope.inner, sample_receipt(i), "receipt {i} mismatch");
+    }
+    tx.commit().unwrap();
+}
+
+/// Migration should not be needed for a database already at the current version.
+#[test]
+fn receipt_migration_not_needed_at_current_version() {
+    let db = Db::in_memory().unwrap();
+    assert!(!Migration::new(&db).is_needed());
 }


### PR DESCRIPTION
Adds a migration step that re-encodes receipts stored as raw postcard bytes (the legacy `Receipt` codec) into the `ReceiptEnvelope` format with compression. The migration reads rows through a shadow `LegacyReceipts` table type that decodes the old format, then writes them back through the real `Receipts` table which encodes as `ReceiptEnvelope`. This is gated on `RECEIPT_ENVELOPE_VERSION` so it only runs on older databases.

## Backward-compatibility

Before this, we guarantee database backward compatibility without requiring any migration whatsoever. Although it works up until now as all of the schema changes we've had are on the type level, this approach, however, breaks once we start introducing (or deleting) new table. Which is the case with #470 - where we've added a new independent table for storing the canonical block state updates instead of deriving them from the historical state index tables.

The `Envelope::decompress` backward-compatibility fallback is removed — legacy rows now produce an `InvalidMagic` error instead of silently falling back to raw deserialization. This makes the migration a hard requirement for databases with pre-envelope receipts.


### Migration is mandatory

Moving forward, backward compatibility is guaranteed through database migration. Katana will not reject database with older versions but expect unexpected behaviours with query results if not migrated.

The **minimum database version** that we can perform migration on is version **5**. 

The `katana-grpc` tests are expected to fail because of this until the database fixtures are migrated to the latest version.