### PR TITLE
feat(db): compress `BlockStateUpdates` 

### DIFF
--- a/crates/storage/db/src/migration/state_updates.rs
+++ b/crates/storage/db/src/migration/state_updates.rs
@@ -11,6 +11,7 @@ use crate::error::DatabaseError;
 use crate::mdbx::tx::TxRW;
 use crate::models::class::MigratedCompiledClassHash;
 use crate::models::contract::{ContractClassChange, ContractClassChangeType};
+use crate::models::state_update::StateUpdateEnvelope;
 use crate::models::storage::ContractStorageEntry;
 use crate::version::Version;
 use crate::{tables, Db};
@@ -45,7 +46,7 @@ impl MigrationStage for StateUpdatesStage {
             let state_updates = reconstruct_state_update(tx, block).map_err(|source| {
                 MigrationError::FailedToReconstructStateUpdate { block, source }
             })?;
-            tx.put::<tables::BlockStateUpdates>(block, state_updates)?;
+            tx.put::<tables::BlockStateUpdates>(block, StateUpdateEnvelope::from(state_updates))?;
         }
         Ok(())
     }

--- a/crates/storage/db/src/models/mod.rs
+++ b/crates/storage/db/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod list;
 pub mod receipt;
 pub mod stage;
 pub mod state;
+pub mod state_update;
 pub mod storage;
 pub mod trie;
 
@@ -13,6 +14,7 @@ pub mod versioned;
 
 pub use envelope::EnvelopeError;
 pub use receipt::ReceiptEnvelope;
+pub use state_update::StateUpdateEnvelope;
 pub use versioned::block::VersionedHeader;
 pub use versioned::class::VersionedContractClass;
 pub use versioned::transaction::{TxEnvelope, VersionedTx};

--- a/crates/storage/db/src/models/state_update.rs
+++ b/crates/storage/db/src/models/state_update.rs
@@ -1,0 +1,80 @@
+use katana_primitives::state::StateUpdates;
+
+use crate::models::envelope::{Envelope, EnvelopePayload};
+
+impl EnvelopePayload for StateUpdates {
+    const MAGIC: &[u8; 4] = b"KSTU";
+    const NAME: &str = "state-update";
+}
+
+/// On-disk representation for `BlockStateUpdates` table values.
+pub type StateUpdateEnvelope = Envelope<StateUpdates>;
+
+impl From<StateUpdateEnvelope> for StateUpdates {
+    fn from(value: StateUpdateEnvelope) -> Self {
+        value.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use katana_primitives::state::StateUpdates;
+    use katana_primitives::{address, felt};
+
+    use super::StateUpdateEnvelope;
+    use crate::abstraction::{Database, DbTx, DbTxMut};
+    use crate::codecs::{Compress, Decompress};
+    use crate::{tables, Db};
+
+    fn sample_state_updates() -> StateUpdates {
+        let mut su = StateUpdates::default();
+        su.nonce_updates.insert(address!("0x1234"), felt!("0x1"));
+        su.deployed_contracts.insert(address!("0x5678"), felt!("0xabc"));
+        su.storage_updates
+            .insert(address!("0x1234"), BTreeMap::from([(felt!("0x10"), felt!("0x20"))]));
+        su
+    }
+
+    #[test]
+    fn state_update_envelope_roundtrip() {
+        let su = sample_state_updates();
+        let envelope = StateUpdateEnvelope::from(su.clone());
+
+        let compressed = envelope.compress().expect("failed to compress state update envelope");
+        assert_eq!(&compressed[..4], b"KSTU");
+        assert_eq!(compressed[4], 1); // FORMAT_VERSION
+
+        let decompressed = StateUpdateEnvelope::decompress(compressed)
+            .expect("failed to decompress state update envelope");
+
+        assert_eq!(decompressed, StateUpdateEnvelope::from(su));
+    }
+
+    #[test]
+    fn state_update_envelope_rejects_legacy_postcard_bytes() {
+        let su = sample_state_updates();
+        let legacy = postcard::to_stdvec(&su).expect("failed to serialize legacy state update");
+
+        StateUpdateEnvelope::decompress(legacy)
+            .expect_err("legacy postcard bytes must not be accepted by envelope codec");
+    }
+
+    #[test]
+    fn block_state_updates_table_roundtrip_uses_envelope() {
+        let db = Db::in_memory().expect("failed to create in-memory db");
+        let su = sample_state_updates();
+        let envelope = StateUpdateEnvelope::from(su.clone());
+
+        let tx = db.tx_mut().expect("failed to open write transaction");
+        tx.put::<tables::BlockStateUpdates>(7, envelope).expect("failed to write");
+        tx.commit().expect("failed to commit write transaction");
+
+        let tx = db.tx().expect("failed to open read transaction");
+        let stored = tx.get::<tables::BlockStateUpdates>(7).expect("failed to read");
+        tx.commit().expect("failed to commit read transaction");
+
+        assert_eq!(stored.map(StateUpdates::from), Some(su));
+    }
+}

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -2,7 +2,6 @@ use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
 use katana_primitives::execution::TypedTransactionExecutionInfo;
-use katana_primitives::state::StateUpdates;
 use katana_primitives::transaction::{TxHash, TxNumber};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
@@ -14,6 +13,7 @@ use crate::models::stage::{
     ExecutionCheckpoint, MigrationCheckpoint, MigrationStageId, PruningCheckpoint, StageId,
 };
 use crate::models::state::HistoricalStateRetention;
+use crate::models::state_update::StateUpdateEnvelope;
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 use crate::models::trie::{TrieDatabaseKey, TrieDatabaseValue, TrieHistoryEntry};
 use crate::models::{ReceiptEnvelope, TxEnvelope, VersionedContractClass, VersionedHeader};
@@ -209,7 +209,7 @@ tables! {
     /// Store canonical block headers
     Headers: (BlockNumber) => VersionedHeader,
     /// Stores canonical state updates by block number.
-    BlockStateUpdates: (BlockNumber) => StateUpdates,
+    BlockStateUpdates: (BlockNumber) => StateUpdateEnvelope,
     /// Stores block hashes according to its block number
     BlockHashes: (BlockNumber) => BlockHash,
     /// Stores block numbers according to its block hash
@@ -392,7 +392,6 @@ mod tests {
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
     use katana_primitives::execution::TypedTransactionExecutionInfo;
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
-    use katana_primitives::state::StateUpdates;
     use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
     use katana_primitives::{address, felt};
 
@@ -407,7 +406,9 @@ mod tests {
     use crate::models::trie::{
         TrieDatabaseKey, TrieDatabaseKeyType, TrieDatabaseValue, TrieHistoryEntry,
     };
-    use crate::models::{ReceiptEnvelope, TxEnvelope, VersionedHeader, VersionedTx};
+    use crate::models::{
+        ReceiptEnvelope, StateUpdateEnvelope, TxEnvelope, VersionedHeader, VersionedTx,
+    };
 
     macro_rules! assert_key_encode_decode {
 	    { $( ($name:ty, $key:expr) ),* } => {
@@ -456,7 +457,7 @@ mod tests {
     fn test_value_compress_decompress() {
         assert_value_compress_decompress! {
             (VersionedHeader, VersionedHeader::default()),
-            (StateUpdates, StateUpdates::default()),
+            (StateUpdateEnvelope, StateUpdateEnvelope::from(katana_primitives::state::StateUpdates::default())),
             (BlockHash, BlockHash::default()),
             (BlockNumber, BlockNumber::default()),
             (FinalityStatus, FinalityStatus::AcceptedOnL1),

--- a/crates/storage/db/tests/migration.rs
+++ b/crates/storage/db/tests/migration.rs
@@ -13,6 +13,7 @@ use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey};
 use katana_db::version::{create_db_version_file, Version};
 use katana_db::{tables, Db};
 use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
+use katana_primitives::state::StateUpdates;
 use katana_primitives::transaction::TxNumber;
 use katana_primitives::{ContractAddress, Felt};
 use katana_utils::arbitrary;
@@ -144,7 +145,7 @@ fn state_updates_reconstructs_all_fields() {
     Migration::new_v9(&db).run().unwrap();
 
     let tx = db.tx().unwrap();
-    let su = tx.get::<tables::BlockStateUpdates>(block).unwrap().unwrap();
+    let su: StateUpdates = tx.get::<tables::BlockStateUpdates>(block).unwrap().unwrap().into();
     tx.commit().unwrap();
 
     assert_eq!(su.nonce_updates.get(&nonce_addr), Some(&nonce_val));
@@ -212,7 +213,7 @@ fn state_updates_multiple_blocks() {
     assert_eq!(count, num_blocks as usize);
 
     for block in 0..num_blocks {
-        let su = tx.get::<tables::BlockStateUpdates>(block).unwrap().unwrap();
+        let su: StateUpdates = tx.get::<tables::BlockStateUpdates>(block).unwrap().unwrap().into();
         assert!(!su.nonce_updates.is_empty(), "block {block} missing nonce updates");
         assert!(!su.deployed_contracts.is_empty(), "block {block} missing deployed contracts");
         assert!(!su.storage_updates.is_empty(), "block {block} missing storage updates");
@@ -233,7 +234,7 @@ fn state_updates_empty_block() {
     Migration::new_v9(&db).run().unwrap();
 
     let tx = db.tx().unwrap();
-    let su = tx.get::<tables::BlockStateUpdates>(0u64).unwrap().unwrap();
+    let su: StateUpdates = tx.get::<tables::BlockStateUpdates>(0u64).unwrap().unwrap().into();
     tx.commit().unwrap();
 
     assert!(su.nonce_updates.is_empty());

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -16,7 +16,9 @@ use katana_db::models::list::BlockChangeList;
 use katana_db::models::stage::{ExecutionCheckpoint, PruningCheckpoint};
 use katana_db::models::state::HistoricalStateRetention;
 use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
-use katana_db::models::{ReceiptEnvelope, TxEnvelope, VersionedHeader, VersionedTx};
+use katana_db::models::{
+    ReceiptEnvelope, StateUpdateEnvelope, TxEnvelope, VersionedHeader, VersionedTx,
+};
 use katana_db::tables;
 use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithTxHashes, FinalityStatus, Header,
@@ -80,12 +82,12 @@ impl<Tx: DbTx> DbProvider<Tx> {
         &self,
         block_number: BlockNumber,
     ) -> ProviderResult<StateUpdates> {
-        let state_update = self
+        let envelope = self
             .0
             .get::<tables::BlockStateUpdates>(block_number)?
             .ok_or(ProviderError::MissingBlockStateUpdate(block_number))?;
 
-        Ok(state_update)
+        Ok(StateUpdates::from(envelope))
     }
 }
 
@@ -542,7 +544,10 @@ impl<Tx: DbTxMut> BlockWriter for DbProvider<Tx> {
         self.0.put::<tables::BlockStatusses>(block_number, block.status)?;
 
         self.0.put::<tables::Headers>(block_number, VersionedHeader::from(block_header))?;
-        self.0.put::<tables::BlockStateUpdates>(block_number, canonical_state_update)?;
+        self.0.put::<tables::BlockStateUpdates>(
+            block_number,
+            StateUpdateEnvelope::from(canonical_state_update),
+        )?;
         self.0.put::<tables::BlockBodyIndices>(block_number, block_body_indices)?;
 
         // Store base transaction details

--- a/crates/storage/provider/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/provider/src/providers/fork/mod.rs
@@ -3,6 +3,7 @@ use std::ops::{Range, RangeInclusive};
 
 use katana_db::abstraction::{DbTx, DbTxMut};
 use katana_db::models::block::StoredBlockBodyIndices;
+use katana_db::models::StateUpdateEnvelope;
 use katana_db::tables;
 use katana_fork::Backend;
 use katana_primitives::block::{
@@ -377,7 +378,7 @@ impl<Tx1: DbTx> StateUpdateProvider for ForkedProvider<Tx1> {
                 let provider_mut = self.fork_db.db.provider_mut();
                 provider_mut.tx().put::<tables::BlockStateUpdates>(
                     block_number,
-                    canonical_state_update.clone(),
+                    StateUpdateEnvelope::from(canonical_state_update.clone()),
                 )?;
                 provider_mut.commit()?;
 


### PR DESCRIPTION
Wraps `StateUpdates` in `StateUpdateEnvelope` using the same `Envelope<T>` pattern already used for receipts (`ReceiptEnvelope`) and transactions (`TxEnvelope`). This gives the `BlockStateUpdates` table adaptive zstd compression and a versioned wire format with `KSTU` magic prefix. The v8→v9 migration stage now writes envelopes directly so no additional migration step is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)