### PR TITLE
refactor(db): migration progress ETA

### DIFF
--- a/crates/storage/db/src/migration/mod.rs
+++ b/crates/storage/db/src/migration/mod.rs
@@ -205,7 +205,7 @@ impl<'a> Migration<'a> {
             ProgressStyle::default_bar()
                 .template(&format!(
                     "[Migrating] \x1b[1;33m{padded_id}\x1b[0m {{bar:40.cyan/blue}} \
-                     {{pos}}/{{len}} [{{elapsed_precise}}] {{per_sec}}"
+                     {{percent:>3}}/100% ({remaining}) [{{elapsed_precise}}] ETA: {{eta}}"
                 ))
                 .expect("valid format"),
         );


### PR DESCRIPTION
## Summary
- Replace raw `pos/len` counters and `per_sec` rate in the migration progress bar with a fixed-width percentage, total entry count, and ETA
- Before: `185000/3470960 [00:11:10] 202.53/s`
- After: ` 10/100% (3470960) [00:11:10] ETA: 1h 40m`