### PR TITLE
fix(full-node): stop `PreconfBlockWatcher` restart loop on shutdown

### DIFF
--- a/crates/node/full/src/pending/mod.rs
+++ b/crates/node/full/src/pending/mod.rs
@@ -47,10 +47,8 @@ impl PreconfStateFactory {
         };
 
         tokio::spawn(async move {
-            loop {
-                if let Err(error) = worker.run().await {
-                    error!(%error, "PreconfBlockWatcher returned with an error.");
-                }
+            if let Err(error) = worker.run().await {
+                error!(%error, "PreconfBlockWatcher returned with an error.");
             }
         });
 
@@ -174,8 +172,7 @@ impl PreconfBlockWatcher {
                 }
             } else {
                 if let Err(err) = self.latest_synced_block.changed().await {
-                    error!(error = ?err, "Error receiving latest block number.");
-                    break;
+                    return Err(anyhow!(err));
                 }
 
                 // reset preconf state
@@ -189,7 +186,5 @@ impl PreconfBlockWatcher {
 
             tokio::time::sleep(self.interval).await
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
Stop repeated `RecvError` error logs when shutting down by removing the restart loop around `PreconfBlockWatcher::run()` and propagating the channel-closed error instead of logging and breaking.