### PR TITLE
feat(sync): add JSON-RPC as alternative sync source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6261,6 +6261,7 @@ dependencies = [
  "katana-rpc-server",
  "katana-rpc-types",
  "katana-stage",
+ "katana-starknet",
  "katana-tasks",
  "parking_lot",
  "serde",

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -5,7 +5,7 @@ use katana_full_node::config::gateway::GatewayConfig;
 use katana_full_node::config::metrics::MetricsConfig;
 use katana_full_node::config::rpc::RpcConfig;
 use katana_full_node::config::trie::TrieConfig;
-use katana_full_node::Network;
+use katana_full_node::{Network, SyncSource};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use url::Url;
@@ -147,9 +147,16 @@ impl FullNodeArgs {
             gateway_api_key: self.gateway_api_key.clone(),
             trie: TrieConfig { compute: !self.trie.disable },
             max_sync_tip: self.max_sync_tip,
-            sync_gateway: self.sync_gateway.clone(),
-            sync_rpc: self.sync_rpc.clone(),
+            sync_source: self.sync_source(),
         })
+    }
+
+    fn sync_source(&self) -> Option<SyncSource> {
+        if let Some(ref url) = self.sync_rpc {
+            Some(SyncSource::JsonRpc(url.clone()))
+        } else {
+            self.sync_gateway.clone().map(SyncSource::Gateway)
+        }
     }
 
     fn pruning_config(&self) -> katana_full_node::PruningConfig {

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -72,7 +72,19 @@ pub struct FullNodeArgs {
     /// feeder gateway.
     #[arg(long = "sync.gateway")]
     #[arg(value_name = "URL")]
+    #[arg(conflicts_with = "sync_rpc")]
     pub sync_gateway: Option<Url>,
+
+    /// JSON-RPC endpoint URL to use as the block download source instead of
+    /// the feeder gateway. When set, blocks and classes are fetched via
+    /// JSON-RPC (`starknet_getBlockWithReceipts`, `starknet_getStateUpdate`,
+    /// `starknet_getClass`).
+    ///
+    /// This is mainly intended for development and testing purposes.
+    #[arg(long = "sync.rpc")]
+    #[arg(value_name = "URL")]
+    #[arg(conflicts_with = "sync_gateway")]
+    pub sync_rpc: Option<Url>,
 }
 
 impl FullNodeArgs {
@@ -136,6 +148,7 @@ impl FullNodeArgs {
             trie: TrieConfig { compute: !self.trie.disable },
             max_sync_tip: self.max_sync_tip,
             sync_gateway: self.sync_gateway.clone(),
+            sync_rpc: self.sync_rpc.clone(),
         })
     }
 

--- a/crates/node/full/Cargo.toml
+++ b/crates/node/full/Cargo.toml
@@ -24,6 +24,7 @@ katana-rpc-server.workspace = true
 katana-rpc-api.workspace = true
 katana-rpc-types.workspace = true
 katana-stage.workspace = true
+katana-starknet.workspace = true
 katana-tasks.workspace = true
 
 anyhow.workspace = true

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -182,10 +182,10 @@ impl Node {
 
         if let Some(SyncSource::JsonRpc(ref rpc_url)) = config.sync_source {
             let rpc_client = katana_starknet::rpc::Client::new(rpc_url.clone());
-            let block_downloader = JsonRpcBlockDownloader::new(rpc_client.clone());
+            let block_downloader = JsonRpcBlockDownloader::new_json_rpc(rpc_client.clone(), 20);
             pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
 
-            let class_downloader = JsonRpcClassDownloader::new(rpc_client);
+            let class_downloader = JsonRpcClassDownloader::new(rpc_client, 20);
             pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
         } else {
             let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -33,7 +33,8 @@ use katana_rpc_api::starknet::{StarknetApiServer, StarknetTraceApiServer, Starkn
 use katana_rpc_server::cors::Cors;
 use katana_rpc_server::starknet::{StarknetApi, StarknetApiConfig};
 use katana_rpc_server::{RpcServer, RpcServerHandle};
-use katana_stage::blocks::BatchBlockDownloader;
+use katana_stage::blocks::{BatchBlockDownloader, JsonRpcBlockDownloader};
+use katana_stage::classes::{GatewayClassDownloader, JsonRpcClassDownloader};
 use katana_stage::{Blocks, Classes, StateTrie};
 use katana_tasks::TaskManager;
 use tracing::{error, info};
@@ -86,6 +87,8 @@ pub struct Config {
     pub max_sync_tip: Option<u64>,
     /// Custom feeder gateway base URL to sync from instead of the default network gateway.
     pub sync_gateway: Option<Url>,
+    /// JSON-RPC endpoint URL to use as the block download source instead of the gateway.
+    pub sync_rpc: Option<Url>,
 }
 
 #[derive(Debug)]
@@ -170,9 +173,20 @@ impl Node {
             Network::Sepolia => katana_primitives::chain::ChainId::SEPOLIA,
         };
 
-        let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
-        pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
-        pipeline.add_stage(Classes::new(storage_provider.clone(), gateway_client.clone(), 20));
+        if let Some(ref rpc_url) = config.sync_rpc {
+            let rpc_client = katana_starknet::rpc::Client::new(rpc_url.clone());
+            let block_downloader = JsonRpcBlockDownloader::new(rpc_client.clone());
+            pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
+
+            let class_downloader = JsonRpcClassDownloader::new(rpc_client);
+            pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
+        } else {
+            let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
+            pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
+
+            let class_downloader = GatewayClassDownloader::new(gateway_client.clone(), 20);
+            pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
+        }
         if config.trie.compute {
             pipeline.add_stage(StateTrie::new(storage_provider.clone(), task_spawner.clone()));
         }

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -85,10 +85,17 @@ pub struct Config {
     /// The maximum block number the pipeline will sync to. When set, the pipeline
     /// will stop syncing after reaching this block while the node remains running.
     pub max_sync_tip: Option<u64>,
-    /// Custom feeder gateway base URL to sync from instead of the default network gateway.
-    pub sync_gateway: Option<Url>,
-    /// JSON-RPC endpoint URL to use as the block download source instead of the gateway.
-    pub sync_rpc: Option<Url>,
+    /// The source to sync blocks and classes from.
+    pub sync_source: Option<SyncSource>,
+}
+
+/// The source from which the node downloads blocks and classes.
+#[derive(Debug, Clone)]
+pub enum SyncSource {
+    /// Custom feeder gateway base URL instead of the default network gateway.
+    Gateway(Url),
+    /// JSON-RPC endpoint URL.
+    JsonRpc(Url),
 }
 
 #[derive(Debug)]
@@ -136,7 +143,7 @@ impl Node {
 
         // --- build gateway client
 
-        let gateway_client = if let Some(ref base_url) = config.sync_gateway {
+        let gateway_client = if let Some(SyncSource::Gateway(ref base_url)) = config.sync_source {
             let gateway = base_url.join("gateway").expect("valid URL join");
             let feeder_gateway = base_url.join("feeder_gateway").expect("valid URL join");
             SequencerGateway::new(gateway, feeder_gateway)
@@ -173,7 +180,7 @@ impl Node {
             Network::Sepolia => katana_primitives::chain::ChainId::SEPOLIA,
         };
 
-        if let Some(ref rpc_url) = config.sync_rpc {
+        if let Some(SyncSource::JsonRpc(ref rpc_url)) = config.sync_source {
             let rpc_client = katana_starknet::rpc::Client::new(rpc_url.clone());
             let block_downloader = JsonRpcBlockDownloader::new(rpc_client.clone());
             pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));

--- a/crates/rpc/rpc-types/src/receipt.rs
+++ b/crates/rpc/rpc-types/src/receipt.rs
@@ -4,7 +4,7 @@ use katana_primitives::fee::{FeeInfo, PriceUnit};
 use katana_primitives::receipt::{self, Event, MessageToL1, Receipt};
 use katana_primitives::transaction::TxHash;
 use katana_primitives::{ContractAddress, Felt, B256};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RpcTxReceiptWithHash {
@@ -127,6 +127,7 @@ pub struct RpcInvokeTxReceipt {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RpcL1HandlerTxReceipt {
+    #[serde(deserialize_with = "deserialize_message_hash")]
     pub message_hash: B256,
     pub actual_fee: FeePayment,
     pub finality_status: FinalityStatus,
@@ -490,4 +491,32 @@ impl From<RpcTxReceipt> for Receipt {
             RpcTxReceipt::Deploy(_) => unimplemented!(),
         }
     }
+}
+
+/// Deserializes `message_hash` from a hex string that may have an odd number of digits.
+///
+/// `B256`'s default deserializer (from alloy_primitives) requires an even-length, zero-padded
+/// hex string. Some RPC servers return hex values with odd length (e.g., `"0x123"` instead of
+/// `"0x0123"`). This deserializer normalizes the input by left-padding with a zero when needed.
+///
+/// We cannot use `Felt` as an intermediary because `message_hash` is a 256-bit Ethereum keccak
+/// hash that can exceed the Stark field modulus.
+fn deserialize_message_hash<'de, D: Deserializer<'de>>(deserializer: D) -> Result<B256, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    let hex_str = s
+        .strip_prefix("0x")
+        .ok_or_else(|| serde::de::Error::custom("expected hex string to be prefixed by '0x'"))?;
+
+    // Left-pad to 64 hex chars (32 bytes) for B256
+    let padded = format!("{hex_str:0>64}");
+    if padded.len() != 64 {
+        return Err(serde::de::Error::custom("message_hash hex too long for B256"));
+    }
+
+    let mut bytes = [0u8; 32];
+    for i in 0..32 {
+        bytes[i] =
+            u8::from_str_radix(&padded[i * 2..i * 2 + 2], 16).map_err(serde::de::Error::custom)?;
+    }
+    Ok(B256::from(bytes))
 }

--- a/crates/starknet/src/rpc.rs
+++ b/crates/starknet/src/rpc.rs
@@ -362,6 +362,23 @@ pub enum Error {
     Client(jsonrpsee::core::client::Error),
 }
 
+impl Error {
+    /// Returns `true` if the error is transient and the request may succeed on retry.
+    ///
+    /// Transport errors (network issues) and request timeouts are considered retryable.
+    /// Parse errors, API errors, and other client errors are not.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Error::Client(inner) => matches!(
+                inner,
+                jsonrpsee::core::client::Error::Transport(_)
+                    | jsonrpsee::core::client::Error::RequestTimeout
+            ),
+            Error::Starknet(_) => false,
+        }
+    }
+}
+
 impl From<jsonrpsee::core::client::Error> for Error {
     fn from(err: jsonrpsee::core::client::Error) -> Self {
         match err {

--- a/crates/sync/stage/src/blocks/downloader.rs
+++ b/crates/sync/stage/src/blocks/downloader.rs
@@ -398,8 +398,7 @@ pub mod json_rpc {
                         }
                     }
                     Err(err) => match err {
-                        // Transport/client errors are retryable
-                        Error::Rpc(katana_starknet::rpc::Error::Client(_)) => {
+                        Error::Rpc(ref rpc_err) if rpc_err.is_retryable() => {
                             DownloaderResult::Retry(err)
                         }
                         _ => DownloaderResult::Err(err),

--- a/crates/sync/stage/src/blocks/downloader.rs
+++ b/crates/sync/stage/src/blocks/downloader.rs
@@ -310,20 +310,19 @@ pub mod json_rpc {
     use starknet::core::types::ResourcePrice;
     use tracing::error;
 
-    use super::{BlockData, BlockDownloader};
+    use super::{BatchBlockDownloader, BlockData};
+    use crate::downloader::{Downloader, DownloaderResult};
 
-    /// A [`BlockDownloader`] that fetches blocks via JSON-RPC.
-    ///
-    /// This downloads blocks one at a time sequentially using
-    /// `starknet_getBlockWithReceipts` and `starknet_getStateUpdate`.
-    #[derive(Debug)]
-    pub struct JsonRpcBlockDownloader {
-        client: JsonRpcClient,
-    }
+    pub type JsonRpcBlockDownloader = BatchBlockDownloader<JsonRpcDownloader>;
 
-    impl JsonRpcBlockDownloader {
-        pub fn new(client: JsonRpcClient) -> Self {
-            Self { client }
+    impl BatchBlockDownloader<JsonRpcDownloader> {
+        /// Create a new [`BatchBlockDownloader`] using a JSON-RPC endpoint for downloading
+        /// blocks.
+        pub fn new_json_rpc(
+            client: JsonRpcClient,
+            batch_size: usize,
+        ) -> BatchBlockDownloader<JsonRpcDownloader> {
+            Self::new(JsonRpcDownloader::new(client), batch_size)
         }
     }
 
@@ -336,20 +335,33 @@ pub mod json_rpc {
         Other(#[from] anyhow::Error),
     }
 
-    impl BlockDownloader for JsonRpcBlockDownloader {
+    /// Internal [`Downloader`] implementation that uses JSON-RPC for downloading a block.
+    #[derive(Debug)]
+    pub struct JsonRpcDownloader {
+        client: JsonRpcClient,
+    }
+
+    impl JsonRpcDownloader {
+        pub fn new(client: JsonRpcClient) -> Self {
+            Self { client }
+        }
+    }
+
+    impl Downloader for JsonRpcDownloader {
+        type Key = BlockNumber;
+        type Value = BlockData;
         type Error = Error;
 
-        async fn download_blocks(
+        #[allow(clippy::manual_async_fn)]
+        fn download(
             &self,
-            from: BlockNumber,
-            to: BlockNumber,
-        ) -> Result<Vec<BlockData>, Self::Error> {
-            let mut blocks = Vec::with_capacity((to - from + 1) as usize);
-
-            for block_num in from..=to {
+            key: &Self::Key,
+        ) -> impl std::future::Future<Output = DownloaderResult<Self::Value, Self::Error>> {
+            let block_num = *key;
+            async move {
                 let block_id = BlockIdOrTag::Number(block_num);
 
-                let (block_resp, state_update) = tokio::try_join!(
+                let result = tokio::try_join!(
                     async {
                         self.client
                             .get_block_with_receipts(block_id)
@@ -376,13 +388,24 @@ pub mod json_rpc {
                             })
                             .map_err(Error::from)
                     },
-                )?;
+                );
 
-                let block_data = BlockData::from_rpc(block_resp, state_update)?;
-                blocks.push(block_data);
+                match result {
+                    Ok((block_resp, state_update)) => {
+                        match BlockData::from_rpc(block_resp, state_update) {
+                            Ok(data) => DownloaderResult::Ok(data),
+                            Err(e) => DownloaderResult::Err(Error::from(e)),
+                        }
+                    }
+                    Err(err) => match err {
+                        // Transport/client errors are retryable
+                        Error::Rpc(katana_starknet::rpc::Error::Client(_)) => {
+                            DownloaderResult::Retry(err)
+                        }
+                        _ => DownloaderResult::Err(err),
+                    },
+                }
             }
-
-            Ok(blocks)
         }
     }
 

--- a/crates/sync/stage/src/classes/downloader.rs
+++ b/crates/sync/stage/src/classes/downloader.rs
@@ -116,10 +116,7 @@ pub mod json_rpc {
                     );
                 }) {
                     Ok(data) => DownloaderResult::Ok(data),
-                    // Transport/client errors are retryable
-                    Err(err @ katana_starknet::rpc::Error::Client(_)) => {
-                        DownloaderResult::Retry(err)
-                    }
+                    Err(err) if err.is_retryable() => DownloaderResult::Retry(err),
                     Err(err) => DownloaderResult::Err(err),
                 }
             }

--- a/crates/sync/stage/src/classes/downloader.rs
+++ b/crates/sync/stage/src/classes/downloader.rs
@@ -57,22 +57,25 @@ pub mod gateway {
 }
 
 pub mod json_rpc {
+    use std::future::Future;
+
     use katana_primitives::block::BlockIdOrTag;
     use katana_rpc_types::Class;
     use katana_starknet::rpc::Client as JsonRpcClient;
     use tracing::error;
 
     use super::super::{ClassDownloadKey, ClassDownloader};
+    use crate::downloader::{BatchDownloader, Downloader, DownloaderResult};
 
     /// A [`ClassDownloader`] that fetches classes via JSON-RPC using `starknet_getClass`.
     #[derive(Debug)]
     pub struct JsonRpcClassDownloader {
-        client: JsonRpcClient,
+        inner: BatchDownloader<JsonRpcDownloader>,
     }
 
     impl JsonRpcClassDownloader {
-        pub fn new(client: JsonRpcClient) -> Self {
-            Self { client }
+        pub fn new(client: JsonRpcClient, batch_size: usize) -> Self {
+            Self { inner: BatchDownloader::new(JsonRpcDownloader { client }, batch_size) }
         }
     }
 
@@ -83,23 +86,43 @@ pub mod json_rpc {
             &self,
             keys: Vec<ClassDownloadKey>,
         ) -> Result<Vec<Class>, Self::Error> {
-            let mut classes = Vec::with_capacity(keys.len());
+            self.inner.download(keys).await
+        }
+    }
 
-            for key in keys {
+    #[derive(Debug)]
+    struct JsonRpcDownloader {
+        client: JsonRpcClient,
+    }
+
+    impl Downloader for JsonRpcDownloader {
+        type Key = ClassDownloadKey;
+        type Value = Class;
+        type Error = katana_starknet::rpc::Error;
+
+        #[allow(clippy::manual_async_fn)]
+        fn download(
+            &self,
+            key: &Self::Key,
+        ) -> impl Future<Output = DownloaderResult<Self::Value, Self::Error>> {
+            async {
                 let block_id = BlockIdOrTag::Number(key.block);
-                let class =
-                    self.client.get_class(block_id, key.class_hash).await.inspect_err(|e| {
-                        error!(
-                            block = %key.block,
-                            class_hash = %format!("{:#x}", key.class_hash),
-                            error = %e,
-                            "Error downloading class via JSON-RPC."
-                        );
-                    })?;
-                classes.push(class);
+                match self.client.get_class(block_id, key.class_hash).await.inspect_err(|e| {
+                    error!(
+                        block = %key.block,
+                        class_hash = %format!("{:#x}", key.class_hash),
+                        error = %e,
+                        "Error downloading class via JSON-RPC."
+                    );
+                }) {
+                    Ok(data) => DownloaderResult::Ok(data),
+                    // Transport/client errors are retryable
+                    Err(err @ katana_starknet::rpc::Error::Client(_)) => {
+                        DownloaderResult::Retry(err)
+                    }
+                    Err(err) => DownloaderResult::Err(err),
+                }
             }
-
-            Ok(classes)
         }
     }
 }

--- a/crates/sync/stage/src/classes/downloader.rs
+++ b/crates/sync/stage/src/classes/downloader.rs
@@ -1,0 +1,105 @@
+pub mod gateway {
+    use std::future::Future;
+
+    use katana_gateway_client::Client as SequencerGateway;
+    use katana_rpc_types::Class;
+
+    use super::super::{ClassDownloadKey, ClassDownloader};
+    use crate::downloader::{BatchDownloader, Downloader, DownloaderResult};
+
+    /// A [`ClassDownloader`] that fetches classes from the Starknet feeder gateway.
+    #[derive(Debug)]
+    pub struct GatewayClassDownloader {
+        inner: BatchDownloader<GatewayDownloader>,
+    }
+
+    impl GatewayClassDownloader {
+        pub fn new(gateway: SequencerGateway, batch_size: usize) -> Self {
+            Self { inner: BatchDownloader::new(GatewayDownloader { gateway }, batch_size) }
+        }
+    }
+
+    impl ClassDownloader for GatewayClassDownloader {
+        type Error = katana_gateway_client::Error;
+
+        async fn download_classes(
+            &self,
+            keys: Vec<ClassDownloadKey>,
+        ) -> Result<Vec<Class>, Self::Error> {
+            self.inner.download(keys).await
+        }
+    }
+
+    #[derive(Debug)]
+    struct GatewayDownloader {
+        gateway: SequencerGateway,
+    }
+
+    impl Downloader for GatewayDownloader {
+        type Key = ClassDownloadKey;
+        type Value = Class;
+        type Error = katana_gateway_client::Error;
+
+        #[allow(clippy::manual_async_fn)]
+        fn download(
+            &self,
+            key: &Self::Key,
+        ) -> impl Future<Output = DownloaderResult<Self::Value, Self::Error>> {
+            async {
+                match self.gateway.get_class(key.class_hash, key.block.into()).await {
+                    Ok(data) => DownloaderResult::Ok(data),
+                    Err(err) if err.is_rate_limited() => DownloaderResult::Retry(err),
+                    Err(err) => DownloaderResult::Err(err),
+                }
+            }
+        }
+    }
+}
+
+pub mod json_rpc {
+    use katana_primitives::block::BlockIdOrTag;
+    use katana_rpc_types::Class;
+    use katana_starknet::rpc::Client as JsonRpcClient;
+    use tracing::error;
+
+    use super::super::{ClassDownloadKey, ClassDownloader};
+
+    /// A [`ClassDownloader`] that fetches classes via JSON-RPC using `starknet_getClass`.
+    #[derive(Debug)]
+    pub struct JsonRpcClassDownloader {
+        client: JsonRpcClient,
+    }
+
+    impl JsonRpcClassDownloader {
+        pub fn new(client: JsonRpcClient) -> Self {
+            Self { client }
+        }
+    }
+
+    impl ClassDownloader for JsonRpcClassDownloader {
+        type Error = katana_starknet::rpc::Error;
+
+        async fn download_classes(
+            &self,
+            keys: Vec<ClassDownloadKey>,
+        ) -> Result<Vec<Class>, Self::Error> {
+            let mut classes = Vec::with_capacity(keys.len());
+
+            for key in keys {
+                let block_id = BlockIdOrTag::Number(key.block);
+                let class =
+                    self.client.get_class(block_id, key.class_hash).await.inspect_err(|e| {
+                        error!(
+                            block = %key.block,
+                            class_hash = %format!("{:#x}", key.class_hash),
+                            error = %e,
+                            "Error downloading class via JSON-RPC."
+                        );
+                    })?;
+                classes.push(class);
+            }
+
+            Ok(classes)
+        }
+    }
+}

--- a/crates/sync/stage/src/classes/mod.rs
+++ b/crates/sync/stage/src/classes/mod.rs
@@ -3,8 +3,6 @@ use std::future::Future;
 use anyhow::Result;
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
-use katana_gateway_client::Client as SequencerGateway;
-use katana_gateway_types::ContractClass as GatewayContractClass;
 use katana_primitives::block::BlockNumber;
 use katana_primitives::class::{ClassHash, ContractClass};
 use katana_provider::api::contract::ContractClassWriter;
@@ -12,6 +10,7 @@ use katana_provider::api::state_update::StateUpdateProvider;
 use katana_provider::api::ProviderError;
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderFactory};
 use katana_rpc_types::class::ConversionError;
+use katana_rpc_types::Class;
 use rayon::prelude::*;
 use tracing::{debug, error, info_span, Instrument};
 
@@ -19,32 +18,45 @@ use super::{
     PruneInput, PruneOutput, PruneResult, Stage, StageExecutionInput, StageExecutionOutput,
     StageResult,
 };
-use crate::downloader::{BatchDownloader, Downloader, DownloaderResult};
+mod downloader;
+
+pub use downloader::gateway::GatewayClassDownloader;
+pub use downloader::json_rpc::JsonRpcClassDownloader;
+
+/// Trait for downloading contract class artifacts.
+///
+/// This provides a stage-specific abstraction for downloading classes, allowing different
+/// implementations (e.g., gateway-based, JSON-RPC-based) to be used with the [`Classes`] stage.
+pub trait ClassDownloader: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Downloads the class artifact for the given class hash at the given block.
+    fn download_classes(
+        &self,
+        keys: Vec<ClassDownloadKey>,
+    ) -> impl Future<Output = Result<Vec<Class>, Self::Error>> + Send;
+}
 
 /// A stage for downloading and storing contract classes.
-pub struct Classes {
+pub struct Classes<D> {
     provider: DbProviderFactory,
-    downloader: BatchDownloader<ClassDownloader>,
+    downloader: D,
     /// Thread pool for parallel class hash verification
     verification_pool: rayon::ThreadPool,
 }
 
-impl std::fmt::Debug for Classes {
+impl<D> std::fmt::Debug for Classes<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Classes")
             .field("provider", &self.provider)
-            .field("downloader", &self.downloader)
             .field("verification_pool", &"<ThreadPool>")
             .finish()
     }
 }
 
-impl Classes {
-    /// Create a new Classes stage using the Feeder Gateway downloader.
-    pub fn new(provider: DbProviderFactory, gateway: SequencerGateway, batch_size: usize) -> Self {
-        let downloader = ClassDownloader { gateway };
-        let downloader = BatchDownloader::new(downloader, batch_size);
-
+impl<D> Classes<D> {
+    /// Create a new [`Classes`] stage with the given downloader.
+    pub fn new(provider: DbProviderFactory, downloader: D) -> Self {
         // A dedicated thread pool for class hash verification
         let verification_pool = rayon::ThreadPoolBuilder::new()
             .build()
@@ -81,7 +93,7 @@ impl Classes {
     async fn verify_class_hashes(
         &self,
         class_hashes: &[ClassDownloadKey],
-        class_artifacts: Vec<GatewayContractClass>,
+        class_artifacts: Vec<Class>,
     ) -> Result<Vec<ContractClass>, Error> {
         let (tx, rx) = oneshot::channel();
         let class_hashes = class_hashes.to_vec();
@@ -90,11 +102,11 @@ impl Classes {
             let result = class_hashes
                 .par_iter()
                 .zip(class_artifacts.into_par_iter())
-                .map(|(key, gateway_class)| {
+                .map(|(key, class)| {
                     let block = key.block;
 
                     let expected_hash = key.class_hash;
-                    let computed_hash = gateway_class.hash();
+                    let computed_hash = class.hash();
 
                     if computed_hash != expected_hash {
                         return Err(Error::ClassHashMismatch {
@@ -104,7 +116,7 @@ impl Classes {
                         });
                     }
 
-                    ContractClass::try_from(gateway_class).map_err(Error::Conversion)
+                    ContractClass::try_from(class).map_err(Error::Conversion)
                 })
                 .collect::<Result<Vec<_>, Error>>();
 
@@ -115,7 +127,10 @@ impl Classes {
     }
 }
 
-impl Stage for Classes {
+impl<D> Stage for Classes<D>
+where
+    D: ClassDownloader,
+{
     fn id(&self) -> &'static str {
         "Classes"
     }
@@ -132,10 +147,10 @@ impl Stage for Classes {
                 // fetch the classes artifacts
                 let class_artifacts = self
                     .downloader
-                    .download(declared_class_hashes.clone())
+                    .download_classes(declared_class_hashes.clone())
                     .instrument(info_span!(target: "stage", "classes.download", %total_classes))
                     .await
-                    .map_err(Error::Gateway)?;
+                    .map_err(|e| Error::Download(Box::new(e)))?;
 
                 let verified_classes =
                     self.verify_class_hashes(&declared_class_hashes, class_artifacts).await?;
@@ -174,9 +189,9 @@ pub enum Error {
         block: BlockNumber,
     },
 
-    /// Error returnd by the client used to download the classes from.
+    /// Error returned by the downloader used to download the classes.
     #[error(transparent)]
-    Gateway(#[from] katana_gateway_client::Error),
+    Download(Box<dyn std::error::Error + Send + Sync>),
 
     /// Error that can occur when converting the classes types to the internal types.
     #[error(transparent)]
@@ -211,34 +226,9 @@ pub enum Error {
     },
 }
 
-#[derive(Debug)]
-struct ClassDownloader {
-    gateway: SequencerGateway,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ClassDownloadKey {
+pub struct ClassDownloadKey {
     /// The hash of the class artifact to download
-    class_hash: ClassHash,
-    block: BlockNumber,
-}
-
-impl Downloader for ClassDownloader {
-    type Key = ClassDownloadKey;
-    type Value = GatewayContractClass;
-    type Error = katana_gateway_client::Error;
-
-    #[allow(clippy::manual_async_fn)]
-    fn download(
-        &self,
-        key: &Self::Key,
-    ) -> impl Future<Output = DownloaderResult<Self::Value, Self::Error>> {
-        async {
-            match self.gateway.get_class(key.class_hash, key.block.into()).await {
-                Ok(data) => DownloaderResult::Ok(data),
-                Err(err) if err.is_rate_limited() => DownloaderResult::Retry(err),
-                Err(err) => DownloaderResult::Err(err),
-            }
-        }
-    }
+    pub class_hash: ClassHash,
+    pub block: BlockNumber,
 }


### PR DESCRIPTION
Adds a `--sync.rpc <URL>` CLI flag to the full node for using a JSON-RPC endpoint as the download source for blocks and classes instead of the feeder gateway. When set, syncing uses `starknet_getBlockWithReceipts` and `starknet_getStateUpdate` for `Blocks` stage, and `starknet_getClass` for `Classes`. 

The flag conflicts with `--sync.gateway` so only one source can be used at a time. Mainly intended for **development and testing**.

The `Classes` stage is refactored from a concrete gateway-coupled struct into a generic `Classes<D>` parameterized over a `ClassDownloader` trait, matching the existing `BlockDownloader` pattern used by the `Blocks` stage. Both gateway and JSON-RPC implementations are provided.
