### PR TITLE
fix(bin): interactive prompt on `katana db migrate`

### DIFF
--- a/bin/katana/src/cli/db/migrate.rs
+++ b/bin/katana/src/cli/db/migrate.rs
@@ -1,9 +1,17 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::Args;
+use katana_cli::utils::prompt_db_migration;
 use katana_db::migration::Migration;
 
 use super::open_db_rw;
 
+/// Migrate the database to the latest version.
+///
+/// Check whether the database at the specified path requires migration. If the
+/// database is already up to date, exit with no changes. Otherwise, prompt for
+/// confirmation before applying the migration.
 #[derive(Debug, Args)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct MigrateArgs {
@@ -15,17 +23,18 @@ pub struct MigrateArgs {
 impl MigrateArgs {
     pub fn execute(self) -> Result<()> {
         let db = open_db_rw(&self.path)?;
-        let migration = Migration::new(&db);
+        let migration = Migration::new_v9(&db);
 
         if !migration.is_needed() {
             println!("Database is up to date. No migration needed.");
             return Ok(());
         }
 
-        println!("Running database migration...");
-        migration.run()?;
-        println!("Database migration completed successfully.");
+        if !prompt_db_migration(&PathBuf::from(&self.path))? {
+            eprintln!("Migration cancelled.");
+            return Ok(());
+        }
 
-        Ok(())
+        Ok(migration.run()?)
     }
 }


### PR DESCRIPTION
## Summary
- Add doc comments to `MigrateArgs` struct for the `katana db migrate` CLI command
- Update migration to use `Migration::new_v9` and add interactive confirmation prompt before running
