### PR TITLE
feat(sync): add prune duration metrics and use gauges for duration tracking

### DIFF
--- a/crates/sync/pipeline/src/lib.rs
+++ b/crates/sync/pipeline/src/lib.rs
@@ -483,6 +483,7 @@ impl Pipeline {
 
         for stage in self.stages.iter_mut() {
             let id = stage.id();
+            let stage_metrics = self.metrics.stage(id);
 
             let span = info_span!(target: "pipeline", "stage.prune", stage = %id);
             let enter = span.entered();
@@ -507,6 +508,7 @@ impl Pipeline {
             info!(target: "pipeline", distance = ?self.config.pruning.distance, from = range.start, to = range.end, "Pruning stage.");
 
             let span_inner = enter.exit();
+            let _guard = stage_metrics.prune_started();
             let PruneOutput { pruned_count } = stage
                 .prune(&prune_input)
                 .instrument(span_inner.clone())

--- a/crates/sync/pipeline/src/metrics.rs
+++ b/crates/sync/pipeline/src/metrics.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use katana_metrics::metrics::{self, Counter, Gauge, Histogram};
+use katana_metrics::metrics::{self, Counter, Gauge};
 use katana_metrics::Metrics;
 use parking_lot::Mutex;
 
@@ -77,7 +77,7 @@ impl PipelineMetrics {
 
     /// Record the duration of a pipeline iteration.
     pub fn record_iteration_duration(&self, duration_seconds: f64) {
-        self.inner.pipeline.iteration_duration_seconds.record(duration_seconds);
+        self.inner.pipeline.iteration_duration_seconds.set(duration_seconds);
     }
 
     /// Record a pipeline error.
@@ -108,8 +108,8 @@ struct PipelineOverallMetrics {
     sync_target: Gauge,
     /// Current fully-synced position (minimum checkpoint across all stages)
     sync_position: Gauge,
-    /// Duration of each pipeline iteration
-    iteration_duration_seconds: Histogram,
+    /// Duration of the last pipeline iteration
+    iteration_duration_seconds: Gauge,
     /// Total number of pipeline errors
     errors_total: Counter,
 }
@@ -122,8 +122,10 @@ pub struct StageMetrics {
     checkpoint: Gauge,
     /// Total number of blocks processed by this stage
     blocks_processed_total: Counter,
-    /// Duration of each stage execution
-    execution_duration_seconds: Histogram,
+    /// Duration of the last stage execution
+    execution_duration_seconds: Gauge,
+    /// Duration of the last stage pruning
+    prune_duration_seconds: Gauge,
     /// Total number of errors encountered by this stage
     errors_total: Counter,
 }
@@ -131,8 +133,20 @@ pub struct StageMetrics {
 impl StageMetrics {
     /// Record a stage execution starting. Returns a guard that records
     /// the execution duration when dropped.
-    pub fn execution_started(&self) -> StageExecutionGuard {
-        StageExecutionGuard { metrics: self.clone(), started_at: Instant::now() }
+    pub fn execution_started(&self) -> StageDurationGuard {
+        StageDurationGuard {
+            gauge: self.execution_duration_seconds.clone(),
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Record a stage pruning starting. Returns a guard that records
+    /// the prune duration when dropped.
+    pub fn prune_started(&self) -> StageDurationGuard {
+        StageDurationGuard {
+            gauge: self.prune_duration_seconds.clone(),
+            started_at: Instant::now(),
+        }
     }
 
     /// Record blocks processed by this stage.
@@ -151,16 +165,15 @@ impl StageMetrics {
     }
 }
 
-/// Guard that records the execution duration when dropped.
+/// Guard that records a duration to a gauge when dropped.
 #[allow(missing_debug_implementations)]
-pub struct StageExecutionGuard {
-    metrics: StageMetrics,
+pub struct StageDurationGuard {
+    gauge: Gauge,
     started_at: Instant,
 }
 
-impl Drop for StageExecutionGuard {
+impl Drop for StageDurationGuard {
     fn drop(&mut self) {
-        let duration = self.started_at.elapsed().as_secs_f64();
-        self.metrics.execution_duration_seconds.record(duration);
+        self.gauge.set(self.started_at.elapsed().as_secs_f64());
     }
 }

--- a/monitoring/grafana/dashboards/overview.json
+++ b/monitoring/grafana/dashboards/overview.json
@@ -102,7 +102,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Execution duration for each stage (p50). Shows which stage is the bottleneck.",
+      "description": "Execution duration for each stage. Shows which stage is the bottleneck.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -181,14 +181,14 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "katana_sync_stage_execution_duration_seconds{instance=~\"$instance\", quantile=\"0.5\"}",
+          "expr": "katana_sync_stage_execution_duration_seconds{instance=~\"$instance\"}",
           "instant": false,
           "legendFormat": "{{stage}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Stage Execution Duration (p50)",
+      "title": "Stage Execution Duration",
       "type": "timeseries"
     },
     {
@@ -2646,7 +2646,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Pipeline iteration duration percentiles (p50, p90, p99)",
+      "description": "Duration of each pipeline iteration",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2670,7 +2670,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "smooth",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -2697,53 +2697,7 @@
           },
           "unit": "s"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p99"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p90"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p50"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -2772,35 +2726,11 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "katana_sync_pipeline_iteration_duration_seconds{instance=~\"$instance\", quantile=\"0.5\"}",
+          "expr": "katana_sync_pipeline_iteration_duration_seconds{instance=~\"$instance\"}",
           "instant": false,
-          "legendFormat": "p50",
+          "legendFormat": "Iteration",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "editorMode": "code",
-          "expr": "katana_sync_pipeline_iteration_duration_seconds{instance=~\"$instance\", quantile=\"0.9\"}",
-          "instant": false,
-          "legendFormat": "p90",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "editorMode": "code",
-          "expr": "katana_sync_pipeline_iteration_duration_seconds{instance=~\"$instance\", quantile=\"0.99\"}",
-          "instant": false,
-          "legendFormat": "p99",
-          "range": true,
-          "refId": "C"
         }
       ],
       "title": "Iteration Duration",
@@ -2932,6 +2862,97 @@
         }
       ],
       "title": "Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Prune duration for each stage. Only stages with active pruning are shown.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 138,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "katana_sync_stage_prune_duration_seconds{instance=~\"$instance\", stage=~\"IndexHistory|StateTrie\"}",
+          "instant": false,
+          "legendFormat": "{{stage}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stage Prune Duration",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
- Add per-stage `prune_duration_seconds` gauge to track how long each stage's prune step takes
- Switch all duration metrics (pipeline iteration, stage execution, stage prune) from `Histogram` to `Gauge` so dashboards show actual durations instead of pre-computed percentiles
- Add "Stage Prune Duration" panel to the Grafana overview dashboard, filtered to stages with active pruning (`IndexHistory`, `StateTrie`)
- Update existing "Stage Execution Duration" and "Iteration Duration" dashboard panels to query the new gauge metrics
