### PR TITLE
feat(cli): skip interactive input on db migration

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -521,11 +521,13 @@ impl SequencerNodeArgs {
     }
 
     fn db_config(&self) -> Result<DbConfig> {
-        let mut migrate = false;
+        let mut migrate = self.db.migrate;
 
-        if let Some(ref path) = self.db.dir {
-            if path.exists() {
-                migrate = prompt_db_migration(path)?;
+        if !migrate {
+            if let Some(ref path) = self.db.dir {
+                if path.exists() {
+                    migrate = prompt_db_migration(path)?;
+                }
             }
         }
 

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -165,11 +165,13 @@ impl FullNodeArgs {
     }
 
     fn db_config(&self) -> Result<DbConfig> {
-        let mut migrate = false;
+        let mut migrate = self.db.migrate;
 
-        if let Some(ref path) = self.db.dir {
-            if path.exists() {
-                migrate = prompt_db_migration(path)?;
+        if !migrate {
+            if let Some(ref path) = self.db.dir {
+                if path.exists() {
+                    migrate = prompt_db_migration(path)?;
+                }
             }
         }
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -62,7 +62,9 @@ pub struct DbOptions {
     pub dir: Option<PathBuf>,
 
     /// Run pending database migrations non-interactively.
-    #[arg(long = "auto-migrate")]
+    ///
+    /// This is a no-op if the database is already on the latest version.
+    #[arg(long = "db.auto-migrate")]
     #[serde(default)]
     pub migrate: bool,
 }

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -60,6 +60,11 @@ pub struct DbOptions {
     #[arg(value_name = "PATH")]
     #[serde(default, alias = "db_dir")]
     pub dir: Option<PathBuf>,
+
+    /// Run pending database migrations non-interactively.
+    #[arg(long = "auto-migrate")]
+    #[serde(default)]
+    pub migrate: bool,
 }
 
 impl DbOptions {
@@ -71,6 +76,9 @@ impl DbOptions {
         if let Some(other) = other {
             if self.dir.is_none() {
                 self.dir = other.dir.clone();
+            }
+            if !self.migrate {
+                self.migrate = other.migrate;
             }
         }
     }

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -212,6 +212,9 @@ pub struct Katana {
     enable_cartridge_paymaster: bool,
     cartridge_api_url: Option<String>,
 
+    // Database options
+    auto_migrate: bool,
+
     // Others
     timeout: Option<u64>,
     program: Option<PathBuf>,
@@ -420,6 +423,12 @@ impl Katana {
         self
     }
 
+    /// Automatically run pending database migrations without an interactive prompt.
+    pub const fn auto_migrate(mut self, auto_migrate: bool) -> Self {
+        self.auto_migrate = auto_migrate;
+        self
+    }
+
     /// Sets the timeout which will be used when the `katana` instance is launched.
     pub const fn timeout(mut self, timeout: u64) -> Self {
         self.timeout = Some(timeout);
@@ -466,6 +475,10 @@ impl Katana {
 
         if let Some(data_dir) = self.data_dir {
             cmd.arg("--data-dir").arg(data_dir);
+        }
+
+        if self.auto_migrate {
+            cmd.arg("--db.auto-migrate");
         }
 
         if let Some(url) = self.l1_provider {

--- a/tests/db-compat/src/main.rs
+++ b/tests/db-compat/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         Katana::new()
     };
 
-    let instance = katana.data_dir(temp_dir.path()).spawn();
+    let instance = katana.data_dir(temp_dir.path()).auto_migrate(true).spawn();
 
     // Create HTTP client for Katana's RPC
     let url = format!("http://{}", instance.rpc_addr());


### PR DESCRIPTION
Adds a `--db.auto-migrate` flag that runs pending database migrations without prompting. This is a no-op if the database is already on the latest version. Intended for programmatic and CI/CD environments where interactive input is not available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)