### PR TITLE
fix(sync): block hash mismatch for early mainnet blocks

### DIFF
--- a/crates/gateway/gateway-client/tests/fixtures/0.7.0/block/mainnet_833.json
+++ b/crates/gateway/gateway-client/tests/fixtures/0.7.0/block/mainnet_833.json
@@ -1,0 +1,1107 @@
+{
+  "status": "ACCEPTED_ON_L1",
+  "block_hash": "0x197cd4f24d30274f0674aec74b86e0405c13de06771cfa1ee472b0d2437db7c",
+  "block_number": 833,
+  "parent_block_hash": "0x2e8508c8488acca8cc1141afa714bb3c74a44b2ab47af60a117c8b85a599874",
+  "l1_da_mode": "CALLDATA",
+  "timestamp": 1643198412,
+  "sequencer_address": null,
+  "starknet_version": null,
+  "l2_gas_price": {
+    "price_in_fri": "0x1",
+    "price_in_wei": "0x1"
+  },
+  "l1_gas_price": {
+    "price_in_fri": "0x0",
+    "price_in_wei": "0x0"
+  },
+  "l1_data_gas_price": {
+    "price_in_fri": "0x1",
+    "price_in_wei": "0x1"
+  },
+  "event_commitment": "0x0",
+  "state_diff_commitment": null,
+  "state_diff_length": null,
+  "state_root": "0x7073a72458d4d96910fa632358be7a1a4ca90122a66370d304b290efd607bc2",
+  "transaction_commitment": "0x127dc88a4f70cd074c4af22a65b33d838d0220158f372c9b6b84cc58fc1eb9a",
+  "receipt_commitment": null,
+  "transaction_receipts": [
+    {
+      "transaction_hash": "0x64683715e5eaf408685c4116cd58014751163b2aed835d5bbd889f99e647c61",
+      "transaction_index": 0,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x48d19bea80a453ba7e6da5a807dd0e509bd506a391d167e2548a9ffbae27a7f",
+      "transaction_index": 1,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x1055c3ae8095ca7efa114451e0241e1828f53019437c7e72077b0cf14cdf161",
+      "transaction_index": 2,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0,
+          "range_check_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3184353e092b3a5137d187cc3e4970677b3377e6b2315acd649bdb9ac975bc7",
+      "transaction_index": 3,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x32b8ad14022b5e4f58073f897f0b149ea2f6fe2d3e47c7f3ae76f714d65e08",
+      "transaction_index": 4,
+      "execution_resources": {
+        "n_steps": 752,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 12,
+          "range_check_builtin": 14,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 1,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x7fd574343f5af0b058a17ac8de8b348fc7222b9b7367deef8b8916ee5aa59b3",
+      "transaction_index": 5,
+      "execution_resources": {
+        "n_steps": 238,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3850489af6c108374c934bddebfed9bd55cc227b8e84798da7160ade93181f",
+      "transaction_index": 6,
+      "execution_resources": {
+        "n_steps": 31,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [
+        {
+          "from_address": "0x74ba0dedffe72a878afb897e29367d66f80d01bfe603c40e21db64f9c75c4e0",
+          "to_address": "0xfb6fa8a7a9ddc88eadac728c9c0ad35fac3a9a5b",
+          "payload": [
+            "0xc",
+            "0x22"
+          ]
+        }
+      ],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x42211f9119a8e4a4ba54510c87cee02f607277ad71b19943cd5f9033fb3ae7a",
+      "transaction_index": 7,
+      "execution_resources": {
+        "n_steps": 178,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "output_builtin": 0,
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 0,
+          "range_check_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x22d7a5218bafcf911fb16a3ea1998bbdffa380ae67ce726ecf366fc99b5b4f6",
+      "transaction_index": 8,
+      "execution_resources": {
+        "n_steps": 426,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [
+        {
+          "from_address": "0x3c09ab778c53330e6b3798a4f55868bf6bc4c58377da8feeca375bda09a4ad5",
+          "to_address": "0x1",
+          "payload": [
+            "0xc",
+            "0x22"
+          ]
+        },
+        {
+          "from_address": "0x3c09ab778c53330e6b3798a4f55868bf6bc4c58377da8feeca375bda09a4ad5",
+          "to_address": "0x2",
+          "payload": [
+            "0xc",
+            "0x22"
+          ]
+        }
+      ],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x6327c03265810ebc30c082a9e91053756070d47d5fdc076ee3ebd7d720bcf0",
+      "transaction_index": 9,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "ecdsa_builtin": 0,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x55b42b1a946fe14d26b78ccb82f29c9a91ddb7f4f0cd96f0af8cd3765e0cf07",
+      "transaction_index": 10,
+      "execution_resources": {
+        "n_steps": 25,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x4f5606556d56a75379fe5a3dc243b8755b031a1b785de5cf748081d6aa383f2",
+      "transaction_index": 11,
+      "execution_resources": {
+        "n_steps": 169,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 2,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "range_check_builtin": 7,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x165de0e4a6a6aae092563270c1f3fd411b58a088071f8441a72f36aba90cdb2",
+      "transaction_index": 12,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x20af531876c826de25417c4ef4c55248e1f38aac14e86321baa20195aa4b8a5",
+      "transaction_index": 13,
+      "execution_resources": {
+        "n_steps": 65,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "output_builtin": 0,
+          "range_check_builtin": 1,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x31ee74c70d6870849de109869d605a988c4372d9ac1c0cb2b7d9c0d9a68010b",
+      "transaction_index": 14,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x5ca05fc0fdf91ab7af298b0eb792db612d9554de2f116087111083c15e94f67",
+      "transaction_index": 15,
+      "execution_resources": {
+        "n_steps": 756,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 12,
+          "range_check_builtin": 14,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 1
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3a4f0441ea6ecb10e7d1a8edb3c22d98804cac535537c30772c54875c50a524",
+      "transaction_index": 16,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "ecdsa_builtin": 0,
+          "pedersen_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3deb5430bf5977ce29c9ebc90eced786c4447679822ecad3b7b4783be6059f",
+      "transaction_index": 17,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0,
+          "ec_op_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x42a179ae1f8211493fce36d98d61436000951425d3add6bbae64fd0d604000f",
+      "transaction_index": 18,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "output_builtin": 0,
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x7b3f88fa54e7786a00f1c3ebab6345c0ea6ea52841ac47e1ae90c8d2e8b32c6",
+      "transaction_index": 19,
+      "execution_resources": {
+        "n_steps": 178,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3d88c49ce2d593c49013446927c8ac1c0b4185ef97612b5561a8cbc0715c9e3",
+      "transaction_index": 20,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 0,
+          "range_check_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x116698b0c506c82bff14904adb088ecc2962354d7305e27e0750770fd1ae146",
+      "transaction_index": 21,
+      "execution_resources": {
+        "n_steps": 752,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 14,
+          "ecdsa_builtin": 1,
+          "ec_op_builtin": 0,
+          "bitwise_builtin": 0,
+          "output_builtin": 0,
+          "pedersen_builtin": 12
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0xf845b56cd56dce0ecb252a2d73b781082bd44232a0b8ad9c82fe157850e9b0",
+      "transaction_index": 22,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ec_op_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x3e1e02fe0d2104ef0225121fa098afb2305f27b0537769eca14c51fe54d93d3",
+      "transaction_index": 23,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x133085cd7776bfc2d5e4c0819f6dc9c29321b80c993365f14293c392bd6472d",
+      "transaction_index": 24,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "ecdsa_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x4317e04ce4d5d3c2dca54051e292a55595dd3f7deae258a03a98838860d9b86",
+      "transaction_index": 25,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x7a545e40e93a65368ce225714113b09ebe31cd6a833b01e7036ab5cb8909cc6",
+      "transaction_index": 26,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "output_builtin": 0,
+          "ecdsa_builtin": 0,
+          "ec_op_builtin": 0,
+          "pedersen_builtin": 0,
+          "range_check_builtin": 0,
+          "bitwise_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    },
+    {
+      "transaction_hash": "0x62e4533bac25b21d4087ebcf53514742f7bdbb48f5ab4285dcbb3d74d0c2be9",
+      "transaction_index": 27,
+      "execution_resources": {
+        "n_steps": 68,
+        "n_memory_holes": 0,
+        "builtin_instance_counter": {
+          "range_check_builtin": 0,
+          "output_builtin": 0,
+          "bitwise_builtin": 0,
+          "ecdsa_builtin": 0,
+          "pedersen_builtin": 0,
+          "ec_op_builtin": 0
+        },
+        "data_availability": null,
+        "total_gas_consumed": null
+      },
+      "l1_to_l2_consumed_message": null,
+      "l2_to_l1_messages": [],
+      "events": [],
+      "actual_fee": "0x0",
+      "execution_status": "SUCCEEDED",
+      "revert_error": null
+    }
+  ],
+  "transactions": [
+    {
+      "transaction_hash": "0x64683715e5eaf408685c4116cd58014751163b2aed835d5bbd889f99e647c61",
+      "type": "DEPLOY",
+      "contract_address": "0x52d8386a572e7539b63303e3fe208d7e4a357ddf53207bde4f6369645ca1b8e",
+      "contract_address_salt": "0x6b5dcbb5393c2e55bc6d3441d0f69b535ec5ad4cb164efbbf050e8fe39a1cbf",
+      "constructor_calldata": [
+        "0x3bc9f9568c71aee9bdec3014d523bf48a82e72f027c312b6549796e850997ca",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x48d19bea80a453ba7e6da5a807dd0e509bd506a391d167e2548a9ffbae27a7f",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x3f4c8a1df90024d05e7d5a3651143168c8798d4940a05bf872021c7a1407a11",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x5e8ce0e92ead6da08c5bda60f4e2ab51ec10c1dd0f529bad2fa22b1c11cd396",
+        "0x36d390aed91a49d136235f7efbe8adbc51a475b20b0dca0da26946d62289f55"
+      ]
+    },
+    {
+      "transaction_hash": "0x1055c3ae8095ca7efa114451e0241e1828f53019437c7e72077b0cf14cdf161",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x3f4c8a1df90024d05e7d5a3651143168c8798d4940a05bf872021c7a1407a11",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x5e8ce0e92ead6da08c5bda60f4e2ab51ec10c1dd0f529bad2fa22b1c11cd396",
+        "0x541596200599bd9324fcd204fd67b42906b7a3300a63754019bc2dba5dbd410"
+      ]
+    },
+    {
+      "transaction_hash": "0x3184353e092b3a5137d187cc3e4970677b3377e6b2315acd649bdb9ac975bc7",
+      "type": "DEPLOY",
+      "contract_address": "0x19716116bc3e4cc2eb89117dff6e6da3bdf4759132b8b066a820c030f0eee1b",
+      "contract_address_salt": "0x6e650ebf6d7b6c2ecf0968aeb0e4df43ddb5c08ba24dbc524d8a572561974df",
+      "constructor_calldata": [
+        "0x4460fb2684a4405d6074b5a7bf1c4c82a1a67ed4352afd81c9bad44cbb1c0c4",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x32b8ad14022b5e4f58073f897f0b149ea2f6fe2d3e47c7f3ae76f714d65e08",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x4d8f0e2066b931cc7ba8de5d8c641c01a883dacfd2543364ca9f5a0105b33dc",
+        "0x54bf3fc4063e35f600143e0b0653a11ea3155472c9140c46fc828712abde48a"
+      ],
+      "contract_address": "0x1b5c238ca37d30ffa108a63d1a1806353b9148ab3296ceff8dcc95c56894831",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x1b5c238ca37d30ffa108a63d1a1806353b9148ab3296ceff8dcc95c56894831",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x7fd574343f5af0b058a17ac8de8b348fc7222b9b7367deef8b8916ee5aa59b3",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x174d9859d5070fe50673c449353417284d5dfb24016b004f66431bcb7e50cda",
+      "entry_point_selector": "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+      "calldata": [
+        "0x306056c13f79f94838081c78386cea396dc1130a72226525acfbf40ef8e4a1c",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x3850489af6c108374c934bddebfed9bd55cc227b8e84798da7160ade93181f",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x74ba0dedffe72a878afb897e29367d66f80d01bfe603c40e21db64f9c75c4e0",
+      "entry_point_selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+      "calldata": [
+        "0xfb6fa8a7a9ddc88eadac728c9c0ad35fac3a9a5b"
+      ]
+    },
+    {
+      "transaction_hash": "0x42211f9119a8e4a4ba54510c87cee02f607277ad71b19943cd5f9033fb3ae7a",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x60c93b48cea8ee2abb277742746b65982dd4c61c299d034916d416d42716349",
+      "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+      "calldata": [
+        "0x39853a5c94fc4d1d20adb9168e32be56491a9586767f109e18ba357e8df754d",
+        "0xbaa3f028b48fa94d81a798f53a29918cfbb93c477edb3c2b7222ad57d91333"
+      ]
+    },
+    {
+      "transaction_hash": "0x22d7a5218bafcf911fb16a3ea1998bbdffa380ae67ce726ecf366fc99b5b4f6",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x3c09ab778c53330e6b3798a4f55868bf6bc4c58377da8feeca375bda09a4ad5",
+      "entry_point_selector": "0x218f305395474a84a39307fa5297be118fe17bf65e27ac5e2de6617baa44c64",
+      "calldata": [
+        "0x518205721dea61dee0cdd29821f5bf6ddfe4ae55bb485ab5a34444bf12e0a6e",
+        "0x2"
+      ]
+    },
+    {
+      "transaction_hash": "0x6327c03265810ebc30c082a9e91053756070d47d5fdc076ee3ebd7d720bcf0",
+      "type": "DEPLOY",
+      "contract_address": "0x399ec6460d6340fb11dcc038937e7225228c2c9cde2da33859aec38c2839e1c",
+      "contract_address_salt": "0x217fa9bfe79f7ab635e46ea30d92896421ab10a3bd26d5bbf104e8cb538d59e",
+      "constructor_calldata": [
+        "0x7b3a9b8e10e3f42d81fb55ad8f2dc33b79ca78c449f6f6d8706c8a792c6ed21",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x55b42b1a946fe14d26b78ccb82f29c9a91ddb7f4f0cd96f0af8cd3765e0cf07",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x1d77d03377f26745ecd47a428edd4fdb723510b4c5c2f6111f3a4a23a1ba142",
+      "entry_point_selector": "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+      "calldata": [
+        "0x20291a361f0f4c4606d9052b9836c5be6cc5e53a869c461eef9992e72055b58",
+        "0x7d50f73313be2e65e7992beec533efadc7d13daddf60253370f7c54467452c5"
+      ]
+    },
+    {
+      "transaction_hash": "0x4f5606556d56a75379fe5a3dc243b8755b031a1b785de5cf748081d6aa383f2",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x5adc2000e4b0b3674c710548df1752218af477ee6a9667bdb637a7cad49c731",
+      "entry_point_selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f",
+      "calldata": [
+        "0x7e6fac1cb89024b888edac218f7c8f826072c98581311f968391d9366a9175a",
+        "0x2",
+        "0x4fd733776dc37778c81407b8d1c64ca39a8f003450612172f7355149eecb069",
+        "0x2b7a3125bd4ba2f5486210f815957fa8a44744bc64ebf1365126d488098fb9a"
+      ]
+    },
+    {
+      "transaction_hash": "0x165de0e4a6a6aae092563270c1f3fd411b58a088071f8441a72f36aba90cdb2",
+      "type": "DEPLOY",
+      "contract_address": "0x41df512af92e38ae7ebc99c0b3f62bcfa87c0937e8b0a5b176a8cf40191348",
+      "contract_address_salt": "0x766835c73f99c3f62130c92118b98ae146ab87dafdcdd3da6fbe8fb4449b244",
+      "constructor_calldata": [
+        "0x70faa2c7fe13bcb0c52da3ed2148e1d107dad8e6c78e06e0812a10a033fc37d",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x20af531876c826de25417c4ef4c55248e1f38aac14e86321baa20195aa4b8a5",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0x12cd6b3f1962c3e217e346e3b0f604df8bd1f84ef74d6b669d7c2e2c3889faa",
+      "entry_point_selector": "0x27c3334165536f239cfd400ed956eabff55fc60de4fb56728b6a4f6b87db01c",
+      "calldata": [
+        "0x7b2b6c1eb20feeaeef9cb2fb0a57030f25d50254be5c92f45da5fc56e0cb07b",
+        "0x3d7905601c217734671143d457f0db37f7f8883112abd34b92c4abfeafde0c3",
+        "0x2",
+        "0x17cb09e8476a4a6aa7444ef6c1af3a51546d3c5a0339d009b19366342391f0b",
+        "0x11cee2d2ab58504d2a38e5a1a4649490d1c232e8104da9af36ddefa4112500b"
+      ]
+    },
+    {
+      "transaction_hash": "0x31ee74c70d6870849de109869d605a988c4372d9ac1c0cb2b7d9c0d9a68010b",
+      "type": "DEPLOY",
+      "contract_address": "0x2c4bec7541273ea6593170740a222dff67bddb33b698f4e9d5b2bc9ea824a78",
+      "contract_address_salt": "0x21c7a905a9fa61db6d00bf03ddf52bfa39a1c6f9611a88f6a5576341611a4cd",
+      "constructor_calldata": [
+        "0x4c212e250203f69168591cb91239cbdd52413b0f4e3e136646327e5b3228127",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x5ca05fc0fdf91ab7af298b0eb792db612d9554de2f116087111083c15e94f67",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x304a5893053c59dbd604a3f94f780e1129c06af173e2f1438d58f6d2d0a1376",
+        "0x15fe63aa74ae48d49b6a6df8fe6746a65b1a5a772e85e4111b0bb41534d794e"
+      ],
+      "contract_address": "0x5fc74ed206c7d6b87da2800514d74bb07d3eb55f8e289af17cf66094a6643a6",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x5fc74ed206c7d6b87da2800514d74bb07d3eb55f8e289af17cf66094a6643a6",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0x3a4f0441ea6ecb10e7d1a8edb3c22d98804cac535537c30772c54875c50a524",
+      "type": "DEPLOY",
+      "contract_address": "0x2651e9793b264110cbcd505f33992d3ee7751af19779edcb6b8ed375f1221d1",
+      "contract_address_salt": "0x74e9ea0e243c3463b740252e55f3dedb1149b3ff9700635821d53377bfc830a",
+      "constructor_calldata": [
+        "0x63ff49c5527e9c07b83bcaa8103b5fb07ff060451cb55f6608e4b59334cce07",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x3deb5430bf5977ce29c9ebc90eced786c4447679822ecad3b7b4783be6059f",
+      "type": "DEPLOY",
+      "contract_address": "0x2246be230b4cf68c29558698d221e841a2972f698f977090e82ccf0b46c5f07",
+      "contract_address_salt": "0x74531e47da3f02a47dce6071f6995f3d0aeeb46647588c00a8d469b2cbc15da",
+      "constructor_calldata": [
+        "0x63ff49c5527e9c07b83bcaa8103b5fb07ff060451cb55f6608e4b59334cce07",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x42a179ae1f8211493fce36d98d61436000951425d3add6bbae64fd0d604000f",
+      "type": "DEPLOY",
+      "contract_address": "0x76bc9262b39c59b9ff91b27a87b5a4c14e5f0081ba17e1c18096d1dd16c49da",
+      "contract_address_salt": "0x5da9b82c15cd118e75c7fb52acde21048c725e018272ad12f0936787bb177e3",
+      "constructor_calldata": [
+        "0x63ff49c5527e9c07b83bcaa8103b5fb07ff060451cb55f6608e4b59334cce07",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x7b3f88fa54e7786a00f1c3ebab6345c0ea6ea52841ac47e1ae90c8d2e8b32c6",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [],
+      "contract_address": "0xee17cbd60963ff38cbcdfb298334eb4d923b02f091b806b6bb41816c170d86",
+      "entry_point_selector": "0x19a35a6e95cb7a3318dbb244f20975a1cd8587cc6b5259f15f61d7beb7ee43b",
+      "calldata": [
+        "0x6af0762a24b7c0017e3839b6f37c9f7a1ac02573d7f160775b8999c57d0f332",
+        "0x1d1604f950d2815705bb1e03ef0f3b1651561b3ebb92418ba1dc3a643f9aeb1"
+      ]
+    },
+    {
+      "transaction_hash": "0x3d88c49ce2d593c49013446927c8ac1c0b4185ef97612b5561a8cbc0715c9e3",
+      "type": "DEPLOY",
+      "contract_address": "0x39f08d0c04b0d057659696241523b63ad5d80fef15fba2c7ed53ae761ae78a2",
+      "contract_address_salt": "0x158caf25761f3be1ad66eb5dd4315b1fbd4297aae11d749c2666df1517927c4",
+      "constructor_calldata": [
+        "0x7a23bc9b3c9e3b2c36983ee72f2d38faac8019edf0903406a0c72bc8d1f0a0",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x116698b0c506c82bff14904adb088ecc2962354d7305e27e0750770fd1ae146",
+      "type": "INVOKE_FUNCTION",
+      "version": "0x0",
+      "max_fee": "0x0",
+      "signature": [
+        "0x7e4e6a5cc4cd4e05474c917fbe97ccf3967ded9478ba7f500dfb5240ab08974",
+        "0x48393f6f7f794711dbfc8f3d57583a46672be8a0882d3d8bc45de1743ded217"
+      ],
+      "contract_address": "0x67fe5d58595d8f621c820399d680092a6004d6dc0a8b7390d24d1ae34dd7d11",
+      "entry_point_selector": "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
+      "calldata": [
+        "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
+        "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "0x3",
+        "0x67fe5d58595d8f621c820399d680092a6004d6dc0a8b7390d24d1ae34dd7d11",
+        "0x3635c9adc5dea00000",
+        "0x0",
+        "0x0"
+      ]
+    },
+    {
+      "transaction_hash": "0xf845b56cd56dce0ecb252a2d73b781082bd44232a0b8ad9c82fe157850e9b0",
+      "type": "DEPLOY",
+      "contract_address": "0x1a349bbc706e2e53bcb7cdb5174ae55e1f762d5bf504a2cecd8e0f3935abb9",
+      "contract_address_salt": "0x31148dba42290c4aa6bdf18e5879a67092db96bf1958e956b33bc381d439028",
+      "constructor_calldata": [
+        "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x3e1e02fe0d2104ef0225121fa098afb2305f27b0537769eca14c51fe54d93d3",
+      "type": "DEPLOY",
+      "contract_address": "0x3a4d224d49f03571add535949bd02276e617a6ed737de2820cc4b32f56e0f4f",
+      "contract_address_salt": "0x4a3ed1d99e9eb0eb73380929e12b2799cce922e52959fa7273588a79f27fa5d",
+      "constructor_calldata": [
+        "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x133085cd7776bfc2d5e4c0819f6dc9c29321b80c993365f14293c392bd6472d",
+      "type": "DEPLOY",
+      "contract_address": "0x7f72b53f6fc745390185c90e3e74c99a598d9aa184b527b3269730d9dcd3683",
+      "contract_address_salt": "0x792c27bd8e7ffbd71ce00ae9533f87ef510fefc5c14c9ce680c2a274b0e8032",
+      "constructor_calldata": [
+        "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x4317e04ce4d5d3c2dca54051e292a55595dd3f7deae258a03a98838860d9b86",
+      "type": "DEPLOY",
+      "contract_address": "0x452d79b09b1ed03fc0e507f31117b569eacc41e1c84e34d1ffeda4087b75adf",
+      "contract_address_salt": "0x766c3b2c5ba5b25080332fdec21d227e2495668b86e3f066e936c4abc657994",
+      "constructor_calldata": [
+        "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x7a545e40e93a65368ce225714113b09ebe31cd6a833b01e7036ab5cb8909cc6",
+      "type": "DEPLOY",
+      "contract_address": "0x70ad6ae5086e1ac228353243735c93b55e70f6ad2a288dae73d2ce22847d399",
+      "contract_address_salt": "0x5a4f99e1e24aa2ba083e00666f3b616f6aadbd711fe9dc85375dc05b2d1f4a9",
+      "constructor_calldata": [
+        "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    },
+    {
+      "transaction_hash": "0x62e4533bac25b21d4087ebcf53514742f7bdbb48f5ab4285dcbb3d74d0c2be9",
+      "type": "DEPLOY",
+      "contract_address": "0x425df7ba15ecc2ad3c57b733044c02963ab49a8b4675e53dd6263883603ba1",
+      "contract_address_salt": "0x257e5ad18f83f5772e126bfb407fef84aae38e0e0ec37418fafbc0f5d3ff0c7",
+      "constructor_calldata": [
+        "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220",
+        "0x0"
+      ],
+      "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33",
+      "version": "0x0"
+    }
+  ]
+}

--- a/crates/gateway/gateway-client/tests/fixtures/0.7.0/state_update/mainnet_833.json
+++ b/crates/gateway/gateway-client/tests/fixtures/0.7.0/state_update/mainnet_833.json
@@ -1,0 +1,272 @@
+{
+  "block_hash": "0x197cd4f24d30274f0674aec74b86e0405c13de06771cfa1ee472b0d2437db7c",
+  "new_root": "0x7073a72458d4d96910fa632358be7a1a4ca90122a66370d304b290efd607bc2",
+  "old_root": "0x3810b7805897aff09b3bba1d41fe2eb21a3853d98553794928684d1089f25cf",
+  "state_diff": {
+    "storage_diffs": {
+      "0x1a349bbc706e2e53bcb7cdb5174ae55e1f762d5bf504a2cecd8e0f3935abb9": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220"
+        }
+      ],
+      "0x41df512af92e38ae7ebc99c0b3f62bcfa87c0937e8b0a5b176a8cf40191348": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x70faa2c7fe13bcb0c52da3ed2148e1d107dad8e6c78e06e0812a10a033fc37d"
+        }
+      ],
+      "0x425df7ba15ecc2ad3c57b733044c02963ab49a8b4675e53dd6263883603ba1": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220"
+        }
+      ],
+      "0xee17cbd60963ff38cbcdfb298334eb4d923b02f091b806b6bb41816c170d86": [
+        {
+          "key": "0x1d1604f950d2815705bb1e03ef0f3b1651561b3ebb92418ba1dc3a643f9aeb1",
+          "value": "0x7c7"
+        }
+      ],
+      "0x174d9859d5070fe50673c449353417284d5dfb24016b004f66431bcb7e50cda": [
+        {
+          "key": "0x5",
+          "value": "0x64"
+        }
+      ],
+      "0x19716116bc3e4cc2eb89117dff6e6da3bdf4759132b8b066a820c030f0eee1b": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x4460fb2684a4405d6074b5a7bf1c4c82a1a67ed4352afd81c9bad44cbb1c0c4"
+        }
+      ],
+      "0x1b5c238ca37d30ffa108a63d1a1806353b9148ab3296ceff8dcc95c56894831": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ],
+      "0x1d77d03377f26745ecd47a428edd4fdb723510b4c5c2f6111f3a4a23a1ba142": [
+        {
+          "key": "0x20291a361f0f4c4606d9052b9836c5be6cc5e53a869c461eef9992e72055b58",
+          "value": "0x7d50f73313be2e65e7992beec533efadc7d13daddf60253370f7c54467452c5"
+        }
+      ],
+      "0x2246be230b4cf68c29558698d221e841a2972f698f977090e82ccf0b46c5f07": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x63ff49c5527e9c07b83bcaa8103b5fb07ff060451cb55f6608e4b59334cce07"
+        }
+      ],
+      "0x2651e9793b264110cbcd505f33992d3ee7751af19779edcb6b8ed375f1221d1": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x63ff49c5527e9c07b83bcaa8103b5fb07ff060451cb55f6608e4b59334cce07"
+        }
+      ],
+      "0x2c4bec7541273ea6593170740a222dff67bddb33b698f4e9d5b2bc9ea824a78": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x4c212e250203f69168591cb91239cbdd52413b0f4e3e136646327e5b3228127"
+        }
+      ],
+      "0x39853a5c94fc4d1d20adb9168e32be56491a9586767f109e18ba357e8df754d": [
+        {
+          "key": "0xbaa3f028b48fa94d81a798f53a29918cfbb93c477edb3c2b7222ad57d91333",
+          "value": "0x7e5"
+        }
+      ],
+      "0x399ec6460d6340fb11dcc038937e7225228c2c9cde2da33859aec38c2839e1c": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x7b3a9b8e10e3f42d81fb55ad8f2dc33b79ca78c449f6f6d8706c8a792c6ed21"
+        }
+      ],
+      "0x39f08d0c04b0d057659696241523b63ad5d80fef15fba2c7ed53ae761ae78a2": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x7a23bc9b3c9e3b2c36983ee72f2d38faac8019edf0903406a0c72bc8d1f0a0"
+        }
+      ],
+      "0x3a4d224d49f03571add535949bd02276e617a6ed737de2820cc4b32f56e0f4f": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220"
+        }
+      ],
+      "0x3c09ab778c53330e6b3798a4f55868bf6bc4c58377da8feeca375bda09a4ad5": [
+        {
+          "key": "0x5",
+          "value": "0x66"
+        }
+      ],
+      "0x3f4c8a1df90024d05e7d5a3651143168c8798d4940a05bf872021c7a1407a11": [
+        {
+          "key": "0x5e8ce0e92ead6da08c5bda60f4e2ab51ec10c1dd0f529bad2fa22b1c11cd396",
+          "value": "0x541596200599bd9324fcd204fd67b42906b7a3300a63754019bc2dba5dbd410"
+        }
+      ],
+      "0x452d79b09b1ed03fc0e507f31117b569eacc41e1c84e34d1ffeda4087b75adf": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220"
+        }
+      ],
+      "0x518205721dea61dee0cdd29821f5bf6ddfe4ae55bb485ab5a34444bf12e0a6e": [
+        {
+          "key": "0x5",
+          "value": "0x456"
+        }
+      ],
+      "0x52d8386a572e7539b63303e3fe208d7e4a357ddf53207bde4f6369645ca1b8e": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x3bc9f9568c71aee9bdec3014d523bf48a82e72f027c312b6549796e850997ca"
+        }
+      ],
+      "0x5adc2000e4b0b3674c710548df1752218af477ee6a9667bdb637a7cad49c731": [
+        {
+          "key": "0x6417f3868411a3e8f8ac7f6fcee11024fb73e742cdda15cc9f29bb2c25a2b51",
+          "value": "0x4fd733776dc37778c81407b8d1c64ca39a8f003450612172f7355149eecb069"
+        },
+        {
+          "key": "0x6417f3868411a3e8f8ac7f6fcee11024fb73e742cdda15cc9f29bb2c25a2b52",
+          "value": "0x2b7a3125bd4ba2f5486210f815957fa8a44744bc64ebf1365126d488098fb9a"
+        }
+      ],
+      "0x5fc74ed206c7d6b87da2800514d74bb07d3eb55f8e289af17cf66094a6643a6": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ],
+      "0x60c93b48cea8ee2abb277742746b65982dd4c61c299d034916d416d42716349": [
+        {
+          "key": "0xbaa3f028b48fa94d81a798f53a29918cfbb93c477edb3c2b7222ad57d91333",
+          "value": "0x7c7"
+        }
+      ],
+      "0x67fe5d58595d8f621c820399d680092a6004d6dc0a8b7390d24d1ae34dd7d11": [
+        {
+          "key": "0x37501df619c4fc4e96f6c0243f55e3abe7d1aca7db9af8f3740ba3696b3fdac",
+          "value": "0x1"
+        }
+      ],
+      "0x6a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75": [
+        {
+          "key": "0x145512439c73c04418aacdb5f23e625bc20bcf737dc4bfb30c1b9f256cc2cb3",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x4c154f2a8aa994d0087411f67899f1b09bf836b6797bafd29f8af13e73f0ed4",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x12ab7fee94f770ab2c3882cfa7e160b18306f88a643e6150d38939a3370f328",
+          "value": "0x3635c9adc5dea00000"
+        },
+        {
+          "key": "0x1557182e4359a1f0c6301278e8f5b35a776ab58d39892581e357578fb287836",
+          "value": "0xe020c00b5e7cf315fe895f094385e54e"
+        }
+      ],
+      "0x6af0762a24b7c0017e3839b6f37c9f7a1ac02573d7f160775b8999c57d0f332": [
+        {
+          "key": "0x1d1604f950d2815705bb1e03ef0f3b1651561b3ebb92418ba1dc3a643f9aeb1",
+          "value": "0x7e5"
+        }
+      ],
+      "0x70ad6ae5086e1ac228353243735c93b55e70f6ad2a288dae73d2ce22847d399": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220"
+        }
+      ],
+      "0x76bc9262b39c59b9ff91b27a87b5a4c14e5f0081ba17e1c18096d1dd16c49da": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x63ff49c5527e9c07b83bcaa8103b5fb07ff060451cb55f6608e4b59334cce07"
+        }
+      ],
+      "0x7b2b6c1eb20feeaeef9cb2fb0a57030f25d50254be5c92f45da5fc56e0cb07b": [
+        {
+          "key": "0x17cb09e8476a4a6aa7444ef6c1af3a51546d3c5a0339d009b19366342391f0b",
+          "value": "0x11cee2d2ab58504d2a38e5a1a4649490d1c232e8104da9af36ddefa4112500b"
+        }
+      ],
+      "0x7f72b53f6fc745390185c90e3e74c99a598d9aa184b527b3269730d9dcd3683": [
+        {
+          "key": "0x1ccc09c8a19948e048de7add6929589945e25f22059c7345aaf7837188d8d05",
+          "value": "0x6577df42723ff9ea4b4c0edef3b617ab62b262274df9bd07ed035a574313220"
+        }
+      ]
+    },
+    "deployed_contracts": [
+      {
+        "address": "0x3a4d224d49f03571add535949bd02276e617a6ed737de2820cc4b32f56e0f4f",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x452d79b09b1ed03fc0e507f31117b569eacc41e1c84e34d1ffeda4087b75adf",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x1a349bbc706e2e53bcb7cdb5174ae55e1f762d5bf504a2cecd8e0f3935abb9",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x39f08d0c04b0d057659696241523b63ad5d80fef15fba2c7ed53ae761ae78a2",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x425df7ba15ecc2ad3c57b733044c02963ab49a8b4675e53dd6263883603ba1",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x7f72b53f6fc745390185c90e3e74c99a598d9aa184b527b3269730d9dcd3683",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x399ec6460d6340fb11dcc038937e7225228c2c9cde2da33859aec38c2839e1c",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x76bc9262b39c59b9ff91b27a87b5a4c14e5f0081ba17e1c18096d1dd16c49da",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x19716116bc3e4cc2eb89117dff6e6da3bdf4759132b8b066a820c030f0eee1b",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x2246be230b4cf68c29558698d221e841a2972f698f977090e82ccf0b46c5f07",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x2c4bec7541273ea6593170740a222dff67bddb33b698f4e9d5b2bc9ea824a78",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x2651e9793b264110cbcd505f33992d3ee7751af19779edcb6b8ed375f1221d1",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x41df512af92e38ae7ebc99c0b3f62bcfa87c0937e8b0a5b176a8cf40191348",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x70ad6ae5086e1ac228353243735c93b55e70f6ad2a288dae73d2ce22847d399",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      },
+      {
+        "address": "0x52d8386a572e7539b63303e3fe208d7e4a357ddf53207bde4f6369645ca1b8e",
+        "class_hash": "0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"
+      }
+    ],
+    "old_declared_contracts": [],
+    "declared_classes": [],
+    "nonces": {},
+    "replaced_classes": [],
+    "migrated_compiled_classes": []
+  }
+}

--- a/crates/sync/stage/src/blocks/downloader.rs
+++ b/crates/sync/stage/src/blocks/downloader.rs
@@ -104,7 +104,7 @@ pub mod gateway {
     };
     use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
     use katana_primitives::transaction::{Tx, TxWithHash};
-    use katana_primitives::Felt;
+    use katana_primitives::{ContractAddress, Felt};
     use num_traits::ToPrimitive;
     use starknet::core::types::ResourcePrice;
 

--- a/crates/sync/stage/src/blocks/downloader.rs
+++ b/crates/sync/stage/src/blocks/downloader.rs
@@ -104,7 +104,7 @@ pub mod gateway {
     };
     use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
     use katana_primitives::transaction::{Tx, TxWithHash};
-    use katana_primitives::{ContractAddress, Felt};
+    use katana_primitives::Felt;
     use num_traits::ToPrimitive;
     use starknet::core::types::ResourcePrice;
 

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -103,43 +103,28 @@ use katana_primitives::state::{compute_state_diff_hash, StateUpdates};
 use katana_primitives::transaction::{DeclareTx, DeployAccountTx, InvokeTx, Tx, TxWithHash};
 use katana_primitives::utils::starknet_keccak;
 use katana_primitives::version::StarknetVersion;
-use katana_primitives::Felt;
+use katana_primitives::{address, ContractAddress, Felt};
 use katana_trie::compute_merkle_root;
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
-
-/// The first block on mainnet that uses the 0.7 hash algorithm.
-///
-/// Blocks before this number use the pre-0.7 algorithm which includes chain_id and zeros
-/// for sequencer/timestamp. The `starknet_version` header field was not populated for
-/// early blocks, so we cannot rely on it alone for the algorithm selection.
-///
-/// Reference: <https://github.com/eqlabs/pathfinder/blob/main/crates/pathfinder/src/state/block_hash.rs>
-const MAINNET_FIRST_0_7_BLOCK: BlockNumber = 833;
 
 /// Fallback sequencer address used for mainnet blocks in the 0.7–0.8.2 range.
 ///
 /// During this period, the sequencer address was not stored in the block header. The actual
 /// address must be injected when computing the block hash for these blocks.
-const MAINNET_FALLBACK_SEQUENCER_ADDRESS: Felt =
-    Felt::from_hex_unchecked("0x021f4b90b0377c82bf330b7b5295820769e72d79d8acd0effa0ebde6e9988bc5");
+const MAINNET_FALLBACK_SEQUENCER_ADDRESS: ContractAddress =
+    address!("0x021f4b90b0377c82bf330b7b5295820769e72d79d8acd0effa0ebde6e9988bc5");
 
-/// Resolves the effective starknet version for hash computation.
-///
-/// Early mainnet blocks lack the `starknet_version` header field (reporting `UNVERSIONED`).
-/// For these, we infer the version from the block number using known mainnet cutoffs.
-fn effective_version(header: &Header, chain_id: &ChainId) -> StarknetVersion {
-    if header.starknet_version != StarknetVersion::UNVERSIONED {
-        return header.starknet_version;
-    }
-
-    // Only mainnet has pre-0.7 blocks; other networks start at 0.7+.
-    if *chain_id == ChainId::MAINNET && header.number < MAINNET_FIRST_0_7_BLOCK {
-        StarknetVersion::UNVERSIONED
-    } else {
-        // Treat unversioned blocks on or after the cutoff as 0.7.
-        StarknetVersion::V0_7_0
-    }
+/// Patches the header for missing fields in the block header (for earlier blocks) and computes the
+/// block hash.
+pub fn patch_header_and_compute_hash(
+    block: &mut SealedBlock,
+    receipts: &[Receipt],
+    state_updates: &StateUpdates,
+    chain_id: &ChainId,
+) -> Felt {
+    patch_missing_fields(block, receipts, state_updates, chain_id);
+    compute_hash(&block.header, chain_id)
 }
 
 /// Computes the block hash for a header, dispatching to the correct algorithm based
@@ -150,23 +135,13 @@ fn effective_version(header: &Header, chain_id: &ChainId) -> StarknetVersion {
 /// The `expected_hash` is used to resolve ambiguity for early mainnet blocks where the
 /// sequencer address was not stored in the header. When the initial hash doesn't match,
 /// the known fallback sequencer address from the 0.7–0.8.2 era is tried.
-pub fn compute_hash(header: &Header, chain_id: &ChainId, expected_hash: Option<Felt>) -> Felt {
+pub fn compute_hash(header: &Header, chain_id: &ChainId) -> Felt {
     let version_str = header.starknet_version.to_string();
 
     if header.starknet_version < StarknetVersion::V0_7_0 {
         compute_hash_pre_0_7(header, chain_id)
     } else if header.starknet_version < StarknetVersion::V0_13_2 {
-        let hash = compute_hash_pre_0_13_2(header);
-
-        // For early mainnet blocks, the sequencer address was not stored in the header.
-        // If the hash doesn't match, retry with the known fallback address.
-        if expected_hash.is_some_and(|expected| hash != expected) && *chain_id == ChainId::MAINNET {
-            let mut patched = header.clone();
-            patched.sequencer_address = MAINNET_FALLBACK_SEQUENCER_ADDRESS.into();
-            compute_hash_pre_0_13_2(&patched)
-        } else {
-            hash
-        }
+        compute_hash_pre_0_13_2(header)
     } else if header.starknet_version < StarknetVersion::V0_13_4 {
         compute_hash_post_0_13_2(header, &version_str)
     } else {
@@ -295,16 +270,16 @@ fn compute_hash_post_0_13_4(header: &Header, version_str: &str) -> Felt {
 ///
 /// This handles two categories of missing data:
 ///
-/// **Header fields** — Early blocks don't populate `starknet_version`. For blocks on or
-/// after the 0.7 cutoff on mainnet, the version is set to `V0_7_0`. Pre-0.7 blocks remain
-/// `UNVERSIONED`.
+/// **Header fields** — Early blocks don't populate `starknet_version` and `sequencer_address`.
+/// For blocks on or after the 0.7 cutoff on mainnet, the version is set to `V0_7_0`. Pre-0.7
+/// blocks remain `UNVERSIONED`.
 ///
 /// **Commitments** — Version gates:
 /// - Transaction commitment: reconstructed for any version when the header field is zero.
 /// - Event commitment: reconstructed for any version when the header field is zero.
 /// - State diff commitment and length: only meaningful from `0.13.2` onward.
 /// - Receipt commitment: only meaningful from `0.13.2` onward.
-pub(crate) fn compute_missing_commitments(
+pub(crate) fn patch_missing_fields(
     block: &mut SealedBlock,
     receipts: &[Receipt],
     state_updates: &StateUpdates,
@@ -323,6 +298,13 @@ pub(crate) fn compute_missing_commitments(
 
     if block.header.events_commitment == Felt::ZERO {
         block.header.events_commitment = compute_event_commitment(&block.body, receipts, version);
+    }
+
+    // For early mainnet blocks, the sequencer address was not stored in the header.
+    //
+    // Early sepolia blocks (>= block 0) already has a non-zero sequencer address.
+    if block.header.sequencer_address == ContractAddress::ZERO && chain_id == &ChainId::MAINNET {
+        block.header.sequencer_address = MAINNET_FALLBACK_SEQUENCER_ADDRESS;
     }
 
     // The rest of the commitments are only meaningful from 0.13.2 onward.
@@ -531,6 +513,34 @@ fn calculate_event_commitment_leaf(event: &Event, tx_hash: Felt, version: Starkn
     }
 }
 
+/// Resolves the effective starknet version for hash computation.
+///
+/// Early mainnet blocks lack the `starknet_version` header field. For these,
+/// we infer the version from the block number using known mainnet cutoffs.
+fn effective_version(header: &Header, chain_id: &ChainId) -> StarknetVersion {
+    /// The first block on mainnet that uses the 0.7 hash algorithm.
+    ///
+    /// Blocks before this number use the pre-0.7 algorithm which includes chain_id and zeros
+    /// for sequencer/timestamp. The `starknet_version` header field was not populated for
+    /// early blocks, so we cannot rely on it alone for the algorithm selection.
+    ///
+    /// Reference: <https://github.com/eqlabs/pathfinder/blob/main/crates/pathfinder/src/state/block_hash.rs>
+    const MAINNET_FIRST_0_7_BLOCK: BlockNumber = 833;
+
+    if header.starknet_version != StarknetVersion::UNVERSIONED {
+        return header.starknet_version;
+    }
+
+    // Only mainnet has pre-0.7 blocks; other networks start at 0.7+.
+    if *chain_id == ChainId::MAINNET && header.number < MAINNET_FIRST_0_7_BLOCK {
+        StarknetVersion::UNVERSIONED
+    }
+    // Treat unversioned blocks on or after the cutoff as 0.7.
+    else {
+        StarknetVersion::V0_7_0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use katana_gateway_types::{Block, ConfirmedStateUpdate, StateUpdate, StateUpdateWithBlock};
@@ -540,7 +550,8 @@ mod tests {
     use katana_primitives::{felt, Felt};
     use num_traits::ToPrimitive;
 
-    use super::{compute_hash, compute_missing_commitments};
+    use super::{compute_hash, patch_missing_fields};
+    use crate::blocks::hash::patch_header_and_compute_hash;
     use crate::blocks::BlockData;
 
     /// Shorthand for including a gateway test fixture file at compile time.
@@ -617,7 +628,7 @@ mod tests {
     fn block_hash_mainnet_65000_v0_11_1() {
         let json = fixture!("0.11.1/block/mainnet_65000.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
+        let hash = compute_hash(&header, &ChainId::MAINNET);
         assert_eq!(hash, expected_hash, "block 65000 (v0.11.1) hash mismatch");
     }
 
@@ -626,7 +637,7 @@ mod tests {
     fn block_hash_mainnet_550000_v0_13_0() {
         let json = fixture!("0.13.0/block/mainnet_550000.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
+        let hash = compute_hash(&header, &ChainId::MAINNET);
         assert_eq!(hash, expected_hash, "block 550000 (v0.13.0) hash mismatch");
     }
 
@@ -635,7 +646,7 @@ mod tests {
     fn block_hash_sepolia_35748_v0_13_2() {
         let json = fixture!("0.13.2/block/sepolia_integration_35748.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::SEPOLIA, Some(expected_hash));
+        let hash = compute_hash(&header, &ChainId::SEPOLIA);
         assert_eq!(hash, expected_hash, "sepolia block 35748 (v0.13.2) hash mismatch");
     }
 
@@ -644,7 +655,7 @@ mod tests {
     fn block_hash_sepolia_63881_v0_13_4() {
         let json = fixture!("0.13.4/block/sepolia_integration_63881.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::SEPOLIA, Some(expected_hash));
+        let hash = compute_hash(&header, &ChainId::SEPOLIA);
         assert_eq!(hash, expected_hash, "sepolia block 63881 (v0.13.4) hash mismatch");
     }
 
@@ -653,7 +664,7 @@ mod tests {
     fn block_hash_sepolia_2473486_v0_14_0() {
         let json = fixture!("0.14.0/block/sepolia_2473486.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::SEPOLIA, Some(expected_hash));
+        let hash = compute_hash(&header, &ChainId::SEPOLIA);
         assert_eq!(hash, expected_hash, "sepolia block 2473486 (v0.14.0) hash mismatch");
     }
 
@@ -662,82 +673,12 @@ mod tests {
     fn block_hash_mainnet_2238855_v0_14_0() {
         let json = fixture!("0.14.0/block/mainnet_2238855.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
+        let hash = compute_hash(&header, &ChainId::MAINNET);
         assert_eq!(hash, expected_hash, "block 2238855 (v0.14.0) hash mismatch");
     }
 
-    /// Block 833 — the first 0.7 block on mainnet.
-    ///
-    /// This block reports `starknet_version: ""` (UNVERSIONED) but must use the 0.7+
-    /// hash algorithm. Additionally, the sequencer address is not stored in the header
-    /// (zero), so the fallback sequencer address must be used.
     #[test]
-    fn block_hash_mainnet_833_first_0_7_block() {
-        use super::{
-            effective_version, MAINNET_FALLBACK_SEQUENCER_ADDRESS, MAINNET_FIRST_0_7_BLOCK,
-        };
-
-        // Block 833 has starknet_version="" → UNVERSIONED, but it's on or after the cutoff
-        let header = Header {
-            number: 833,
-            starknet_version: StarknetVersion::UNVERSIONED,
-            ..Default::default()
-        };
-        assert_eq!(
-            effective_version(&header, &ChainId::MAINNET),
-            StarknetVersion::V0_7_0,
-            "block 833 should use 0.7 algorithm despite UNVERSIONED"
-        );
-
-        // Block 832 is still pre-0.7
-        let header = Header {
-            number: 832,
-            starknet_version: StarknetVersion::UNVERSIONED,
-            ..Default::default()
-        };
-        assert_eq!(
-            effective_version(&header, &ChainId::MAINNET),
-            StarknetVersion::UNVERSIONED,
-            "block 832 should use pre-0.7 algorithm"
-        );
-
-        // On Sepolia, UNVERSIONED blocks always use 0.7 (no pre-0.7 era)
-        let header = Header {
-            number: 0,
-            starknet_version: StarknetVersion::UNVERSIONED,
-            ..Default::default()
-        };
-        assert_eq!(
-            effective_version(&header, &ChainId::SEPOLIA),
-            StarknetVersion::V0_7_0,
-            "sepolia block 0 should use 0.7 algorithm"
-        );
-    }
-
-    /// Block 833 — full hash verification using gateway fixture.
-    ///
-    /// This block has `starknet_version: ""` but is the first 0.7 block. The test verifies
-    /// that the version cutoff + fallback sequencer address produce the correct hash.
-    #[test]
-    fn block_hash_mainnet_833() {
-        // The gateway returns starknet_version=null for this block; override to 0.7.0
-        // since compute_missing_commitments would infer this from the block number.
-        let (header, expected_hash) = header_from_fixture(
-            fixture!("0.7.0/block/mainnet_833.json"),
-            Some(StarknetVersion::V0_7_0),
-        );
-        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
-        assert_eq!(hash, expected_hash, "block 833 (first 0.7 block) hash mismatch");
-    }
-
-    /// Block 833 — commitment reconstruction + hash verification.
-    ///
-    /// Simulates the full pipeline flow: reconstruct commitments (which also patches
-    /// starknet_version), then verify the hash. This mirrors what happens when syncing
-    /// via JSON-RPC where starknet_version, sequencer_address, and commitments are all
-    /// missing.
-    #[test]
-    fn reconstructs_missing_commitments_for_0_7_0_mainnet_833() {
+    fn mainnet_0_7_0_cutoff_block_833() {
         let (mut block_data, _) = block_data_from_split_fixtures(
             fixture!("0.7.0/block/mainnet_833.json"),
             fixture!("0.7.0/state_update/mainnet_833.json"),
@@ -751,20 +692,14 @@ mod tests {
         block_data.block.block.header.starknet_version = StarknetVersion::UNVERSIONED;
         block_data.block.block.header.sequencer_address = Default::default();
 
-        compute_missing_commitments(
+        patch_header_and_compute_hash(
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
             &ChainId::MAINNET,
         );
 
-        let computed_hash =
-            compute_hash(&block_data.block.block.header, &ChainId::MAINNET, Some(expected_hash));
-
-        assert_eq!(
-            computed_hash, expected_hash,
-            "block 833 (first 0.7 block) hash mismatch after commitment reconstruction"
-        );
+        assert_eq!(computed_hash, expected_hash);
     }
 
     #[test]
@@ -778,7 +713,7 @@ mod tests {
         block_data.block.block.header.transactions_commitment = Felt::ZERO;
         block_data.block.block.header.events_commitment = Felt::ZERO;
 
-        compute_missing_commitments(
+        patch_missing_fields(
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
@@ -803,7 +738,7 @@ mod tests {
         block_data.block.block.header.transactions_commitment = Felt::ZERO;
         block_data.block.block.header.events_commitment = Felt::ZERO;
 
-        compute_missing_commitments(
+        patch_missing_fields(
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
@@ -831,7 +766,7 @@ mod tests {
         block_data.block.block.header.state_diff_length = 0;
         block_data.block.block.header.state_diff_commitment = Felt::ZERO;
 
-        compute_missing_commitments(
+        patch_missing_fields(
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
@@ -865,7 +800,7 @@ mod tests {
         block_data.block.block.header.state_diff_length = 0;
         block_data.block.block.header.state_diff_commitment = Felt::ZERO;
 
-        compute_missing_commitments(
+        patch_missing_fields(
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -95,7 +95,7 @@
 //! * <https://github.com/starkware-libs/sequencer/blob/e3be9f1a0f3514e989f5b6d753022f6ef7bf5b1d/crates/starknet_api/src/block_hash/block_hash_calculator.rs#L219-L256>
 //! * <https://github.com/starkware-libs/sequencer/blob/e3be9f1a0f3514e989f5b6d753022f6ef7bf5b1d/crates/starknet_api/src/block_hash/block_hash_calculator.rs#L383-L409>
 
-use katana_primitives::block::{Header, SealedBlock};
+use katana_primitives::block::{BlockNumber, Header, SealedBlock};
 use katana_primitives::cairo::ShortString;
 use katana_primitives::chain::ChainId;
 use katana_primitives::receipt::{Event, Receipt};
@@ -108,17 +108,65 @@ use katana_trie::compute_merkle_root;
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
 
+/// The first block on mainnet that uses the 0.7 hash algorithm.
+///
+/// Blocks before this number use the pre-0.7 algorithm which includes chain_id and zeros
+/// for sequencer/timestamp. The `starknet_version` header field was not populated for
+/// early blocks, so we cannot rely on it alone for the algorithm selection.
+///
+/// Reference: <https://github.com/eqlabs/pathfinder/blob/main/crates/pathfinder/src/state/block_hash.rs>
+const MAINNET_FIRST_0_7_BLOCK: BlockNumber = 833;
+
+/// Fallback sequencer address used for mainnet blocks in the 0.7–0.8.2 range.
+///
+/// During this period, the sequencer address was not stored in the block header. The actual
+/// address must be injected when computing the block hash for these blocks.
+const MAINNET_FALLBACK_SEQUENCER_ADDRESS: Felt =
+    Felt::from_hex_unchecked("0x021f4b90b0377c82bf330b7b5295820769e72d79d8acd0effa0ebde6e9988bc5");
+
+/// Resolves the effective starknet version for hash computation.
+///
+/// Early mainnet blocks lack the `starknet_version` header field (reporting `UNVERSIONED`).
+/// For these, we infer the version from the block number using known mainnet cutoffs.
+fn effective_version(header: &Header, chain_id: &ChainId) -> StarknetVersion {
+    if header.starknet_version != StarknetVersion::UNVERSIONED {
+        return header.starknet_version;
+    }
+
+    // Only mainnet has pre-0.7 blocks; other networks start at 0.7+.
+    if *chain_id == ChainId::MAINNET && header.number < MAINNET_FIRST_0_7_BLOCK {
+        StarknetVersion::UNVERSIONED
+    } else {
+        // Treat unversioned blocks on or after the cutoff as 0.7.
+        StarknetVersion::V0_7_0
+    }
+}
+
 /// Computes the block hash for a header, dispatching to the correct algorithm based
-/// on the block's `starknet_version`.
+/// on the block's protocol version.
 ///
 /// The `chain_id` is required for pre-0.7 blocks which include the chain ID in the hash.
-pub fn compute_hash(header: &Header, chain_id: &ChainId) -> Felt {
+///
+/// The `expected_hash` is used to resolve ambiguity for early mainnet blocks where the
+/// sequencer address was not stored in the header. When the initial hash doesn't match,
+/// the known fallback sequencer address from the 0.7–0.8.2 era is tried.
+pub fn compute_hash(header: &Header, chain_id: &ChainId, expected_hash: Option<Felt>) -> Felt {
     let version_str = header.starknet_version.to_string();
 
     if header.starknet_version < StarknetVersion::V0_7_0 {
         compute_hash_pre_0_7(header, chain_id)
     } else if header.starknet_version < StarknetVersion::V0_13_2 {
-        compute_hash_pre_0_13_2(header)
+        let hash = compute_hash_pre_0_13_2(header);
+
+        // For early mainnet blocks, the sequencer address was not stored in the header.
+        // If the hash doesn't match, retry with the known fallback address.
+        if expected_hash.is_some_and(|expected| hash != expected) && *chain_id == ChainId::MAINNET {
+            let mut patched = header.clone();
+            patched.sequencer_address = MAINNET_FALLBACK_SEQUENCER_ADDRESS.into();
+            compute_hash_pre_0_13_2(&patched)
+        } else {
+            hash
+        }
     } else if header.starknet_version < StarknetVersion::V0_13_4 {
         compute_hash_post_0_13_2(header, &version_str)
     } else {
@@ -243,9 +291,15 @@ fn compute_hash_post_0_13_4(header: &Header, version_str: &str) -> Felt {
     ])
 }
 
-/// Computes block commitments that some synced block sources omit from the header.
+/// Fills in header fields and commitments that some synced block sources omit.
 ///
-/// Version gates:-
+/// This handles two categories of missing data:
+///
+/// **Header fields** — Early blocks don't populate `starknet_version`. For blocks on or
+/// after the 0.7 cutoff on mainnet, the version is set to `V0_7_0`. Pre-0.7 blocks remain
+/// `UNVERSIONED`.
+///
+/// **Commitments** — Version gates:
 /// - Transaction commitment: reconstructed for any version when the header field is zero.
 /// - Event commitment: reconstructed for any version when the header field is zero.
 /// - State diff commitment and length: only meaningful from `0.13.2` onward.
@@ -254,7 +308,13 @@ pub(crate) fn compute_missing_commitments(
     block: &mut SealedBlock,
     receipts: &[Receipt],
     state_updates: &StateUpdates,
+    chain_id: &ChainId,
 ) {
+    // Patch starknet_version for early blocks that don't populate it.
+    if block.header.starknet_version == StarknetVersion::UNVERSIONED {
+        block.header.starknet_version = effective_version(&block.header, chain_id);
+    }
+
     let version = block.header.starknet_version;
 
     if block.header.transactions_commitment == Felt::ZERO {
@@ -557,7 +617,7 @@ mod tests {
     fn block_hash_mainnet_65000_v0_11_1() {
         let json = fixture!("0.11.1/block/mainnet_65000.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::MAINNET);
+        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
         assert_eq!(hash, expected_hash, "block 65000 (v0.11.1) hash mismatch");
     }
 
@@ -566,7 +626,7 @@ mod tests {
     fn block_hash_mainnet_550000_v0_13_0() {
         let json = fixture!("0.13.0/block/mainnet_550000.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::MAINNET);
+        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
         assert_eq!(hash, expected_hash, "block 550000 (v0.13.0) hash mismatch");
     }
 
@@ -575,7 +635,7 @@ mod tests {
     fn block_hash_sepolia_35748_v0_13_2() {
         let json = fixture!("0.13.2/block/sepolia_integration_35748.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::SEPOLIA);
+        let hash = compute_hash(&header, &ChainId::SEPOLIA, Some(expected_hash));
         assert_eq!(hash, expected_hash, "sepolia block 35748 (v0.13.2) hash mismatch");
     }
 
@@ -584,7 +644,7 @@ mod tests {
     fn block_hash_sepolia_63881_v0_13_4() {
         let json = fixture!("0.13.4/block/sepolia_integration_63881.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::SEPOLIA);
+        let hash = compute_hash(&header, &ChainId::SEPOLIA, Some(expected_hash));
         assert_eq!(hash, expected_hash, "sepolia block 63881 (v0.13.4) hash mismatch");
     }
 
@@ -593,7 +653,7 @@ mod tests {
     fn block_hash_sepolia_2473486_v0_14_0() {
         let json = fixture!("0.14.0/block/sepolia_2473486.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::SEPOLIA);
+        let hash = compute_hash(&header, &ChainId::SEPOLIA, Some(expected_hash));
         assert_eq!(hash, expected_hash, "sepolia block 2473486 (v0.14.0) hash mismatch");
     }
 
@@ -602,8 +662,109 @@ mod tests {
     fn block_hash_mainnet_2238855_v0_14_0() {
         let json = fixture!("0.14.0/block/mainnet_2238855.json");
         let (header, expected_hash) = header_from_fixture(json, None);
-        let hash = compute_hash(&header, &ChainId::MAINNET);
+        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
         assert_eq!(hash, expected_hash, "block 2238855 (v0.14.0) hash mismatch");
+    }
+
+    /// Block 833 — the first 0.7 block on mainnet.
+    ///
+    /// This block reports `starknet_version: ""` (UNVERSIONED) but must use the 0.7+
+    /// hash algorithm. Additionally, the sequencer address is not stored in the header
+    /// (zero), so the fallback sequencer address must be used.
+    #[test]
+    fn block_hash_mainnet_833_first_0_7_block() {
+        use super::{
+            effective_version, MAINNET_FALLBACK_SEQUENCER_ADDRESS, MAINNET_FIRST_0_7_BLOCK,
+        };
+
+        // Block 833 has starknet_version="" → UNVERSIONED, but it's on or after the cutoff
+        let header = Header {
+            number: 833,
+            starknet_version: StarknetVersion::UNVERSIONED,
+            ..Default::default()
+        };
+        assert_eq!(
+            effective_version(&header, &ChainId::MAINNET),
+            StarknetVersion::V0_7_0,
+            "block 833 should use 0.7 algorithm despite UNVERSIONED"
+        );
+
+        // Block 832 is still pre-0.7
+        let header = Header {
+            number: 832,
+            starknet_version: StarknetVersion::UNVERSIONED,
+            ..Default::default()
+        };
+        assert_eq!(
+            effective_version(&header, &ChainId::MAINNET),
+            StarknetVersion::UNVERSIONED,
+            "block 832 should use pre-0.7 algorithm"
+        );
+
+        // On Sepolia, UNVERSIONED blocks always use 0.7 (no pre-0.7 era)
+        let header = Header {
+            number: 0,
+            starknet_version: StarknetVersion::UNVERSIONED,
+            ..Default::default()
+        };
+        assert_eq!(
+            effective_version(&header, &ChainId::SEPOLIA),
+            StarknetVersion::V0_7_0,
+            "sepolia block 0 should use 0.7 algorithm"
+        );
+    }
+
+    /// Block 833 — full hash verification using gateway fixture.
+    ///
+    /// This block has `starknet_version: ""` but is the first 0.7 block. The test verifies
+    /// that the version cutoff + fallback sequencer address produce the correct hash.
+    #[test]
+    fn block_hash_mainnet_833() {
+        // The gateway returns starknet_version=null for this block; override to 0.7.0
+        // since compute_missing_commitments would infer this from the block number.
+        let (header, expected_hash) = header_from_fixture(
+            fixture!("0.7.0/block/mainnet_833.json"),
+            Some(StarknetVersion::V0_7_0),
+        );
+        let hash = compute_hash(&header, &ChainId::MAINNET, Some(expected_hash));
+        assert_eq!(hash, expected_hash, "block 833 (first 0.7 block) hash mismatch");
+    }
+
+    /// Block 833 — commitment reconstruction + hash verification.
+    ///
+    /// Simulates the full pipeline flow: reconstruct commitments (which also patches
+    /// starknet_version), then verify the hash. This mirrors what happens when syncing
+    /// via JSON-RPC where starknet_version, sequencer_address, and commitments are all
+    /// missing.
+    #[test]
+    fn reconstructs_missing_commitments_for_0_7_0_mainnet_833() {
+        let (mut block_data, _) = block_data_from_split_fixtures(
+            fixture!("0.7.0/block/mainnet_833.json"),
+            fixture!("0.7.0/state_update/mainnet_833.json"),
+        );
+
+        let expected_hash = block_data.block.block.hash;
+
+        // Reset fields as if downloaded from JSON-RPC
+        block_data.block.block.header.transactions_commitment = Felt::ZERO;
+        block_data.block.block.header.events_commitment = Felt::ZERO;
+        block_data.block.block.header.starknet_version = StarknetVersion::UNVERSIONED;
+        block_data.block.block.header.sequencer_address = Default::default();
+
+        compute_missing_commitments(
+            &mut block_data.block.block,
+            &block_data.receipts,
+            &block_data.state_updates.state_updates,
+            &ChainId::MAINNET,
+        );
+
+        let computed_hash =
+            compute_hash(&block_data.block.block.header, &ChainId::MAINNET, Some(expected_hash));
+
+        assert_eq!(
+            computed_hash, expected_hash,
+            "block 833 (first 0.7 block) hash mismatch after commitment reconstruction"
+        );
     }
 
     #[test]
@@ -621,6 +782,7 @@ mod tests {
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
+            &ChainId::MAINNET,
         );
 
         assert_eq!(
@@ -645,6 +807,7 @@ mod tests {
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
+            &ChainId::MAINNET,
         );
 
         assert_eq!(
@@ -672,6 +835,7 @@ mod tests {
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
+            &ChainId::SEPOLIA,
         );
 
         assert_eq!(
@@ -705,6 +869,7 @@ mod tests {
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
+            &ChainId::SEPOLIA,
         );
 
         assert_eq!(

--- a/crates/sync/stage/src/blocks/hash.rs
+++ b/crates/sync/stage/src/blocks/hash.rs
@@ -115,16 +115,26 @@ use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
 const MAINNET_FALLBACK_SEQUENCER_ADDRESS: ContractAddress =
     address!("0x021f4b90b0377c82bf330b7b5295820769e72d79d8acd0effa0ebde6e9988bc5");
 
-/// Patches the header for missing fields in the block header (for earlier blocks) and computes the
-/// block hash.
-pub fn patch_header_and_compute_hash(
+/// Patches the header for missing fields in the block header (earlier Starknet blocks omit some
+/// fields) and computes the block hash.
+pub fn patch_and_verify_block_hash(
     block: &mut SealedBlock,
     receipts: &[Receipt],
     state_updates: &StateUpdates,
     chain_id: &ChainId,
-) -> Felt {
+) -> bool {
+    let expected_hash = block.hash;
+
     patch_missing_fields(block, receipts, state_updates, chain_id);
-    compute_hash(&block.header, chain_id)
+    let computed_hash = compute_hash(&block.header, chain_id);
+
+    if expected_hash != computed_hash {
+        block.header.sequencer_address = MAINNET_FALLBACK_SEQUENCER_ADDRESS;
+        let updated_computed_hash = compute_hash(&block.header, chain_id);
+        updated_computed_hash == expected_hash
+    } else {
+        true
+    }
 }
 
 /// Computes the block hash for a header, dispatching to the correct algorithm based
@@ -138,13 +148,20 @@ pub fn patch_header_and_compute_hash(
 pub fn compute_hash(header: &Header, chain_id: &ChainId) -> Felt {
     let version_str = header.starknet_version.to_string();
 
+    // [0, 0.7.0)
     if header.starknet_version < StarknetVersion::V0_7_0 {
         compute_hash_pre_0_7(header, chain_id)
-    } else if header.starknet_version < StarknetVersion::V0_13_2 {
+    }
+    // [0.7.0, 0.13.2)
+    else if header.starknet_version < StarknetVersion::V0_13_2 {
         compute_hash_pre_0_13_2(header)
-    } else if header.starknet_version < StarknetVersion::V0_13_4 {
+    }
+    // [0.13.2, 0.13.4)
+    else if header.starknet_version < StarknetVersion::V0_13_4 {
         compute_hash_post_0_13_2(header, &version_str)
-    } else {
+    }
+    // [0.13.4, ..)
+    else {
         compute_hash_post_0_13_4(header, &version_str)
     }
 }
@@ -300,16 +317,16 @@ pub(crate) fn patch_missing_fields(
         block.header.events_commitment = compute_event_commitment(&block.body, receipts, version);
     }
 
-    // For early mainnet blocks, the sequencer address was not stored in the header.
-    //
-    // Early sepolia blocks (>= block 0) already has a non-zero sequencer address.
-    if block.header.sequencer_address == ContractAddress::ZERO && chain_id == &ChainId::MAINNET {
-        block.header.sequencer_address = MAINNET_FALLBACK_SEQUENCER_ADDRESS;
-    }
-
     // The rest of the commitments are only meaningful from 0.13.2 onward.
     if version < StarknetVersion::V0_13_2 {
         return;
+    }
+
+    // For early mainnet blocks, the sequencer address was not stored in the header.
+    //
+    // Early sepolia blocks (>= block 0) already have a non-zero sequencer address.
+    if block.header.sequencer_address == ContractAddress::ZERO && chain_id == &ChainId::MAINNET {
+        block.header.sequencer_address = MAINNET_FALLBACK_SEQUENCER_ADDRESS;
     }
 
     // Post-0.13.2 block hashes include `state_diff_length` and `state_diff_commitment`.
@@ -551,7 +568,7 @@ mod tests {
     use num_traits::ToPrimitive;
 
     use super::{compute_hash, patch_missing_fields};
-    use crate::blocks::hash::patch_header_and_compute_hash;
+    use crate::blocks::hash::patch_and_verify_block_hash;
     use crate::blocks::BlockData;
 
     /// Shorthand for including a gateway test fixture file at compile time.
@@ -684,22 +701,12 @@ mod tests {
             fixture!("0.7.0/state_update/mainnet_833.json"),
         );
 
-        let expected_hash = block_data.block.block.hash;
-
-        // Reset fields as if downloaded from JSON-RPC
-        block_data.block.block.header.transactions_commitment = Felt::ZERO;
-        block_data.block.block.header.events_commitment = Felt::ZERO;
-        block_data.block.block.header.starknet_version = StarknetVersion::UNVERSIONED;
-        block_data.block.block.header.sequencer_address = Default::default();
-
-        patch_header_and_compute_hash(
+        assert!(patch_and_verify_block_hash(
             &mut block_data.block.block,
             &block_data.receipts,
             &block_data.state_updates.state_updates,
             &ChainId::MAINNET,
-        );
-
-        assert_eq!(computed_hash, expected_hash);
+        ));
     }
 
     #[test]

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -120,12 +120,10 @@ where
             // These are CPU-bound hash computations with no inter-block dependencies.
             let mut blocks = blocks;
             blocks.par_iter_mut().for_each(|block_data| {
+                let block_hash = block_data.block.block.hash;
                 let block_number = block_data.block.block.header.number;
 
-                // Compute missing commitments for older blocks where the source
-                // doesn't include them in the block header. This also patches
-                // starknet_version for early blocks that don't populate it.
-                hash::compute_missing_commitments(
+                let computed_block_hash = hash::patch_header_and_compute_hash(
                     &mut block_data.block.block,
                     &block_data.receipts,
                     &block_data.state_updates.state_updates,
@@ -133,18 +131,11 @@ where
                 );
 
                 // Verify the block hash matches what we compute locally.
-                let expected = block_data.block.block.hash;
-                let computed_hash = hash::compute_hash(
-                    &block_data.block.block.header,
-                    &self.chain_id,
-                    Some(expected),
-                );
-
-                if computed_hash != expected {
+                if computed_block_hash != block_hash {
                     warn!(
                         block = %block_number,
                         expected = %format!("{:#x}", block_data.block.block.hash),
-                        computed = %format!("{:#x}", computed_hash),
+                        computed = %format!("{:#x}", computed_block_hash),
                         "Block hash mismatch"
                     );
                 }

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -15,7 +15,7 @@ use katana_provider::api::block::{BlockHashProvider, BlockWriter};
 use katana_provider::api::state::HistoricalStateRetentionProvider;
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderError, ProviderFactory};
 use rayon::prelude::*;
-use tracing::{error, info_span, warn, Instrument};
+use tracing::{error, info_span, Instrument};
 
 use crate::{
     PruneInput, PruneOutput, PruneResult, Stage, StageExecutionInput, StageExecutionOutput,
@@ -119,27 +119,26 @@ where
             // Phase 1: Compute commitments and verify hashes in parallel.
             // These are CPU-bound hash computations with no inter-block dependencies.
             let mut blocks = blocks;
-            blocks.par_iter_mut().for_each(|block_data| {
+            blocks.par_iter_mut().try_for_each(|block_data| {
                 let block_hash = block_data.block.block.hash;
-                let block_number = block_data.block.block.header.number;
+                let block_num = block_data.block.block.header.number;
 
-                let computed_block_hash = hash::patch_header_and_compute_hash(
+                let verified = hash::patch_and_verify_block_hash(
                     &mut block_data.block.block,
                     &block_data.receipts,
                     &block_data.state_updates.state_updates,
                     &self.chain_id,
                 );
 
-                // Verify the block hash matches what we compute locally.
-                if computed_block_hash != block_hash {
-                    warn!(
-                        block = %block_number,
-                        expected = %format!("{:#x}", block_data.block.block.hash),
-                        computed = %format!("{:#x}", computed_block_hash),
-                        "Block hash mismatch"
-                    );
+                if verified {
+                    Ok(())
+                } else {
+                    Err(Error::BlockVerificationFailed {
+                        block_num,
+                        expected_block_hash: block_hash,
+                    })
                 }
-            });
+            })?;
 
             // Phase 2: Write blocks to the database sequentially.
             let provider_mut = self.provider.provider_mut();
@@ -528,9 +527,6 @@ pub enum Error {
     )]
     ChainInvariantViolation { block_num: u64, parent_hash: Felt, expected_hash: Felt },
 
-    #[error(
-        "block hash mismatch: block {block_num} gateway hash {expected:#x} does not match \
-         computed hash {computed:#x}"
-    )]
-    BlockHashMismatch { block_num: u64, expected: Felt, computed: Felt },
+    #[error("block hash verification failed: block {block_num} hash {expected_block_hash:#x}")]
+    BlockVerificationFailed { block_num: u64, expected_block_hash: Felt },
 }

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -123,18 +123,24 @@ where
                 let block_number = block_data.block.block.header.number;
 
                 // Compute missing commitments for older blocks where the source
-                // doesn't include them in the block header.
+                // doesn't include them in the block header. This also patches
+                // starknet_version for early blocks that don't populate it.
                 hash::compute_missing_commitments(
                     &mut block_data.block.block,
                     &block_data.receipts,
                     &block_data.state_updates.state_updates,
+                    &self.chain_id,
                 );
 
                 // Verify the block hash matches what we compute locally.
-                let computed_hash =
-                    hash::compute_hash(&block_data.block.block.header, &self.chain_id);
+                let expected = block_data.block.block.hash;
+                let computed_hash = hash::compute_hash(
+                    &block_data.block.block.header,
+                    &self.chain_id,
+                    Some(expected),
+                );
 
-                if computed_hash != block_data.block.block.hash {
+                if computed_hash != expected {
                     warn!(
                         block = %block_number,
                         expected = %format!("{:#x}", block_data.block.block.hash),

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
+use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 
 use katana_gateway_client::Client as SequencerGateway;
@@ -7,12 +8,13 @@ use katana_gateway_types::{
     Block, BlockStatus, ConfirmedStateUpdate, StateDiff, StateUpdate, StateUpdateWithBlock,
 };
 use katana_primitives::block::{
-    BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,
+    BlockHash, BlockNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus,
 };
 use katana_primitives::chain::ChainId;
 use katana_primitives::class::ClassHash;
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
+use katana_primitives::version::StarknetVersion;
 use katana_primitives::{felt, ContractAddress, Felt};
 use katana_provider::api::block::{BlockHashProvider, BlockNumberProvider, BlockWriter};
 use katana_provider::api::state::{
@@ -20,6 +22,7 @@ use katana_provider::api::state::{
 };
 use katana_provider::api::state_update::StateUpdateProvider;
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderError, ProviderFactory};
+use katana_stage::blocks::hash::compute_hash;
 use katana_stage::blocks::{BatchBlockDownloader, BlockData, BlockDownloader, Blocks};
 use katana_stage::{PruneInput, Stage, StageExecutionInput};
 use rstest::rstest;
@@ -53,6 +56,14 @@ impl MockBlockDownloader {
     /// `block_data` is returned.
     fn with_block(self, block_number: BlockNumber, block_data: StateUpdateWithBlock) -> Self {
         self.responses.lock().unwrap().insert(block_number, Ok(block_data));
+        self
+    }
+
+    fn with_blocks<I>(self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = (BlockNumber, StateUpdateWithBlock)>,
+    {
+        self.responses.lock().unwrap().extend(iter.into_iter().map(|(k, v)| (k, Ok(v))));
         self
     }
 
@@ -121,34 +132,40 @@ impl BlockDownloader for MockBlockDownloader {
     }
 }
 
-/// Creates a new in-memory provider with an initial block stored.
-fn create_provider_with_block(block: SealedBlockWithStatus) -> DbProviderFactory {
+fn create_provider_with_blocks(blocks: Vec<SealedBlockWithStatus>) -> DbProviderFactory {
     let provider_factory = DbProviderFactory::new_in_memory();
     let provider_mut = provider_factory.provider_mut();
-    provider_mut
-        .insert_block_with_states_and_receipts(block, Default::default(), Vec::new(), Vec::new())
-        .expect("failed to insert initial block");
+
+    for block in blocks {
+        provider_mut
+            .insert_block_with_states_and_receipts(
+                block,
+                Default::default(),
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+    }
+
     provider_mut.commit().expect("failed to commit");
     provider_factory
 }
 
-fn create_provider_with_blocks(
-    blocks: std::ops::RangeInclusive<BlockNumber>,
-    updates_by_block: BTreeMap<BlockNumber, StateUpdatesWithClasses>,
+fn create_provider_with_block_range(
+    block_range: RangeInclusive<BlockNumber>,
+    state_updates: BTreeMap<BlockNumber, StateUpdatesWithClasses>,
 ) -> DbProviderFactory {
     let provider_factory = DbProviderFactory::new_in_memory();
     let provider_mut = provider_factory.provider_mut();
+    let blocks = create_stored_blocks(block_range);
 
-    for block_number in blocks {
-        let state_updates = updates_by_block.get(&block_number).cloned().unwrap_or_default();
+    for block in blocks {
+        let block_num = block.block.header.number;
+        let state_updates = state_updates.get(&block_num).cloned().unwrap_or_default();
+
         provider_mut
-            .insert_block_with_states_and_receipts(
-                create_stored_block(block_number),
-                state_updates,
-                Vec::new(),
-                Vec::new(),
-            )
-            .expect("failed to insert block");
+            .insert_block_with_states_and_receipts(block, state_updates, Vec::new(), Vec::new())
+            .unwrap();
     }
 
     provider_mut.commit().expect("failed to commit");
@@ -181,21 +198,31 @@ fn get_stored_block_numbers(
     expected_range.filter(|&num| p.block_hash_by_num(num).ok().flatten().is_some()).collect()
 }
 
-/// Helper function to create a minimal test `SealedBlockWithStatus`.
-///
-/// Creates a block with the given number and automatically sets the parent hash
-/// to the hash of block N-1 (using `Felt::from(block_number - 1)`).
-fn create_stored_block(block_number: BlockNumber) -> SealedBlockWithStatus {
+fn create_stored_blocks(block_range: RangeInclusive<BlockNumber>) -> Vec<SealedBlockWithStatus> {
+    let mut blocks: Vec<SealedBlockWithStatus> = Vec::new();
+
+    let offset = *block_range.start();
+    for i in block_range {
+        let idx = i.abs_diff(offset) as usize;
+        let parent_hash = if idx == 0 { Felt::ZERO } else { blocks[idx - 1].block.hash };
+
+        blocks.push(create_stored_block(i, parent_hash));
+    }
+
+    blocks
+}
+
+fn create_stored_block(block_number: BlockNumber, parent_hash: BlockHash) -> SealedBlockWithStatus {
     let header = Header {
         number: block_number,
-        parent_hash: Felt::from(block_number.saturating_sub(1)),
-        timestamp: block_number,
+        parent_hash,
+        timestamp: 0,
         sequencer_address: ContractAddress::default(),
         l1_gas_prices: Default::default(),
         l1_data_gas_prices: Default::default(),
         l2_gas_prices: Default::default(),
         l1_da_mode: L1DataAvailabilityMode::Calldata,
-        starknet_version: Default::default(),
+        starknet_version: StarknetVersion::V0_13_4,
         state_root: Felt::ZERO,
         state_diff_commitment: Felt::ZERO,
         transactions_commitment: Felt::ZERO,
@@ -206,24 +233,18 @@ fn create_stored_block(block_number: BlockNumber) -> SealedBlockWithStatus {
         state_diff_length: 0,
     };
 
+    // the chain id is irrelevant here because the block is using starknet version 0.13.4
+    // only block pre 0.7.0 uses chain id in the hash computation
+    let hash = compute_hash(&header, &ChainId::SEPOLIA);
+
     SealedBlockWithStatus {
-        block: SealedBlock { hash: Felt::from(block_number), header, body: Vec::new() },
+        block: SealedBlock { hash, header, body: Vec::new() },
         status: FinalityStatus::AcceptedOnL2,
     }
 }
 
-/// Helper function to create a minimal test block. The created block has a parent hash == block
-/// number - 1 for simplicity sake
-fn create_downloaded_block(block_number: BlockNumber) -> StateUpdateWithBlock {
-    create_downloaded_block_with_parent(block_number, Felt::from(block_number.saturating_sub(1)))
-}
-
-/// Helper function to create a test block with a specific parent hash.
-fn create_downloaded_block_with_parent(
-    block_number: BlockNumber,
-    parent_hash: Felt,
-) -> StateUpdateWithBlock {
-    StateUpdateWithBlock {
+fn create_downloaded_block(block_number: BlockNumber, parent_hash: Felt) -> StateUpdateWithBlock {
+    let mut downloaded_block = StateUpdateWithBlock {
         block: Block {
             status: BlockStatus::AcceptedOnL2,
             block_hash: Some(Felt::from(block_number)),
@@ -251,7 +272,13 @@ fn create_downloaded_block_with_parent(
             old_root: Felt::ZERO,
             state_diff: StateDiff::default(),
         }),
-    }
+    };
+
+    let block: BlockData = downloaded_block.clone().into();
+    let actual_block_hash = compute_hash(&block.block.block.header, &ChainId::SEPOLIA);
+
+    downloaded_block.block.block_hash = Some(actual_block_hash);
+    downloaded_block
 }
 
 #[rstest]
@@ -264,12 +291,23 @@ async fn download_and_store_blocks(
     #[case] to_block: BlockNumber,
     #[case] expected_blocks: Vec<BlockNumber>,
 ) {
-    let provider = create_provider_with_block(create_stored_block(from_block - 1));
-    let mut downloader = MockBlockDownloader::new();
+    let genesis = create_stored_block(from_block - 1, BlockHash::ZERO);
+    let mut downloaded_blocks: Vec<(BlockNumber, StateUpdateWithBlock)> = Vec::new();
 
-    for block_num in from_block..=to_block {
-        downloader = downloader.with_block(block_num, create_downloaded_block(block_num));
+    for i in from_block..=to_block {
+        let idx = (i % from_block) as usize;
+
+        let parent_hash = if idx == 0 {
+            genesis.block.hash
+        } else {
+            downloaded_blocks[idx - 1].1.block.block_hash.unwrap()
+        };
+
+        downloaded_blocks.push((i, create_downloaded_block(i, parent_hash)));
     }
+
+    let provider = create_provider_with_blocks(vec![genesis]);
+    let downloader = MockBlockDownloader::new().with_blocks(downloaded_blocks);
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(from_block, to_block);
@@ -290,9 +328,11 @@ async fn download_failure_returns_error() {
     let block_number = 100;
     let error_msg = "Network error".to_string();
 
+    // Create provider with initial block number 99
+    let genesis = create_stored_block(99, BlockHash::ZERO);
+    let provider = create_provider_with_blocks(vec![genesis]);
+
     let downloader = MockBlockDownloader::new().with_error(block_number, error_msg.clone());
-    // Create provider with initial block at block_number - 1
-    let provider = create_provider_with_block(create_stored_block(block_number - 1));
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(block_number, block_number);
@@ -322,13 +362,26 @@ async fn partial_download_failure_stops_execution() {
     let to_block = 105;
 
     // Configure first 3 blocks to succeed, 4th to fail
-    let mut downloader = MockBlockDownloader::new();
-    for block_num in from_block..=102 {
-        downloader = downloader.with_block(block_num, create_downloaded_block(block_num));
-    }
-    downloader = downloader.with_error(103, "Block not found".to_string());
+    let mut downloaded_blocks: Vec<(BlockNumber, StateUpdateWithBlock)> = Vec::new();
 
-    let provider = create_provider_with_block(create_stored_block(from_block - 1));
+    for block_num in from_block..=102 {
+        let idx = (block_num % from_block) as usize;
+
+        let parent_hash = if idx == 0 {
+            BlockHash::ZERO
+        } else {
+            downloaded_blocks[idx - 1].1.block.block_hash.unwrap()
+        };
+
+        let block = create_downloaded_block(block_num, parent_hash);
+        downloaded_blocks.push((block_num, block));
+    }
+
+    let downloader = MockBlockDownloader::new()
+        .with_blocks(downloaded_blocks)
+        .with_error(103, "Block not found".to_string());
+
+    let provider = create_provider_with_block_range(99..=99, Default::default());
     let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
 
     let input = StageExecutionInput::new(from_block, to_block);
@@ -348,9 +401,9 @@ async fn fetch_blocks_from_gateway() {
     let from_block = 308919;
     let to_block = from_block + 2;
 
-    // Create provider with initial block before the test range
-    // The parent hash must match what the network returns for block from_block
-    let provider = create_provider_with_block(create_stored_block(from_block - 1));
+    let genesis = create_stored_block(from_block - 1, BlockHash::ZERO);
+    let provider = create_provider_with_blocks(vec![genesis]);
+
     let feeder_gateway = SequencerGateway::sepolia();
     let downloader = BatchBlockDownloader::new_gateway(feeder_gateway, 10);
 
@@ -369,9 +422,14 @@ async fn fetch_blocks_from_gateway() {
 async fn downloaded_blocks_do_not_form_valid_chain_with_stored_blocks() {
     use katana_stage::blocks;
 
-    let provider = create_provider_with_block(create_stored_block(99));
-    let downloader = MockBlockDownloader::new()
-        .with_block(100, create_downloaded_block_with_parent(100, felt!("0x1337")));
+    let genesis = create_stored_block(99, BlockHash::ZERO);
+    let expected_parent_hash = genesis.block.hash;
+
+    let provider = create_provider_with_blocks(vec![genesis]);
+
+    // download a block with an invalid parent hash
+    let block1 = create_downloaded_block(100, felt!("0x1337"));
+    let downloader = MockBlockDownloader::new().with_block(100, block1);
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(100, 100);
@@ -381,7 +439,7 @@ async fn downloaded_blocks_do_not_form_valid_chain_with_stored_blocks() {
     let expected_error = blocks::Error::ChainInvariantViolation {
         block_num: 100,
         parent_hash: felt!("0x1337"),
-        expected_hash: felt!("99"),
+        expected_hash: expected_parent_hash,
     };
 
     // Should fail with chain invariant violation
@@ -404,13 +462,18 @@ async fn downloaded_blocks_do_not_form_valid_chain_with_stored_blocks() {
 async fn downloaded_blocks_do_not_form_valid_chain() {
     use katana_stage::blocks;
 
-    let provider = create_provider_with_block(create_stored_block(99));
+    let genesis = create_stored_block(99, BlockHash::ZERO);
+    let block1 = create_downloaded_block(100, genesis.block.hash);
+    let block2 = create_downloaded_block(101, block1.block.block_hash.unwrap());
+
+    let expected_prev_block_hash = block2.block.block_hash.clone().unwrap();
+
+    let provider = create_provider_with_blocks(vec![genesis]);
     let downloader = MockBlockDownloader::new()
-        .with_block(100, create_downloaded_block(100))
-        .with_block(101, create_downloaded_block(101))
-        // Create blocks where block 102 has an invalid parent hash
-        // Block 102 with incorrect parent hash (should be 101)
-        .with_block(102, create_downloaded_block_with_parent(102, Felt::from(999)));
+        .with_block(100, block1)
+        .with_block(101, block2)
+        // block 102 has an invalid parent hash
+        .with_block(102, create_downloaded_block(102, Felt::from(999)));
 
     let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
     let input = StageExecutionInput::new(100, 102);
@@ -420,7 +483,7 @@ async fn downloaded_blocks_do_not_form_valid_chain() {
     let expected_error = blocks::Error::ChainInvariantViolation {
         block_num: 102,
         parent_hash: felt!("999"),
-        expected_hash: felt!("101"),
+        expected_hash: expected_prev_block_hash,
     };
 
     // Should fail with chain invariant violation
@@ -460,7 +523,7 @@ async fn prune_compacts_state_history_at_boundary() {
         ),
     );
 
-    let provider = create_provider_with_blocks(0..=8, updates_by_block);
+    let provider = create_provider_with_block_range(0..=8, updates_by_block);
     let mut stage = Blocks::new(provider.clone(), MockBlockDownloader::new(), ChainId::SEPOLIA);
 
     // keep_from = 5, prune range = [0, 5)
@@ -499,7 +562,7 @@ async fn prune_compacts_state_history_at_boundary() {
 
 #[tokio::test]
 async fn historical_returns_pruned_error_below_retention_boundary() {
-    let provider = create_provider_with_blocks(0..=8, BTreeMap::new());
+    let provider = create_provider_with_block_range(0..=8, BTreeMap::new());
 
     let provider_mut = provider.provider_mut();
     provider_mut.set_earliest_available_state_block(5).unwrap();
@@ -519,7 +582,7 @@ async fn historical_returns_pruned_error_below_retention_boundary() {
 
 #[tokio::test]
 async fn blocks_prune_does_not_decrease_existing_retention_boundary() {
-    let provider = create_provider_with_blocks(0..=8, BTreeMap::new());
+    let provider = create_provider_with_block_range(0..=8, BTreeMap::new());
     let mut stage = Blocks::new(provider.clone(), MockBlockDownloader::new(), ChainId::SEPOLIA);
 
     let provider_mut = provider.provider_mut();
@@ -527,7 +590,7 @@ async fn blocks_prune_does_not_decrease_existing_retention_boundary() {
     provider_mut.commit().unwrap();
 
     // keep_from=5
-    let _output =
-        stage.prune(&PruneInput::new(8, Some(3), None)).await.expect("prune must succeed");
+
+    stage.prune(&PruneInput::new(8, Some(3), None)).await.expect("prune must succeed");
     assert_eq!(provider.provider_mut().earliest_available_state_block().unwrap(), Some(10));
 }


### PR DESCRIPTION
The block hash algorithm changed at **mainnet block 833** (Starknet 0.7 release), but early blocks don't have the `starknet_version` header field populated. The hash computation was using version-based dispatch, treating **all unversioned blocks as pre-0.7** — causing hash mismatches for blocks 833 and above.

This switches to block number-based cutoffs for unversioned blocks on mainnet (matching Pathfinder's approach). It also handles the 0.7–0.8.2 era where the sequencer address wasn't stored in block headers by falling back to the known sequencer address from that period when the hash doesn't match.