### PR TITLE
fix(provider): return earliest block when no pruning has been performed

### DIFF
--- a/crates/storage/provider/provider-api/src/state.rs
+++ b/crates/storage/provider/provider-api/src/state.rs
@@ -80,8 +80,8 @@ pub trait HistoricalStateRetentionProvider: Send + Sync {
     /// # Returns
     ///
     /// - `None` if no blocks have been stored in the database yet.
-    /// - `Some(0)` if blocks exist but no pruning has ever been performed, meaning all
-    ///   historical state since genesis is available.
+    /// - `Some(0)` if blocks exist but no pruning has ever been performed, meaning all historical
+    ///   state since genesis is available.
     /// - `Some(n)` if pruning has been performed, where `n` is the earliest block for which
     ///   historical state is still retained. Blocks before `n` have been pruned.
     fn earliest_available_state_block(&self) -> ProviderResult<Option<BlockNumber>>;
@@ -95,8 +95,8 @@ pub trait HistoricalStateRetentionProvider: Send + Sync {
     /// # Returns
     ///
     /// - `None` if no blocks have been stored in the database yet.
-    /// - `Some(0)` if blocks exist but no pruning has ever been performed, meaning all
-    ///   historical trie snapshots since genesis are available.
+    /// - `Some(0)` if blocks exist but no pruning has ever been performed, meaning all historical
+    ///   trie snapshots since genesis are available.
     /// - `Some(n)` if pruning has been performed, where `n` is the earliest block for which
     ///   historical trie snapshots are still retained. Blocks before `n` have been pruned.
     fn earliest_available_state_trie_block(&self) -> ProviderResult<Option<BlockNumber>>;

--- a/crates/storage/provider/provider-api/src/state.rs
+++ b/crates/storage/provider/provider-api/src/state.rs
@@ -76,6 +76,14 @@ pub trait StateFactoryProvider: Send + Sync {
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait HistoricalStateRetentionProvider: Send + Sync {
     /// Returns the first block number for which historical state is still available.
+    ///
+    /// # Returns
+    ///
+    /// - `None` if no blocks have been stored in the database yet.
+    /// - `Some(0)` if blocks exist but no pruning has ever been performed, meaning all
+    ///   historical state since genesis is available.
+    /// - `Some(n)` if pruning has been performed, where `n` is the earliest block for which
+    ///   historical state is still retained. Blocks before `n` have been pruned.
     fn earliest_available_state_block(&self) -> ProviderResult<Option<BlockNumber>>;
 
     /// Sets the first block number for which historical state is still available.
@@ -83,6 +91,14 @@ pub trait HistoricalStateRetentionProvider: Send + Sync {
 
     /// Returns the first block number for which historical state trie snapshots are still
     /// available.
+    ///
+    /// # Returns
+    ///
+    /// - `None` if no blocks have been stored in the database yet.
+    /// - `Some(0)` if blocks exist but no pruning has ever been performed, meaning all
+    ///   historical trie snapshots since genesis are available.
+    /// - `Some(n)` if pruning has been performed, where `n` is the earliest block for which
+    ///   historical trie snapshots are still retained. Blocks before `n` have been pruned.
     fn earliest_available_state_trie_block(&self) -> ProviderResult<Option<BlockNumber>>;
 
     /// Sets the first block number for which historical state trie snapshots are still available.

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -918,8 +918,12 @@ pub const STATE_TRIE_HISTORY_RETENTION_KEY: u64 = 1;
 impl<Tx: DbTxMut> HistoricalStateRetentionProvider for DbProvider<Tx> {
     fn earliest_available_state_block(&self) -> ProviderResult<Option<BlockNumber>> {
         let key = STATE_HISTORY_RETENTION_KEY;
-        let result = self.0.get::<tables::StateHistoryRetention>(key)?;
-        Ok(result.map(|retention| retention.earliest_available_block))
+        if let Some(retention) = self.0.get::<tables::StateHistoryRetention>(key)? {
+            return Ok(Some(retention.earliest_available_block));
+        }
+        // No pruning entry — return block 0 if any blocks exist, None otherwise.
+        let has_blocks = self.0.cursor::<tables::BlockHashes>()?.last()?.is_some();
+        Ok(has_blocks.then_some(0))
     }
 
     fn set_earliest_available_state_block(&self, block_number: BlockNumber) -> ProviderResult<()> {
@@ -931,8 +935,12 @@ impl<Tx: DbTxMut> HistoricalStateRetentionProvider for DbProvider<Tx> {
 
     fn earliest_available_state_trie_block(&self) -> ProviderResult<Option<BlockNumber>> {
         let key = STATE_TRIE_HISTORY_RETENTION_KEY;
-        let result = self.0.get::<tables::StateHistoryRetention>(key)?;
-        Ok(result.map(|retention| retention.earliest_available_block))
+        if let Some(retention) = self.0.get::<tables::StateHistoryRetention>(key)? {
+            return Ok(Some(retention.earliest_available_block));
+        }
+        // No pruning entry — return block 0 if any blocks exist, None otherwise.
+        let has_blocks = self.0.cursor::<tables::BlockHashes>()?.last()?.is_some();
+        Ok(has_blocks.then_some(0))
     }
 
     fn set_earliest_available_state_trie_block(

--- a/crates/storage/provider/provider/src/providers/db/state.rs
+++ b/crates/storage/provider/provider/src/providers/db/state.rs
@@ -112,17 +112,13 @@ impl<Tx: DbTx> StateFactoryProvider for DbProvider<Tx> {
         let earliest_available = self
             .0
             .get::<tables::StateHistoryRetention>(STATE_HISTORY_RETENTION_KEY)?
-            .map(|retention| retention.earliest_available_block);
+            .map_or(0, |retention| retention.earliest_available_block);
 
-        // If there's no history retention marker, then it is assumed that pruning has never
-        // been performed and all historical state is available.
-        if let Some(earliest_available) = earliest_available {
-            if num < earliest_available {
-                return Err(ProviderError::HistoricalStatePruned {
-                    requested: num,
-                    earliest_available,
-                });
-            }
+        if num < earliest_available {
+            return Err(ProviderError::HistoricalStatePruned {
+                requested: num,
+                earliest_available,
+            });
         }
 
         Ok(Some(Box::new(HistoricalStateProvider::new(self.0.clone(), num))))
@@ -249,21 +245,17 @@ impl<Tx: DbTx> HistoricalStateProvider<Tx> {
         Ok(is_declared)
     }
 
-    // If there's no trie history retention marker, then it is assumed that pruning has never
-    // been performed and all historical trie is available.
     fn ensure_historical_state_trie_available(&self) -> ProviderResult<()> {
         let earliest_available = self
             .tx
             .get::<tables::StateHistoryRetention>(STATE_TRIE_HISTORY_RETENTION_KEY)?
-            .map(|retention| retention.earliest_available_block);
+            .map_or(0, |retention| retention.earliest_available_block);
 
-        if let Some(earliest_available) = earliest_available {
-            if self.block_number < earliest_available {
-                return Err(ProviderError::HistoricalStatePruned {
-                    requested: self.block_number,
-                    earliest_available,
-                });
-            }
+        if self.block_number < earliest_available {
+            return Err(ProviderError::HistoricalStatePruned {
+                requested: self.block_number,
+                earliest_available,
+            });
         }
 
         Ok(())

--- a/crates/storage/provider/provider/tests/block.rs
+++ b/crates/storage/provider/provider/tests/block.rs
@@ -333,7 +333,7 @@ fn state_trie_retention_is_independent_from_state_retention() -> Result<()> {
 
     // State and trie retention are tracked independently.
     let provider = provider_factory.provider_mut();
-    assert_eq!(provider.earliest_available_state_block()?, None);
+    assert_eq!(provider.earliest_available_state_block()?, Some(0));
     assert_eq!(provider.earliest_available_state_trie_block()?, Some(10));
     provider.commit()?;
 

--- a/crates/sync/stage/tests/index_history.rs
+++ b/crates/sync/stage/tests/index_history.rs
@@ -224,7 +224,7 @@ async fn prune_archive_mode_is_noop() {
     // distance=None means archive mode.
     let output = stage.prune(&PruneInput::new(5, None, None)).await.expect("prune");
     assert_eq!(output.pruned_count, 0);
-    assert_eq!(provider.provider_mut().earliest_available_state_block().unwrap(), None);
+    assert_eq!(provider.provider_mut().earliest_available_state_block().unwrap(), Some(0));
 }
 
 // ---- prune tests ----


### PR DESCRIPTION
Previously, `earliest_available_state_block` and `earliest_available_state_trie_block` returned `None` when no `StateHistoryRetention` entry existed, making it ambiguous whether historical state was unavailable or simply had never been pruned. Callers had to separately reason about the `None` case to avoid false negatives. Here, we define the semantics explicitly.

Now, when no pruning entry exists, the implementation checks whether any blocks are stored and returns `Some(0)` if they are — correctly reflecting that all historical state since genesis is available. `None` is reserved for when the database has no blocks at all.