### PR TITLE
refactor(sync): configurable pipeline chunk and download batch sizes

### DIFF
--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -5,10 +5,9 @@ use katana_full_node::config::gateway::GatewayConfig;
 use katana_full_node::config::metrics::MetricsConfig;
 use katana_full_node::config::rpc::RpcConfig;
 use katana_full_node::config::trie::TrieConfig;
-use katana_full_node::{Network, SyncSource};
+use katana_full_node::{Network, SyncConfig, SyncSource};
 use serde::{Deserialize, Serialize};
 use tracing::info;
-use url::Url;
 
 use crate::options::*;
 use crate::utils::prompt_db_migration;
@@ -61,30 +60,8 @@ pub struct FullNodeArgs {
     #[command(flatten)]
     pub pruning: PruningOptions,
 
-    /// The maximum block number to sync to. Once reached, the pipeline stops
-    /// syncing but the node and RPC server remain running.
-    #[arg(long = "sync.tip")]
-    #[arg(value_name = "BLOCK_NUMBER")]
-    pub max_sync_tip: Option<u64>,
-
-    /// Custom feeder gateway base URL to sync from instead of the default
-    /// network gateway. Useful for syncing from another katana node's
-    /// feeder gateway.
-    #[arg(long = "sync.gateway")]
-    #[arg(value_name = "URL")]
-    #[arg(conflicts_with = "sync_rpc")]
-    pub sync_gateway: Option<Url>,
-
-    /// JSON-RPC endpoint URL to use as the block download source instead of
-    /// the feeder gateway. When set, blocks and classes are fetched via
-    /// JSON-RPC (`starknet_getBlockWithReceipts`, `starknet_getStateUpdate`,
-    /// `starknet_getClass`).
-    ///
-    /// This is mainly intended for development and testing purposes.
-    #[arg(long = "sync.rpc")]
-    #[arg(value_name = "URL")]
-    #[arg(conflicts_with = "sync_gateway")]
-    pub sync_rpc: Option<Url>,
+    #[command(flatten)]
+    pub sync: SyncOptions,
 }
 
 impl FullNodeArgs {
@@ -146,16 +123,20 @@ impl FullNodeArgs {
             network: self.network,
             gateway_api_key: self.gateway_api_key.clone(),
             trie: TrieConfig { compute: !self.trie.disable },
-            max_sync_tip: self.max_sync_tip,
-            sync_source: self.sync_source(),
+            sync: SyncConfig {
+                max_tip: self.sync.tip,
+                source: self.sync_source(),
+                chunk_size: Some(self.sync.chunk_size),
+                download_batch_size: Some(self.sync.download_batch_size),
+            },
         })
     }
 
     fn sync_source(&self) -> Option<SyncSource> {
-        if let Some(ref url) = self.sync_rpc {
+        if let Some(ref url) = self.sync.rpc {
             Some(SyncSource::JsonRpc(url.clone()))
         } else {
-            self.sync_gateway.clone().map(SyncSource::Gateway)
+            self.sync.gateway.clone().map(SyncSource::Gateway)
         }
     }
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -974,7 +974,8 @@ pub struct TrieOptions {
 #[command(next_help_heading = "Sync options")]
 pub struct SyncOptions {
     /// The maximum block number to sync to. Once reached, the pipeline stops
-    /// syncing but the node and RPC server remain running.
+    /// syncing but the node and RPC server remain running. By default, the
+    /// pipeline syncs to the head of the chain.
     #[arg(long = "sync.tip")]
     #[arg(value_name = "BLOCK_NUMBER")]
     pub tip: Option<u64>,
@@ -1003,6 +1004,7 @@ pub struct SyncOptions {
     #[arg(long = "sync.chunk-size")]
     #[arg(value_name = "COUNT")]
     #[arg(default_value_t = katana_full_node::DEFAULT_SYNC_CHUNK_SIZE)]
+    #[arg(value_parser = clap::value_parser!(u64).range(1..))]
     pub chunk_size: u64,
 
     /// Number of blocks or classes to download concurrently within each
@@ -1010,6 +1012,7 @@ pub struct SyncOptions {
     #[arg(long = "sync.download-batch-size")]
     #[arg(value_name = "COUNT")]
     #[arg(default_value_t = katana_full_node::DEFAULT_DOWNLOAD_BATCH_SIZE)]
+    #[arg(value_parser = parse_nonzero_usize)]
     pub download_batch_size: usize,
 }
 
@@ -1049,6 +1052,15 @@ impl Default for PruningOptions {
 pub enum PruningMode {
     Archive,
     Full(u64),
+}
+
+fn parse_nonzero_usize(s: &str) -> Result<usize, String> {
+    let n: usize = s.parse().map_err(|e| format!("{e}"))?;
+    if n == 0 {
+        Err("value must be greater than 0".to_string())
+    } else {
+        Ok(n)
+    }
 }
 
 fn parse_pruning_mode(s: &str) -> Result<PruningMode, String> {

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -971,6 +971,61 @@ pub struct TrieOptions {
 }
 
 #[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
+#[command(next_help_heading = "Sync options")]
+pub struct SyncOptions {
+    /// The maximum block number to sync to. Once reached, the pipeline stops
+    /// syncing but the node and RPC server remain running.
+    #[arg(long = "sync.tip")]
+    #[arg(value_name = "BLOCK_NUMBER")]
+    pub tip: Option<u64>,
+
+    /// Custom feeder gateway base URL to sync from instead of the default
+    /// network gateway. Useful for syncing from another katana node's
+    /// feeder gateway.
+    #[arg(long = "sync.gateway")]
+    #[arg(value_name = "URL")]
+    #[arg(conflicts_with = "rpc")]
+    pub gateway: Option<Url>,
+
+    /// JSON-RPC endpoint URL to use as the block download source instead of
+    /// the feeder gateway. When set, blocks and classes are fetched via
+    /// JSON-RPC (`starknet_getBlockWithReceipts`, `starknet_getStateUpdate`,
+    /// `starknet_getClass`).
+    ///
+    /// This is mainly intended for development and testing purposes.
+    #[arg(long = "sync.rpc")]
+    #[arg(value_name = "URL")]
+    #[arg(conflicts_with = "gateway")]
+    pub rpc: Option<Url>,
+
+    /// Maximum number of blocks to process per pipeline iteration before
+    /// advancing to the next chunk.
+    #[arg(long = "sync.chunk-size")]
+    #[arg(value_name = "COUNT")]
+    #[arg(default_value_t = katana_full_node::DEFAULT_SYNC_CHUNK_SIZE)]
+    pub chunk_size: u64,
+
+    /// Number of blocks or classes to download concurrently within each
+    /// chunk.
+    #[arg(long = "sync.download-batch-size")]
+    #[arg(value_name = "COUNT")]
+    #[arg(default_value_t = katana_full_node::DEFAULT_DOWNLOAD_BATCH_SIZE)]
+    pub download_batch_size: usize,
+}
+
+impl Default for SyncOptions {
+    fn default() -> Self {
+        Self {
+            tip: None,
+            gateway: None,
+            rpc: None,
+            chunk_size: katana_full_node::DEFAULT_SYNC_CHUNK_SIZE,
+            download_batch_size: katana_full_node::DEFAULT_DOWNLOAD_BATCH_SIZE,
+        }
+    }
+}
+
+#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Pruning options")]
 pub struct PruningOptions {
     /// State pruning mode

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -82,12 +82,27 @@ pub struct Config {
     pub network: Network,
     pub trie: TrieConfig,
     pub gateway: Option<GatewayConfig>,
+    pub sync: SyncConfig,
+}
+
+/// Configuration for the sync pipeline.
+#[derive(Debug, Default)]
+pub struct SyncConfig {
     /// The maximum block number the pipeline will sync to. When set, the pipeline
     /// will stop syncing after reaching this block while the node remains running.
-    pub max_sync_tip: Option<u64>,
+    pub max_tip: Option<u64>,
     /// The source to sync blocks and classes from.
-    pub sync_source: Option<SyncSource>,
+    pub source: Option<SyncSource>,
+    /// Maximum number of blocks to process per pipeline iteration.
+    /// Defaults to 256 if not set.
+    pub chunk_size: Option<u64>,
+    /// Number of blocks or classes to download concurrently within each chunk.
+    /// Defaults to 20 if not set.
+    pub download_batch_size: Option<usize>,
 }
+
+pub const DEFAULT_SYNC_CHUNK_SIZE: u64 = 256;
+pub const DEFAULT_DOWNLOAD_BATCH_SIZE: usize = 20;
 
 /// The source from which the node downloads blocks and classes.
 #[derive(Debug, Clone)]
@@ -143,7 +158,7 @@ impl Node {
 
         // --- build gateway client
 
-        let gateway_client = if let Some(SyncSource::Gateway(ref base_url)) = config.sync_source {
+        let gateway_client = if let Some(SyncSource::Gateway(ref base_url)) = config.sync.source {
             let gateway = base_url.join("gateway").expect("valid URL join");
             let feeder_gateway = base_url.join("feeder_gateway").expect("valid URL join");
             SequencerGateway::new(gateway, feeder_gateway)
@@ -167,11 +182,14 @@ impl Node {
 
         // --- build pipeline
 
-        let (mut pipeline, pipeline_handle) = Pipeline::new(storage_provider.clone(), 256);
+        let chunk_size = config.sync.chunk_size.unwrap_or(DEFAULT_SYNC_CHUNK_SIZE);
+        let batch_size = config.sync.download_batch_size.unwrap_or(DEFAULT_DOWNLOAD_BATCH_SIZE);
+
+        let (mut pipeline, pipeline_handle) = Pipeline::new(storage_provider.clone(), chunk_size);
 
         // Configure pipeline
         pipeline.set_config(PipelineConfig {
-            max_sync_tip: config.max_sync_tip,
+            max_sync_tip: config.sync.max_tip,
             pruning: config.pruning.clone(),
         });
 
@@ -180,9 +198,10 @@ impl Node {
             Network::Sepolia => katana_primitives::chain::ChainId::SEPOLIA,
         };
 
-        if let Some(SyncSource::JsonRpc(ref rpc_url)) = config.sync_source {
+        if let Some(SyncSource::JsonRpc(ref rpc_url)) = config.sync.source {
             let rpc_client = katana_starknet::rpc::Client::new(rpc_url.clone());
-            let block_downloader = JsonRpcBlockDownloader::new_json_rpc(rpc_client.clone(), 20);
+            let block_downloader =
+                JsonRpcBlockDownloader::new_json_rpc(rpc_client.clone(), batch_size);
             pipeline.add_stage(Blocks::new(
                 storage_provider.clone(),
                 block_downloader,
@@ -190,10 +209,11 @@ impl Node {
                 task_spawner.clone(),
             ));
 
-            let class_downloader = JsonRpcClassDownloader::new(rpc_client, 20);
+            let class_downloader = JsonRpcClassDownloader::new(rpc_client, batch_size);
             pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
         } else {
-            let block_downloader = BatchBlockDownloader::new_gateway(gateway_client.clone(), 20);
+            let block_downloader =
+                BatchBlockDownloader::new_gateway(gateway_client.clone(), batch_size);
             pipeline.add_stage(Blocks::new(
                 storage_provider.clone(),
                 block_downloader,
@@ -201,7 +221,7 @@ impl Node {
                 task_spawner.clone(),
             ));
 
-            let class_downloader = GatewayClassDownloader::new(gateway_client.clone(), 20);
+            let class_downloader = GatewayClassDownloader::new(gateway_client.clone(), batch_size);
             pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
         }
         if config.trie.compute {

--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -277,7 +277,11 @@ impl Pipeline {
     /// # Returns
     ///
     /// A tuple containing the pipeline instance and a handle for controlling it.
+    /// # Panics
+    ///
+    /// Panics if `chunk_size` is 0.
     pub fn new(provider: DbProviderFactory, chunk_size: u64) -> (Self, PipelineHandle) {
+        assert!(chunk_size > 0, "chunk size must be greater than 0");
         let (tx, rx) = watch::channel(None);
         let (block_tx, _block_rx) = watch::channel(None);
         let handle = PipelineHandle { tx: tx.clone(), block_tx: block_tx.clone() };

--- a/crates/sync/stage/src/downloader.rs
+++ b/crates/sync/stage/src/downloader.rs
@@ -63,7 +63,12 @@ impl<D> BatchDownloader<D> {
     ///
     /// * `downloader` - The downloader implementation to use for individual downloads
     /// * `batch_size` - Maximum number of items to download concurrently in each batch
+    ///
+    /// # Panics
+    ///
+    /// Panics if `batch_size` is 0.
     pub fn new(downloader: D, batch_size: usize) -> Self {
+        assert!(batch_size > 0, "batch size must be greater than 0");
         let backoff = ExponentialBuilder::default()
             .with_min_delay(Duration::from_secs(3))
             .with_max_delay(Duration::from_secs(60))


### PR DESCRIPTION
The full node's sync pipeline had hardcoded values for the chunk size (256) and the download batch size (20). This makes them configurable at runtime via `--sync.chunk-size` and `--sync.download-batch-size` CLI flags, with the same defaults as before.

Also groups all sync-related CLI args (`--sync.tip`, `--sync.gateway`, `--sync.rpc`, and the two new flags) into a `SyncOptions` struct, and the corresponding node config fields into a `SyncConfig` struct, consistent with how other option groups (db, metrics, trie, etc.) are organized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)