### PR TITLE
fix(sync): move `Blocks` stage blocking work off async runtime

### DIFF
--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -183,13 +183,23 @@ impl Node {
         if let Some(SyncSource::JsonRpc(ref rpc_url)) = config.sync_source {
             let rpc_client = katana_starknet::rpc::Client::new(rpc_url.clone());
             let block_downloader = JsonRpcBlockDownloader::new_json_rpc(rpc_client.clone(), 20);
-            pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
+            pipeline.add_stage(Blocks::new(
+                storage_provider.clone(),
+                block_downloader,
+                chain_id,
+                task_spawner.clone(),
+            ));
 
             let class_downloader = JsonRpcClassDownloader::new(rpc_client, 20);
             pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
         } else {
             let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
-            pipeline.add_stage(Blocks::new(storage_provider.clone(), block_downloader, chain_id));
+            pipeline.add_stage(Blocks::new(
+                storage_provider.clone(),
+                block_downloader,
+                chain_id,
+                task_spawner.clone(),
+            ));
 
             let class_downloader = GatewayClassDownloader::new(gateway_client.clone(), 20);
             pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));

--- a/crates/sync/stage/src/blocks/mod.rs
+++ b/crates/sync/stage/src/blocks/mod.rs
@@ -14,6 +14,7 @@ use katana_primitives::Felt;
 use katana_provider::api::block::{BlockHashProvider, BlockWriter};
 use katana_provider::api::state::HistoricalStateRetentionProvider;
 use katana_provider::{DbProviderFactory, MutableProvider, ProviderError, ProviderFactory};
+use katana_tasks::TaskSpawner;
 use rayon::prelude::*;
 use tracing::{error, info_span, Instrument};
 
@@ -36,61 +37,69 @@ pub struct Blocks<B> {
     provider: DbProviderFactory,
     downloader: B,
     chain_id: ChainId,
+    task_spawner: TaskSpawner,
 }
 
 impl<B> Blocks<B> {
     /// Create a new [`Blocks`] stage.
-    pub fn new(provider: DbProviderFactory, downloader: B, chain_id: ChainId) -> Self {
-        Self { provider, downloader, chain_id }
+    pub fn new(
+        provider: DbProviderFactory,
+        downloader: B,
+        chain_id: ChainId,
+        task_spawner: TaskSpawner,
+    ) -> Self {
+        Self { provider, downloader, chain_id, task_spawner }
+    }
+}
+
+/// Validates that the downloaded blocks form a valid chain.
+///
+/// Checks the chain invariant: block N's parent hash must be block N-1's hash.
+/// For the first block in the list (if not block 0), it fetches the parent hash from storage.
+fn validate_chain_invariant(
+    provider: &DbProviderFactory,
+    blocks: &[BlockData],
+) -> Result<(), Error> {
+    if blocks.is_empty() {
+        return Ok(());
     }
 
-    /// Validates that the downloaded blocks form a valid chain.
-    ///
-    /// This method checks the chain invariant: block N's parent hash must be block N-1's hash.
-    /// For the first block in the list (if not block 0), it fetches the parent hash from storage.
-    fn validate_chain_invariant(&self, blocks: &[BlockData]) -> Result<(), Error> {
-        if blocks.is_empty() {
-            return Ok(());
+    let first_block = &blocks[0].block.block;
+    let first_block_num = first_block.header.number;
+
+    if first_block_num > 0 {
+        let parent_block_num = first_block_num - 1;
+        let expected_parent_hash = provider
+            .provider()
+            .block_hash_by_num(parent_block_num)?
+            .ok_or(ProviderError::MissingBlockHash(parent_block_num))?;
+
+        if first_block.header.parent_hash != expected_parent_hash {
+            return Err(Error::ChainInvariantViolation {
+                block_num: first_block_num,
+                parent_hash: first_block.header.parent_hash,
+                expected_hash: expected_parent_hash,
+            });
         }
-
-        let first_block = &blocks[0].block.block;
-        let first_block_num = first_block.header.number;
-
-        if first_block_num > 0 {
-            let parent_block_num = first_block_num - 1;
-            let expected_parent_hash = self
-                .provider
-                .provider()
-                .block_hash_by_num(parent_block_num)?
-                .ok_or(ProviderError::MissingBlockHash(parent_block_num))?;
-
-            if first_block.header.parent_hash != expected_parent_hash {
-                return Err(Error::ChainInvariantViolation {
-                    block_num: first_block_num,
-                    parent_hash: first_block.header.parent_hash,
-                    expected_hash: expected_parent_hash,
-                });
-            }
-        }
-
-        for window in blocks.windows(2) {
-            let prev_block = &window[0].block.block;
-            let curr_block = &window[1].block.block;
-
-            let prev_hash = prev_block.hash;
-            let curr_block_num = curr_block.header.number;
-
-            if curr_block.header.parent_hash != prev_hash {
-                return Err(Error::ChainInvariantViolation {
-                    block_num: curr_block_num,
-                    parent_hash: curr_block.header.parent_hash,
-                    expected_hash: prev_hash,
-                });
-            }
-        }
-
-        Ok(())
     }
+
+    for window in blocks.windows(2) {
+        let prev_block = &window[0].block.block;
+        let curr_block = &window[1].block.block;
+
+        let prev_hash = prev_block.hash;
+        let curr_block_num = curr_block.header.number;
+
+        if curr_block.header.parent_hash != prev_hash {
+            return Err(Error::ChainInvariantViolation {
+                block_num: curr_block_num,
+                parent_hash: curr_block.header.parent_hash,
+                expected_hash: prev_hash,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 impl<D> Stage for Blocks<D>
@@ -113,53 +122,69 @@ where
             let span = info_span!(target: "stage", "blocks.insert", from = %input.from(), to = %input.to());
             let _enter = span.enter();
 
-            // TODO: spawn onto a blocking thread pool
-            self.validate_chain_invariant(&blocks)?;
+            // Validate chain invariant and compute commitments/hashes in parallel on the CPU pool.
+            let chain_id = self.chain_id;
+            let provider = self.provider.clone();
+            let mut blocks = self
+                .task_spawner
+                .cpu_bound()
+                .spawn(move || {
+                    validate_chain_invariant(&provider, &blocks)?;
 
-            // Phase 1: Compute commitments and verify hashes in parallel.
-            // These are CPU-bound hash computations with no inter-block dependencies.
-            let mut blocks = blocks;
-            blocks.par_iter_mut().try_for_each(|block_data| {
-                let block_hash = block_data.block.block.hash;
-                let block_num = block_data.block.block.header.number;
+                    let mut blocks = blocks;
+                    blocks.par_iter_mut().try_for_each(|block_data| {
+                        let block_hash = block_data.block.block.hash;
+                        let block_num = block_data.block.block.header.number;
 
-                let verified = hash::patch_and_verify_block_hash(
-                    &mut block_data.block.block,
-                    &block_data.receipts,
-                    &block_data.state_updates.state_updates,
-                    &self.chain_id,
-                );
+                        let verified = hash::patch_and_verify_block_hash(
+                            &mut block_data.block.block,
+                            &block_data.receipts,
+                            &block_data.state_updates.state_updates,
+                            &chain_id,
+                        );
 
-                if verified {
-                    Ok(())
-                } else {
-                    Err(Error::BlockVerificationFailed {
-                        block_num,
-                        expected_block_hash: block_hash,
-                    })
-                }
-            })?;
+                        if verified {
+                            Ok(())
+                        } else {
+                            Err(Error::BlockVerificationFailed {
+                                block_num,
+                                expected_block_hash: block_hash,
+                            })
+                        }
+                    })?;
 
-            // Phase 2: Write blocks to the database sequentially.
-            let provider_mut = self.provider.provider_mut();
+                    Result::<_, Error>::Ok(blocks)
+                })
+                .await
+                .map_err(Error::TaskJoinError)??;
 
-            for block_data in blocks {
-                let BlockData { block, receipts, state_updates } = block_data;
-                let block_number = block.block.header.number;
+            // Write blocks to the database sequentially.
+            let provider = self.provider.clone();
+            self.task_spawner
+                .spawn_blocking(move || {
+                    let provider_mut = provider.provider_mut();
 
-                provider_mut
-                    .insert_block_with_states_and_receipts(
-                        block,
-                        state_updates,
-                        receipts,
-                        Vec::new(),
-                    )
-                    .inspect_err(
-                        |e| error!(error = %e, block = %block_number, "Error storing block."),
-                    )?;
-            }
+                    for block_data in blocks.drain(..) {
+                        let BlockData { block, receipts, state_updates } = block_data;
+                        let block_number = block.block.header.number;
 
-            provider_mut.commit()?;
+                        provider_mut
+                            .insert_block_with_states_and_receipts(
+                                block,
+                                state_updates,
+                                receipts,
+                                Vec::new(),
+                            )
+                            .inspect_err(
+                                |e| error!(error = %e, block = %block_number, "Error storing block."),
+                            )?;
+                    }
+
+                    provider_mut.commit()?;
+                    Result::<(), Error>::Ok(())
+                })
+                .await
+                .map_err(Error::TaskJoinError)??;
 
             Ok(StageExecutionOutput { last_block_processed: input.to() })
         })
@@ -529,4 +554,7 @@ pub enum Error {
 
     #[error("block hash verification failed: block {block_num} hash {expected_block_hash:#x}")]
     BlockVerificationFailed { block_num: u64, expected_block_hash: Felt },
+
+    #[error("task join error: {0}")]
+    TaskJoinError(katana_tasks::JoinError),
 }

--- a/crates/sync/stage/tests/block.rs
+++ b/crates/sync/stage/tests/block.rs
@@ -25,6 +25,7 @@ use katana_provider::{DbProviderFactory, MutableProvider, ProviderError, Provide
 use katana_stage::blocks::hash::compute_hash;
 use katana_stage::blocks::{BatchBlockDownloader, BlockData, BlockDownloader, Blocks};
 use katana_stage::{PruneInput, Stage, StageExecutionInput};
+use katana_tasks::TaskManager;
 use rstest::rstest;
 use starknet::core::types::ResourcePrice;
 
@@ -309,7 +310,12 @@ async fn download_and_store_blocks(
     let provider = create_provider_with_blocks(vec![genesis]);
     let downloader = MockBlockDownloader::new().with_blocks(downloaded_blocks);
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        downloader.clone(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
     let input = StageExecutionInput::new(from_block, to_block);
 
     let result = stage.execute(&input).await;
@@ -334,7 +340,12 @@ async fn download_failure_returns_error() {
 
     let downloader = MockBlockDownloader::new().with_error(block_number, error_msg.clone());
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        downloader.clone(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
     let input = StageExecutionInput::new(block_number, block_number);
 
     let result = stage.execute(&input).await;
@@ -382,7 +393,12 @@ async fn partial_download_failure_stops_execution() {
         .with_error(103, "Block not found".to_string());
 
     let provider = create_provider_with_block_range(99..=99, Default::default());
-    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        downloader.clone(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
 
     let input = StageExecutionInput::new(from_block, to_block);
     let result = stage.execute(&input).await;
@@ -407,7 +423,12 @@ async fn fetch_blocks_from_gateway() {
     let feeder_gateway = SequencerGateway::sepolia();
     let downloader = BatchBlockDownloader::new_gateway(feeder_gateway, 10);
 
-    let mut stage = Blocks::new(provider.clone(), downloader, ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        downloader,
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
 
     let input = StageExecutionInput::new(from_block, to_block);
     stage.execute(&input).await.expect("failed to execute stage");
@@ -431,7 +452,12 @@ async fn downloaded_blocks_do_not_form_valid_chain_with_stored_blocks() {
     let block1 = create_downloaded_block(100, felt!("0x1337"));
     let downloader = MockBlockDownloader::new().with_block(100, block1);
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        downloader.clone(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
     let input = StageExecutionInput::new(100, 100);
 
     let result = stage.execute(&input).await;
@@ -475,7 +501,12 @@ async fn downloaded_blocks_do_not_form_valid_chain() {
         // block 102 has an invalid parent hash
         .with_block(102, create_downloaded_block(102, Felt::from(999)));
 
-    let mut stage = Blocks::new(provider.clone(), downloader.clone(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        downloader.clone(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
     let input = StageExecutionInput::new(100, 102);
 
     let result = stage.execute(&input).await;
@@ -524,7 +555,12 @@ async fn prune_compacts_state_history_at_boundary() {
     );
 
     let provider = create_provider_with_block_range(0..=8, updates_by_block);
-    let mut stage = Blocks::new(provider.clone(), MockBlockDownloader::new(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        MockBlockDownloader::new(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
 
     // keep_from = 5, prune range = [0, 5)
     let output = stage.prune(&PruneInput::new(8, Some(3), None)).await.expect("prune must succeed");
@@ -583,7 +619,12 @@ async fn historical_returns_pruned_error_below_retention_boundary() {
 #[tokio::test]
 async fn blocks_prune_does_not_decrease_existing_retention_boundary() {
     let provider = create_provider_with_block_range(0..=8, BTreeMap::new());
-    let mut stage = Blocks::new(provider.clone(), MockBlockDownloader::new(), ChainId::SEPOLIA);
+    let mut stage = Blocks::new(
+        provider.clone(),
+        MockBlockDownloader::new(),
+        ChainId::SEPOLIA,
+        TaskManager::current().task_spawner(),
+    );
 
     let provider_mut = provider.provider_mut();
     provider_mut.set_earliest_available_state_block(10).unwrap();

--- a/crates/tasks/src/blocking.rs
+++ b/crates/tasks/src/blocking.rs
@@ -75,14 +75,20 @@ impl CpuBlockingTaskPool {
 
     /// Spawns an asynchronous task in this thread pool, returning a handle for waiting on the
     /// result asynchronously.
+    ///
+    /// The closure is executed via [`rayon::ThreadPool::install`] so that any nested rayon
+    /// parallel iterators (e.g., `par_iter`) will use this pool rather than the global
+    /// thread pool.
     pub fn spawn<F, R>(&self, func: F) -> CpuBlockingJoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
         let (tx, rx) = oneshot::channel();
+        let pool = self.pool.clone();
         self.pool.spawn(move || {
-            let _ = tx.send(std::panic::catch_unwind(AssertUnwindSafe(func)));
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| pool.install(func)));
+            let _ = tx.send(result);
         });
         CpuBlockingJoinHandle { inner: rx }
     }


### PR DESCRIPTION
When running as a full node, the Blocks stage's `execute` method performed chain validation, parallel hash computation (via rayon), and sequential DB writes all synchronously on the async runtime thread. After `download_blocks().await` completed, there were zero `.await` points, so the `tokio::select!` in the pipeline's `run()` loop could never poll the stop signal — making the node unresponsive to Ctrl+C during block processing.

This PR moves the blocking work off the async runtime by splitting execution into separate async phases with `.await` points between them, giving the runtime opportunities to handle shutdown signals at each phase boundary:

1. **Download** (async) — network I/O, already async
2. **Validate + hash** (`cpu_bound().spawn()`) — chain invariant check and parallel hash computation on the rayon CPU pool
3. **DB writes** (`spawn_blocking()`) — sequential database insertion on tokio's blocking pool

Additionally, `CpuBlockingTaskPool::spawn` is fixed to use `rayon::ThreadPool::install` internally, so that nested `par_iter` calls execute on the task manager's CPU pool rather than silently falling back to rayon's global pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)