### PR TITLE
feat(cli): add `katana db migrate` subcommand

### DIFF
--- a/bin/katana/src/cli/db/migrate.rs
+++ b/bin/katana/src/cli/db/migrate.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use clap::Args;
+use katana_db::migration::Migration;
+
+use super::open_db_rw;
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct MigrateArgs {
+    /// Path to the database directory.
+    #[arg(short, long)]
+    pub path: String,
+}
+
+impl MigrateArgs {
+    pub fn execute(self) -> Result<()> {
+        let db = open_db_rw(&self.path)?;
+        let migration = Migration::new(&db);
+
+        if !migration.is_needed() {
+            println!("Database is up to date. No migration needed.");
+            return Ok(());
+        }
+
+        println!("Running database migration...");
+        migration.run()?;
+        println!("Database migration completed successfully.");
+
+        Ok(())
+    }
+}

--- a/bin/katana/src/cli/db/mod.rs
+++ b/bin/katana/src/cli/db/mod.rs
@@ -5,6 +5,7 @@ use clap::{Args, Subcommand};
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::Table;
+mod migrate;
 mod prune;
 mod stats;
 mod trie;
@@ -26,6 +27,9 @@ enum Commands {
     /// Shows database version information
     Version(version::VersionArgs),
 
+    /// Run database migrations.
+    Migrate(migrate::MigrateArgs),
+
     /// Prune historical trie data.
     Prune(prune::PruneArgs),
 
@@ -36,6 +40,7 @@ enum Commands {
 impl DbArgs {
     pub fn execute(self) -> Result<()> {
         match self.commands {
+            Commands::Migrate(args) => args.execute(),
             Commands::Prune(args) => args.execute(),
             Commands::Stats(args) => args.execute(),
             Commands::Version(args) => args.execute(),


### PR DESCRIPTION
Add a dedicated `katana db migrate --path <dir>` command that runs database migrations independently of node startup. This allows users to migrate databases ahead of time, which is useful in CI/scripts and non-interactive environments. The existing interactive migration prompt during node startup is unchanged.

The failing tests are expected. They will be resolved by #481.