### PR TITLE
feat(cli): add `katana db inspect` TUI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,10 +2911,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbindgen"
@@ -3178,7 +3193,21 @@ checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm 0.28.1",
  "unicode-segmentation",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3204,7 +3233,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3445,8 +3474,11 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.10.0",
  "crossterm_winapi",
+ "mio 1.0.4",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -3527,6 +3559,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,6 +3612,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,6 +3653,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -5325,7 +5391,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -5377,6 +5443,19 @@ dependencies = [
  "once_cell",
  "unicode-segmentation",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5949,6 +6028,7 @@ dependencies = [
  "colored_json",
  "comfy-table",
  "const_format",
+ "crossterm 0.28.1",
  "indicatif",
  "inquire",
  "jsonrpsee 0.26.0",
@@ -5964,6 +6044,7 @@ dependencies = [
  "piltover",
  "proptest",
  "rand 0.8.5",
+ "ratatui",
  "rstest 0.18.2",
  "serde",
  "serde_json",
@@ -7495,6 +7576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -8189,7 +8271,7 @@ checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -9241,6 +9323,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2988730ee014541157f48ce4dcc603940e00915edc3c7f9a8d78092256bb2493"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -10559,6 +10662,7 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
+ "mio 1.0.4",
  "signal-hook",
 ]
 
@@ -11297,6 +11401,15 @@ dependencies = [
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -11311,6 +11424,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -12392,6 +12518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12399,9 +12536,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -17,6 +17,9 @@ katana-starknet.workspace = true
 katana-rpc-types.workspace = true
 katana-utils.workspace = true
 
+crossterm = "0.28"
+ratatui = "0.29"
+
 anyhow.workspace = true
 async-trait.workspace = true
 byte-unit = "5.1.4"

--- a/bin/katana/src/cli/db/inspect.rs
+++ b/bin/katana/src/cli/db/inspect.rs
@@ -41,6 +41,7 @@ const INSPECT_TABLES: &[Tables] = &[
     Tables::StateHistoryRetention,
     Tables::MigrationCheckpoints,
 ];
+
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -104,100 +105,227 @@ macro_rules! try_count_entries {
     };
 }
 
-/// Fetch a page of entries from a table as formatted string pairs.
-/// Keys use Display format where available, Debug otherwise. Values always use Debug.
-/// Returns an empty vec if the table doesn't exist in the database.
-fn fetch_entries<Tx: DbTx>(
-    tx: &Tx,
-    table: Tables,
-    offset: usize,
-    limit: usize,
-) -> Vec<(String, String)> {
-    /// Walk a table cursor, formatting keys with Display.
-    fn walk_display<Tx: DbTx, T: tables::Table>(
+// -- Data fetching --
+
+/// Result of fetching entries from a table.
+struct FetchResult {
+    /// Column headers (key column(s) + value column(s)).
+    columns: Vec<&'static str>,
+    /// Each row is a vec of cell strings, matching `columns`.
+    rows: Vec<Vec<String>>,
+    /// Whether to display in tabular mode or detail (split-panel) mode.
+    tabular: bool,
+    /// The value type name (shown above the field table in tabular mode).
+    value_type: &'static str,
+}
+
+/// Fetch a page of entries from a table with per-table formatting.
+fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usize) -> FetchResult {
+    /// Walk a cursor and format each entry using the provided closure.
+    fn walk<Tx: DbTx, T: tables::Table, F: Fn(&T::Key, &T::Value) -> Vec<String>>(
         tx: &Tx,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<(String, String)>, katana_db::error::DatabaseError>
-    where
-        T::Key: std::fmt::Display,
-    {
-        let mut cursor = tx.cursor::<T>()?;
-        let mut entries = Vec::with_capacity(limit);
-        let mut walker = cursor.walk(None)?;
-        for _ in 0..offset {
-            if walker.next().is_none() {
-                return Ok(entries);
+        fmt: F,
+    ) -> Vec<Vec<String>> {
+        let result: Result<_, katana_db::error::DatabaseError> = (|| {
+            let mut cursor = tx.cursor::<T>()?;
+            let mut rows = Vec::with_capacity(limit);
+            let mut walker = cursor.walk(None)?;
+            for _ in 0..offset {
+                if walker.next().is_none() {
+                    return Ok(rows);
+                }
             }
-        }
-        for item in walker.take(limit) {
-            let Ok((key, value)) = item else { break };
-            entries.push((format!("{key}"), format!("{value:#?}")));
-        }
-        Ok(entries)
+            for item in walker.take(limit) {
+                let Ok((key, value)) = item else { break };
+                rows.push(fmt(&key, &value));
+            }
+            Ok(rows)
+        })();
+        result.unwrap_or_default()
     }
 
-    /// Walk a table cursor, formatting keys with Debug (fallback for types without Display).
-    fn walk_debug<Tx: DbTx, T: tables::Table>(
-        tx: &Tx,
-        offset: usize,
-        limit: usize,
-    ) -> Result<Vec<(String, String)>, katana_db::error::DatabaseError> {
-        let mut cursor = tx.cursor::<T>()?;
-        let mut entries = Vec::with_capacity(limit);
-        let mut walker = cursor.walk(None)?;
-        for _ in 0..offset {
-            if walker.next().is_none() {
-                return Ok(entries);
+    /// Helper to build a tabular FetchResult.
+    macro_rules! tabular {
+        ($t:ty, $vtype:expr, [$($col:expr),+], |$k:ident, $v:ident| $body:expr) => {{
+            let rows = walk::<Tx, $t, _>(tx, offset, limit, |$k, $v| $body);
+            FetchResult {
+                columns: vec![$($col),+],
+                rows,
+                tabular: true,
+                value_type: $vtype,
             }
-        }
-        for item in walker.take(limit) {
-            let Ok((key, value)) = item else { break };
-            entries.push((format!("{key:?}"), format!("{value:#?}")));
-        }
-        Ok(entries)
+        }};
     }
 
-    macro_rules! fetch {
-        ($t:ty) => {
-            walk_display::<Tx, $t>(tx, offset, limit).unwrap_or_default()
-        };
-        (debug $t:ty) => {
-            walk_debug::<Tx, $t>(tx, offset, limit).unwrap_or_default()
-        };
+    /// Helper to build a detail (split-panel) FetchResult.
+    macro_rules! detail {
+        ($t:ty) => {{
+            let rows = walk::<Tx, $t, _>(tx, offset, limit, |k, v| {
+                vec![format!("{k}"), format!("{v:#?}")]
+            });
+            FetchResult { columns: vec!["Key", "Value"], rows, tabular: false, value_type: "" }
+        }};
+        (debug $t:ty) => {{
+            let rows = walk::<Tx, $t, _>(tx, offset, limit, |k, v| {
+                vec![format!("{k:?}"), format!("{v:#?}")]
+            });
+            FetchResult { columns: vec!["Key", "Value"], rows, tabular: false, value_type: "" }
+        }};
     }
 
     match table {
-        Tables::Headers => fetch!(tables::Headers),
-        Tables::BlockStateUpdates => fetch!(tables::BlockStateUpdates),
-        Tables::BlockHashes => fetch!(tables::BlockHashes),
-        Tables::BlockNumbers => fetch!(tables::BlockNumbers),
-        Tables::BlockBodyIndices => fetch!(tables::BlockBodyIndices),
-        Tables::BlockStatusses => fetch!(tables::BlockStatusses),
-        Tables::TxNumbers => fetch!(tables::TxNumbers),
-        Tables::TxBlocks => fetch!(tables::TxBlocks),
-        Tables::TxHashes => fetch!(tables::TxHashes),
-        Tables::TxTraces => fetch!(tables::TxTraces),
-        Tables::Transactions => fetch!(tables::Transactions),
-        Tables::Receipts => fetch!(tables::Receipts),
-        Tables::CompiledClassHashes => fetch!(tables::CompiledClassHashes),
-        Tables::Classes => fetch!(tables::Classes),
-        Tables::ContractInfo => fetch!(tables::ContractInfo),
-        Tables::ContractStorage => fetch!(debug tables::ContractStorage),
-        Tables::ClassDeclarationBlock => fetch!(tables::ClassDeclarationBlock),
-        Tables::ClassDeclarations => fetch!(tables::ClassDeclarations),
-        Tables::MigratedCompiledClassHashes => fetch!(tables::MigratedCompiledClassHashes),
-        Tables::ContractInfoChangeSet => fetch!(tables::ContractInfoChangeSet),
-        Tables::NonceChangeHistory => fetch!(tables::NonceChangeHistory),
-        Tables::ClassChangeHistory => fetch!(tables::ClassChangeHistory),
-        Tables::StorageChangeHistory => fetch!(debug tables::StorageChangeHistory),
-        Tables::StorageChangeSet => fetch!(debug tables::StorageChangeSet),
-        Tables::StageExecutionCheckpoints => fetch!(tables::StageExecutionCheckpoints),
-        Tables::StagePruningCheckpoints => fetch!(tables::StagePruningCheckpoints),
-        Tables::StateHistoryRetention => fetch!(tables::StateHistoryRetention),
-        Tables::MigrationCheckpoints => fetch!(tables::MigrationCheckpoints),
-        // State trie tables are excluded from the inspector
-        _ => Vec::new(),
+        // -- Simple key-value (scalar value) --
+        Tables::BlockHashes => {
+            tabular!(tables::BlockHashes, "BlockHash", ["Block", "Hash"], |k, v| vec![
+                format!("{k}"),
+                format!("{v}")
+            ])
+        }
+        Tables::BlockNumbers => {
+            tabular!(tables::BlockNumbers, "BlockNumber", ["Hash", "Block"], |k, v| vec![
+                format!("{k}"),
+                format!("{v}")
+            ])
+        }
+        Tables::BlockStatusses => {
+            tabular!(tables::BlockStatusses, "FinalityStatus", ["Block", "Status"], |k, v| vec![
+                format!("{k}"),
+                format!("{v:?}")
+            ])
+        }
+        Tables::TxNumbers => {
+            tabular!(tables::TxNumbers, "TxNumber", ["TxHash", "TxNumber"], |k, v| vec![
+                format!("{k}"),
+                format!("{v}")
+            ])
+        }
+        Tables::TxBlocks => {
+            tabular!(tables::TxBlocks, "BlockNumber", ["TxNumber", "Block"], |k, v| vec![
+                format!("{k}"),
+                format!("{v}")
+            ])
+        }
+        Tables::TxHashes => {
+            tabular!(tables::TxHashes, "TxHash", ["TxNumber", "TxHash"], |k, v| vec![
+                format!("{k}"),
+                format!("{v}")
+            ])
+        }
+        Tables::CompiledClassHashes => tabular!(
+            tables::CompiledClassHashes,
+            "CompiledClassHash",
+            ["ClassHash", "CompiledHash"],
+            |k, v| vec![format!("{k}"), format!("{v}")]
+        ),
+        Tables::ClassDeclarationBlock => tabular!(
+            tables::ClassDeclarationBlock,
+            "BlockNumber",
+            ["ClassHash", "Block"],
+            |k, v| vec![format!("{k}"), format!("{v}")]
+        ),
+        Tables::ClassDeclarations => {
+            tabular!(tables::ClassDeclarations, "ClassHash", ["Block", "ClassHash"], |k, v| vec![
+                format!("{k}"),
+                format!("{v}")
+            ])
+        }
+
+        // -- Struct values (few simple fields) --
+        Tables::BlockBodyIndices => tabular!(
+            tables::BlockBodyIndices,
+            "StoredBlockBodyIndices",
+            ["Block", "TxOffset", "TxCount"],
+            |k, v| vec![format!("{k}"), format!("{}", v.tx_offset), format!("{}", v.tx_count)]
+        ),
+        Tables::ContractInfo => tabular!(
+            tables::ContractInfo,
+            "GenericContractInfo",
+            ["Address", "Nonce", "ClassHash"],
+            |k, v| vec![format!("{k}"), format!("{}", v.nonce), format!("{}", v.class_hash)]
+        ),
+        Tables::ContractStorage => tabular!(
+            tables::ContractStorage,
+            "StorageEntry",
+            ["Address", "Key", "Value"],
+            |k, v| vec![format!("{k}"), format!("{}", v.key), format!("{}", v.value)]
+        ),
+        Tables::MigratedCompiledClassHashes => tabular!(
+            tables::MigratedCompiledClassHashes,
+            "MigratedCompiledClassHash",
+            ["Block", "ClassHash", "CompiledHash"],
+            |k, v| vec![
+                format!("{k}"),
+                format!("{}", v.class_hash),
+                format!("{}", v.compiled_class_hash)
+            ]
+        ),
+        Tables::NonceChangeHistory => tabular!(
+            tables::NonceChangeHistory,
+            "ContractNonceChange",
+            ["Block", "Address", "Nonce"],
+            |k, v| vec![format!("{k}"), format!("{}", v.contract_address), format!("{}", v.nonce)]
+        ),
+        Tables::ClassChangeHistory => tabular!(
+            tables::ClassChangeHistory,
+            "ContractClassChange",
+            ["Block", "Type", "Address", "ClassHash"],
+            |k, v| vec![
+                format!("{k}"),
+                format!("{:?}", v.r#type),
+                format!("{}", v.contract_address),
+                format!("{}", v.class_hash)
+            ]
+        ),
+        Tables::StorageChangeHistory => tabular!(
+            tables::StorageChangeHistory,
+            "ContractStorageEntry",
+            ["Block", "Address", "Key", "Value"],
+            |k, v| vec![
+                format!("{k}"),
+                format!("{}", v.key.contract_address),
+                format!("{}", v.key.key),
+                format!("{}", v.value)
+            ]
+        ),
+        Tables::StageExecutionCheckpoints => tabular!(
+            tables::StageExecutionCheckpoints,
+            "ExecutionCheckpoint",
+            ["StageId", "Block"],
+            |k, v| vec![format!("{k}"), format!("{}", v.block)]
+        ),
+        Tables::StagePruningCheckpoints => tabular!(
+            tables::StagePruningCheckpoints,
+            "PruningCheckpoint",
+            ["StageId", "Block"],
+            |k, v| vec![format!("{k}"), format!("{}", v.block)]
+        ),
+        Tables::StateHistoryRetention => tabular!(
+            tables::StateHistoryRetention,
+            "HistoricalStateRetention",
+            ["Key", "EarliestBlock"],
+            |k, v| vec![format!("{k}"), format!("{}", v.earliest_available_block)]
+        ),
+        Tables::MigrationCheckpoints => tabular!(
+            tables::MigrationCheckpoints,
+            "MigrationCheckpoint",
+            ["StageId", "LastKey"],
+            |k, v| vec![format!("{k}"), format!("{}", v.last_key_migrated)]
+        ),
+
+        // -- Complex values (detail / split-panel mode) --
+        Tables::Headers => detail!(tables::Headers),
+        Tables::BlockStateUpdates => detail!(tables::BlockStateUpdates),
+        Tables::Transactions => detail!(tables::Transactions),
+        Tables::TxTraces => detail!(tables::TxTraces),
+        Tables::Receipts => detail!(tables::Receipts),
+        Tables::Classes => detail!(tables::Classes),
+        Tables::ContractInfoChangeSet => detail!(tables::ContractInfoChangeSet),
+        Tables::StorageChangeSet => detail!(debug tables::StorageChangeSet),
+
+        // State trie tables are excluded
+        _ => FetchResult { columns: vec![], rows: vec![], tabular: true, value_type: "" },
     }
 }
 
@@ -215,15 +343,21 @@ struct App {
     /// Entry counts per table (indexed same as INSPECT_TABLES).
     /// `None` means the table doesn't exist in the database.
     table_counts: Vec<Option<usize>>,
-    /// Currently loaded entries for the open table (key, value) Debug strings
-    entries: Vec<(String, String)>,
+    /// Column headers for the currently open table
+    columns: Vec<&'static str>,
+    /// Row data for the currently open table
+    rows: Vec<Vec<String>>,
+    /// Whether the current table uses tabular display
+    tabular: bool,
+    /// Value type name (for tabular display header)
+    value_type: &'static str,
     /// Total entry count for the currently open table
     current_table_count: usize,
     /// Current offset into the table for pagination
     entry_offset: usize,
-    /// Entry list selection state
+    /// Selection state for key list
     entry_list: ListState,
-    /// Scroll offset for the value panel
+    /// Scroll offset for the value panel (detail mode only)
     value_scroll: u16,
     /// Should quit
     quit: bool,
@@ -239,7 +373,10 @@ impl App {
             screen: Screen::TableList,
             table_list,
             table_counts,
-            entries: Vec::new(),
+            columns: Vec::new(),
+            rows: Vec::new(),
+            tabular: false,
+            value_type: "",
             current_table_count: 0,
             entry_offset: 0,
             entry_list: ListState::default(),
@@ -256,6 +393,11 @@ impl App {
         self.entry_list.selected().unwrap_or(0)
     }
 
+    fn select_entry(&mut self, index: usize) {
+        self.entry_list.select(Some(index));
+        self.value_scroll = 0;
+    }
+
     /// Open a table: load its first page of entries.
     /// Does nothing if the table doesn't exist in the database.
     fn open_table<Tx: DbTx>(&mut self, tx: &Tx) {
@@ -266,24 +408,27 @@ impl App {
         let table = INSPECT_TABLES[idx];
         self.current_table_count = count;
         self.entry_offset = 0;
-        self.entries = fetch_entries(tx, table, 0, PAGE_SIZE);
+        let data = fetch_table_data(tx, table, 0, PAGE_SIZE);
+        self.columns = data.columns;
+        self.rows = data.rows;
+        self.tabular = data.tabular;
+        self.value_type = data.value_type;
         self.entry_list = ListState::default();
-        if !self.entries.is_empty() {
-            self.entry_list.select(Some(0));
+        if !self.rows.is_empty() {
+            self.select_entry(0);
         }
-        self.value_scroll = 0;
         self.screen = Screen::EntryView;
     }
 
     /// Ensure the selected entry is within the loaded page, re-fetching if needed.
     fn ensure_entry_loaded<Tx: DbTx>(&mut self, tx: &Tx, absolute_index: usize) {
-        let page_end = self.entry_offset + self.entries.len();
+        let page_end = self.entry_offset + self.rows.len();
         if absolute_index >= page_end || absolute_index < self.entry_offset {
-            // Re-fetch a page centered around the target
             let new_offset = absolute_index.saturating_sub(PAGE_SIZE / 4);
             let idx = self.selected_table_index();
             let table = INSPECT_TABLES[idx];
-            self.entries = fetch_entries(tx, table, new_offset, PAGE_SIZE);
+            let data = fetch_table_data(tx, table, new_offset, PAGE_SIZE);
+            self.rows = data.rows;
             self.entry_offset = new_offset;
         }
     }
@@ -299,8 +444,7 @@ impl App {
             (current + delta as usize).min(self.current_table_count - 1)
         };
         self.ensure_entry_loaded(tx, new_abs);
-        self.entry_list.select(Some(new_abs - self.entry_offset));
-        self.value_scroll = 0;
+        self.select_entry(new_abs - self.entry_offset);
     }
 
     fn jump_entry_first<Tx: DbTx>(&mut self, tx: &Tx) {
@@ -308,8 +452,7 @@ impl App {
             return;
         }
         self.ensure_entry_loaded(tx, 0);
-        self.entry_list.select(Some(0));
-        self.value_scroll = 0;
+        self.select_entry(0);
     }
 
     fn jump_entry_last<Tx: DbTx>(&mut self, tx: &Tx) {
@@ -318,8 +461,7 @@ impl App {
         }
         let last = self.current_table_count - 1;
         self.ensure_entry_loaded(tx, last);
-        self.entry_list.select(Some(last - self.entry_offset));
-        self.value_scroll = 0;
+        self.select_entry(last - self.entry_offset);
     }
 }
 
@@ -421,7 +563,7 @@ fn run_event_loop<Tx: DbTx>(
                     KeyCode::Char('q') => app.quit = true,
                     KeyCode::Esc => {
                         app.screen = Screen::TableList;
-                        app.entries.clear();
+                        app.rows.clear();
                     }
                     KeyCode::Down | KeyCode::Char('j') => {
                         app.move_entry_selection(tx, 1);
@@ -435,10 +577,10 @@ fn run_event_loop<Tx: DbTx>(
                     KeyCode::Char('G') => {
                         app.jump_entry_last(tx);
                     }
-                    KeyCode::Char('h') | KeyCode::Left => {
+                    KeyCode::Char('h') | KeyCode::Left if !app.tabular => {
                         app.value_scroll = app.value_scroll.saturating_sub(4);
                     }
-                    KeyCode::Char('l') | KeyCode::Right => {
+                    KeyCode::Char('l') | KeyCode::Right if !app.tabular => {
                         app.value_scroll = app.value_scroll.saturating_add(4);
                     }
                     _ => {}
@@ -447,6 +589,8 @@ fn run_event_loop<Tx: DbTx>(
         }
     }
 }
+
+// -- Drawing --
 
 fn draw(f: &mut ratatui::Frame<'_>, app: &mut App) {
     match app.screen {
@@ -497,16 +641,22 @@ fn draw_entry_view(f: &mut ratatui::Frame<'_>, app: &mut App) {
 
     let title = format!(" {} ({} entries) ", table.name(), format_number(count));
 
-    let outer_block = Block::default().borders(Borders::ALL).title(title).title_bottom(
-        Line::from(" Esc:back  \u{2191}\u{2193}:nav  h/l:scroll value  g/G:first/last  q:quit ")
-            .centered(),
-    );
+    let footer = if app.tabular {
+        " Esc:back  \u{2191}\u{2193}:nav  g/G:first/last  q:quit "
+    } else {
+        " Esc:back  \u{2191}\u{2193}:nav  h/l:scroll value  g/G:first/last  q:quit "
+    };
+
+    let outer_block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .title_bottom(Line::from(footer).centered());
 
     let inner = outer_block.inner(area);
     f.render_widget(outer_block, area);
 
     // Split vertically: 1-line header + remaining content
-    let rows = Layout::default()
+    let vchunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(1), Constraint::Min(1)])
         .split(inner);
@@ -515,12 +665,12 @@ fn draw_entry_view(f: &mut ratatui::Frame<'_>, app: &mut App) {
     let header_cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
-        .split(rows[0]);
+        .split(vchunks[0]);
 
     let content_cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
-        .split(rows[1]);
+        .split(vchunks[1]);
 
     // Render column headers
     let header_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
@@ -549,16 +699,16 @@ fn draw_entry_view(f: &mut ratatui::Frame<'_>, app: &mut App) {
 
 fn draw_key_panel(f: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
     // Split into fixed-width line number column and key list
-    let num_width = 6u16; // enough for "99999 "
+    let num_width = 6u16;
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Length(num_width), Constraint::Min(1)])
         .split(area);
 
-    // Line numbers (rendered as plain Paragraph, scrolled in sync with the key list)
+    // Line numbers
     let selected = app.selected_entry_index();
     let num_lines: Vec<Line<'_>> = app
-        .entries
+        .rows
         .iter()
         .enumerate()
         .map(|(i, _)| {
@@ -572,19 +722,18 @@ fn draw_key_panel(f: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
         })
         .collect();
 
-    // Offset the paragraph to keep line numbers in sync with the list scroll.
-    // ListState handles its own viewport scroll; we replicate the offset here.
     let visible_height = cols[0].height as usize;
     let scroll_offset = selected.saturating_sub(visible_height.saturating_sub(1));
     let num_paragraph = Paragraph::new(num_lines).scroll((scroll_offset as u16, 0));
     f.render_widget(num_paragraph, cols[0]);
 
-    // Key list
+    // Key list (first column of each row)
     let key_area = cols[1];
     let items: Vec<ListItem<'_>> = app
-        .entries
+        .rows
         .iter()
-        .map(|(key, _)| {
+        .map(|row| {
+            let key = row.first().map(|s| s.as_str()).unwrap_or("");
             let display = truncate_str(key, key_area.width.saturating_sub(4) as usize);
             ListItem::new(Line::from(display))
         })
@@ -600,22 +749,42 @@ fn draw_key_panel(f: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
 
 fn draw_value_panel(f: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
     let selected = app.selected_entry_index();
-    let value_text = app.entries.get(selected).map(|(_, v)| v.as_str()).unwrap_or("");
 
-    // Apply horizontal scroll by trimming each line
-    let lines: Vec<Line<'_>> = value_text
-        .lines()
-        .map(|line| {
-            let scroll = app.value_scroll as usize;
-            let visible = if scroll < line.len() { &line[scroll..] } else { "" };
-            Line::from(Span::raw(visible.to_string()))
-        })
-        .collect();
+    if app.tabular {
+        // Render value type name + field table
+        let Some(row) = app.rows.get(selected) else {
+            return;
+        };
 
-    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+        let mut table = crate::cli::db::table();
+        table.set_header(vec!["Field", "Value"]);
+        for (col, val) in app.columns.iter().skip(1).zip(row.iter().skip(1)) {
+            table.add_row(vec![col.to_string(), val.clone()]);
+        }
 
-    f.render_widget(paragraph, area);
+        let text = format!("{}\n{table}", app.value_type);
+        let paragraph = Paragraph::new(text);
+        f.render_widget(paragraph, area);
+    } else {
+        // Render full Debug output with horizontal scroll
+        let value_text =
+            app.rows.get(selected).and_then(|row| row.get(1)).map(|s| s.as_str()).unwrap_or("");
+
+        let lines: Vec<Line<'_>> = value_text
+            .lines()
+            .map(|line| {
+                let scroll = app.value_scroll as usize;
+                let visible = if scroll < line.len() { &line[scroll..] } else { "" };
+                Line::from(Span::raw(visible.to_string()))
+            })
+            .collect();
+
+        let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+        f.render_widget(paragraph, area);
+    }
 }
+
+// -- Helpers --
 
 /// Truncate a string to fit within `max_len` characters, adding "..." if truncated.
 fn truncate_str(s: &str, max_len: usize) -> String {

--- a/bin/katana/src/cli/db/inspect.rs
+++ b/bin/katana/src/cli/db/inspect.rs
@@ -178,37 +178,37 @@ fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usiz
     match table {
         // -- Simple key-value (scalar value) --
         Tables::BlockHashes => {
-            tabular!(tables::BlockHashes, "BlockHash", ["Block", "Hash"], |k, v| vec![
+            tabular!(tables::BlockHashes, "BlockHash", ["number", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v}")
             ])
         }
         Tables::BlockNumbers => {
-            tabular!(tables::BlockNumbers, "BlockNumber", ["Hash", "Block"], |k, v| vec![
+            tabular!(tables::BlockNumbers, "BlockNumber", ["hash", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v}")
             ])
         }
         Tables::BlockStatusses => {
-            tabular!(tables::BlockStatusses, "FinalityStatus", ["Block", "Status"], |k, v| vec![
+            tabular!(tables::BlockStatusses, "FinalityStatus", ["number", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v:?}")
             ])
         }
         Tables::TxNumbers => {
-            tabular!(tables::TxNumbers, "TxNumber", ["TxHash", "TxNumber"], |k, v| vec![
+            tabular!(tables::TxNumbers, "TxNumber", ["tx_hash", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v}")
             ])
         }
         Tables::TxBlocks => {
-            tabular!(tables::TxBlocks, "BlockNumber", ["TxNumber", "Block"], |k, v| vec![
+            tabular!(tables::TxBlocks, "BlockNumber", ["tx_number", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v}")
             ])
         }
         Tables::TxHashes => {
-            tabular!(tables::TxHashes, "TxHash", ["TxNumber", "TxHash"], |k, v| vec![
+            tabular!(tables::TxHashes, "TxHash", ["tx_number", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v}")
             ])
@@ -216,17 +216,17 @@ fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usiz
         Tables::CompiledClassHashes => tabular!(
             tables::CompiledClassHashes,
             "CompiledClassHash",
-            ["ClassHash", "CompiledHash"],
+            ["class_hash", "value"],
             |k, v| vec![format!("{k}"), format!("{v}")]
         ),
         Tables::ClassDeclarationBlock => tabular!(
             tables::ClassDeclarationBlock,
             "BlockNumber",
-            ["ClassHash", "Block"],
+            ["class_hash", "value"],
             |k, v| vec![format!("{k}"), format!("{v}")]
         ),
         Tables::ClassDeclarations => {
-            tabular!(tables::ClassDeclarations, "ClassHash", ["Block", "ClassHash"], |k, v| vec![
+            tabular!(tables::ClassDeclarations, "ClassHash", ["number", "value"], |k, v| vec![
                 format!("{k}"),
                 format!("{v}")
             ])
@@ -236,25 +236,25 @@ fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usiz
         Tables::BlockBodyIndices => tabular!(
             tables::BlockBodyIndices,
             "StoredBlockBodyIndices",
-            ["Block", "TxOffset", "TxCount"],
+            ["number", "tx_offset", "tx_count"],
             |k, v| vec![format!("{k}"), format!("{}", v.tx_offset), format!("{}", v.tx_count)]
         ),
         Tables::ContractInfo => tabular!(
             tables::ContractInfo,
             "GenericContractInfo",
-            ["Address", "Nonce", "ClassHash"],
+            ["contract_address", "nonce", "class_hash"],
             |k, v| vec![format!("{k}"), format!("{}", v.nonce), format!("{}", v.class_hash)]
         ),
         Tables::ContractStorage => tabular!(
             tables::ContractStorage,
             "StorageEntry",
-            ["Address", "Key", "Value"],
+            ["contract_address", "key", "value"],
             |k, v| vec![format!("{k}"), format!("{}", v.key), format!("{}", v.value)]
         ),
         Tables::MigratedCompiledClassHashes => tabular!(
             tables::MigratedCompiledClassHashes,
             "MigratedCompiledClassHash",
-            ["Block", "ClassHash", "CompiledHash"],
+            ["number", "class_hash", "compiled_class_hash"],
             |k, v| vec![
                 format!("{k}"),
                 format!("{}", v.class_hash),
@@ -264,13 +264,13 @@ fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usiz
         Tables::NonceChangeHistory => tabular!(
             tables::NonceChangeHistory,
             "ContractNonceChange",
-            ["Block", "Address", "Nonce"],
+            ["number", "contract_address", "nonce"],
             |k, v| vec![format!("{k}"), format!("{}", v.contract_address), format!("{}", v.nonce)]
         ),
         Tables::ClassChangeHistory => tabular!(
             tables::ClassChangeHistory,
             "ContractClassChange",
-            ["Block", "Type", "Address", "ClassHash"],
+            ["number", "type", "contract_address", "class_hash"],
             |k, v| vec![
                 format!("{k}"),
                 format!("{:?}", v.r#type),
@@ -281,7 +281,7 @@ fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usiz
         Tables::StorageChangeHistory => tabular!(
             tables::StorageChangeHistory,
             "ContractStorageEntry",
-            ["Block", "Address", "Key", "Value"],
+            ["number", "key.contract_address", "key.key", "value"],
             |k, v| vec![
                 format!("{k}"),
                 format!("{}", v.key.contract_address),
@@ -292,30 +292,74 @@ fn fetch_table_data<Tx: DbTx>(tx: &Tx, table: Tables, offset: usize, limit: usiz
         Tables::StageExecutionCheckpoints => tabular!(
             tables::StageExecutionCheckpoints,
             "ExecutionCheckpoint",
-            ["StageId", "Block"],
+            ["stage_id", "block"],
             |k, v| vec![format!("{k}"), format!("{}", v.block)]
         ),
         Tables::StagePruningCheckpoints => tabular!(
             tables::StagePruningCheckpoints,
             "PruningCheckpoint",
-            ["StageId", "Block"],
+            ["stage_id", "block"],
             |k, v| vec![format!("{k}"), format!("{}", v.block)]
         ),
         Tables::StateHistoryRetention => tabular!(
             tables::StateHistoryRetention,
             "HistoricalStateRetention",
-            ["Key", "EarliestBlock"],
+            ["key", "earliest_available_block"],
             |k, v| vec![format!("{k}"), format!("{}", v.earliest_available_block)]
         ),
         Tables::MigrationCheckpoints => tabular!(
             tables::MigrationCheckpoints,
             "MigrationCheckpoint",
-            ["StageId", "LastKey"],
+            ["stage_id", "last_key_migrated"],
             |k, v| vec![format!("{k}"), format!("{}", v.last_key_migrated)]
         ),
 
+        // -- Header (convert VersionedHeader to Header for field access) --
+        Tables::Headers => tabular!(
+            tables::Headers,
+            "Header",
+            [
+                "number",
+                "parent_hash",
+                "state_root",
+                "transaction_count",
+                "events_count",
+                "state_diff_length",
+                "timestamp",
+                "sequencer_address",
+                "l1_gas_prices.eth",
+                "l1_gas_prices.strk",
+                "l1_data_gas_prices.eth",
+                "l1_data_gas_prices.strk",
+                "l2_gas_prices.eth",
+                "l2_gas_prices.strk",
+                "l1_da_mode",
+                "starknet_version"
+            ],
+            |k, v| {
+                let h = katana_primitives::block::Header::from(v.clone());
+                vec![
+                    format!("{k}"),
+                    format!("{}", h.parent_hash),
+                    format!("{}", h.state_root),
+                    format!("{}", h.transaction_count),
+                    format!("{}", h.events_count),
+                    format!("{}", h.state_diff_length),
+                    format!("{}", h.timestamp),
+                    format!("{}", h.sequencer_address),
+                    format!("{}", h.l1_gas_prices.eth),
+                    format!("{}", h.l1_gas_prices.strk),
+                    format!("{}", h.l1_data_gas_prices.eth),
+                    format!("{}", h.l1_data_gas_prices.strk),
+                    format!("{}", h.l2_gas_prices.eth),
+                    format!("{}", h.l2_gas_prices.strk),
+                    format!("{:?}", h.l1_da_mode),
+                    format!("{}", h.starknet_version),
+                ]
+            }
+        ),
+
         // -- Complex values (detail / split-panel mode) --
-        Tables::Headers => detail!(tables::Headers),
         Tables::BlockStateUpdates => detail!(tables::BlockStateUpdates),
         Tables::Transactions => detail!(tables::Transactions),
         Tables::TxTraces => detail!(tables::TxTraces),

--- a/bin/katana/src/cli/db/inspect.rs
+++ b/bin/katana/src/cli/db/inspect.rs
@@ -1,0 +1,642 @@
+use std::io;
+
+use anyhow::Result;
+use clap::Args;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use katana_db::abstraction::{Database, DbCursor, DbTx};
+use katana_db::tables::{self, Tables};
+
+/// Tables to display in the inspector (excludes state trie tables).
+const INSPECT_TABLES: &[Tables] = &[
+    Tables::Headers,
+    Tables::BlockStateUpdates,
+    Tables::BlockHashes,
+    Tables::BlockNumbers,
+    Tables::BlockBodyIndices,
+    Tables::BlockStatusses,
+    Tables::TxNumbers,
+    Tables::TxBlocks,
+    Tables::TxHashes,
+    Tables::TxTraces,
+    Tables::Transactions,
+    Tables::Receipts,
+    Tables::CompiledClassHashes,
+    Tables::Classes,
+    Tables::ContractInfo,
+    Tables::ContractStorage,
+    Tables::ClassDeclarationBlock,
+    Tables::ClassDeclarations,
+    Tables::MigratedCompiledClassHashes,
+    Tables::ContractInfoChangeSet,
+    Tables::NonceChangeHistory,
+    Tables::ClassChangeHistory,
+    Tables::StorageChangeHistory,
+    Tables::StorageChangeSet,
+    Tables::StageExecutionCheckpoints,
+    Tables::StagePruningCheckpoints,
+    Tables::StateHistoryRetention,
+    Tables::MigrationCheckpoints,
+];
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::Terminal;
+
+use crate::cli::db::open_db_ro;
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct InspectArgs {
+    /// Path to the database directory.
+    #[arg(short, long)]
+    #[arg(default_value = "~/.katana/db")]
+    pub path: String,
+}
+
+/// Dispatch only `tx.entries::<T>()` without creating a cursor.
+/// Returns `None` if the table doesn't exist in the database (e.g. older DB version).
+macro_rules! try_count_entries {
+    ($tables_variant:expr, $tx:expr) => {
+        match $tables_variant {
+            Tables::Headers => $tx.entries::<tables::Headers>().ok(),
+            Tables::BlockStateUpdates => $tx.entries::<tables::BlockStateUpdates>().ok(),
+            Tables::BlockHashes => $tx.entries::<tables::BlockHashes>().ok(),
+            Tables::BlockNumbers => $tx.entries::<tables::BlockNumbers>().ok(),
+            Tables::BlockBodyIndices => $tx.entries::<tables::BlockBodyIndices>().ok(),
+            Tables::BlockStatusses => $tx.entries::<tables::BlockStatusses>().ok(),
+            Tables::TxNumbers => $tx.entries::<tables::TxNumbers>().ok(),
+            Tables::TxBlocks => $tx.entries::<tables::TxBlocks>().ok(),
+            Tables::TxHashes => $tx.entries::<tables::TxHashes>().ok(),
+            Tables::TxTraces => $tx.entries::<tables::TxTraces>().ok(),
+            Tables::Transactions => $tx.entries::<tables::Transactions>().ok(),
+            Tables::Receipts => $tx.entries::<tables::Receipts>().ok(),
+            Tables::CompiledClassHashes => $tx.entries::<tables::CompiledClassHashes>().ok(),
+            Tables::Classes => $tx.entries::<tables::Classes>().ok(),
+            Tables::ContractInfo => $tx.entries::<tables::ContractInfo>().ok(),
+            Tables::ContractStorage => $tx.entries::<tables::ContractStorage>().ok(),
+            Tables::ClassDeclarationBlock => $tx.entries::<tables::ClassDeclarationBlock>().ok(),
+            Tables::ClassDeclarations => $tx.entries::<tables::ClassDeclarations>().ok(),
+            Tables::MigratedCompiledClassHashes => {
+                $tx.entries::<tables::MigratedCompiledClassHashes>().ok()
+            }
+            Tables::ContractInfoChangeSet => $tx.entries::<tables::ContractInfoChangeSet>().ok(),
+            Tables::NonceChangeHistory => $tx.entries::<tables::NonceChangeHistory>().ok(),
+            Tables::ClassChangeHistory => $tx.entries::<tables::ClassChangeHistory>().ok(),
+            Tables::StorageChangeHistory => $tx.entries::<tables::StorageChangeHistory>().ok(),
+            Tables::StorageChangeSet => $tx.entries::<tables::StorageChangeSet>().ok(),
+            Tables::StageExecutionCheckpoints => {
+                $tx.entries::<tables::StageExecutionCheckpoints>().ok()
+            }
+            Tables::StagePruningCheckpoints => {
+                $tx.entries::<tables::StagePruningCheckpoints>().ok()
+            }
+            Tables::StateHistoryRetention => $tx.entries::<tables::StateHistoryRetention>().ok(),
+            Tables::MigrationCheckpoints => $tx.entries::<tables::MigrationCheckpoints>().ok(),
+            // State trie tables are excluded from the inspector
+            _ => None,
+        }
+    };
+}
+
+/// Fetch a page of entries from a table as formatted string pairs.
+/// Keys use Display format where available, Debug otherwise. Values always use Debug.
+/// Returns an empty vec if the table doesn't exist in the database.
+fn fetch_entries<Tx: DbTx>(
+    tx: &Tx,
+    table: Tables,
+    offset: usize,
+    limit: usize,
+) -> Vec<(String, String)> {
+    /// Walk a table cursor, formatting keys with Display.
+    fn walk_display<Tx: DbTx, T: tables::Table>(
+        tx: &Tx,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, String)>, katana_db::error::DatabaseError>
+    where
+        T::Key: std::fmt::Display,
+    {
+        let mut cursor = tx.cursor::<T>()?;
+        let mut entries = Vec::with_capacity(limit);
+        let mut walker = cursor.walk(None)?;
+        for _ in 0..offset {
+            if walker.next().is_none() {
+                return Ok(entries);
+            }
+        }
+        for item in walker.take(limit) {
+            let Ok((key, value)) = item else { break };
+            entries.push((format!("{key}"), format!("{value:#?}")));
+        }
+        Ok(entries)
+    }
+
+    /// Walk a table cursor, formatting keys with Debug (fallback for types without Display).
+    fn walk_debug<Tx: DbTx, T: tables::Table>(
+        tx: &Tx,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, String)>, katana_db::error::DatabaseError> {
+        let mut cursor = tx.cursor::<T>()?;
+        let mut entries = Vec::with_capacity(limit);
+        let mut walker = cursor.walk(None)?;
+        for _ in 0..offset {
+            if walker.next().is_none() {
+                return Ok(entries);
+            }
+        }
+        for item in walker.take(limit) {
+            let Ok((key, value)) = item else { break };
+            entries.push((format!("{key:?}"), format!("{value:#?}")));
+        }
+        Ok(entries)
+    }
+
+    macro_rules! fetch {
+        ($t:ty) => {
+            walk_display::<Tx, $t>(tx, offset, limit).unwrap_or_default()
+        };
+        (debug $t:ty) => {
+            walk_debug::<Tx, $t>(tx, offset, limit).unwrap_or_default()
+        };
+    }
+
+    match table {
+        Tables::Headers => fetch!(tables::Headers),
+        Tables::BlockStateUpdates => fetch!(tables::BlockStateUpdates),
+        Tables::BlockHashes => fetch!(tables::BlockHashes),
+        Tables::BlockNumbers => fetch!(tables::BlockNumbers),
+        Tables::BlockBodyIndices => fetch!(tables::BlockBodyIndices),
+        Tables::BlockStatusses => fetch!(tables::BlockStatusses),
+        Tables::TxNumbers => fetch!(tables::TxNumbers),
+        Tables::TxBlocks => fetch!(tables::TxBlocks),
+        Tables::TxHashes => fetch!(tables::TxHashes),
+        Tables::TxTraces => fetch!(tables::TxTraces),
+        Tables::Transactions => fetch!(tables::Transactions),
+        Tables::Receipts => fetch!(tables::Receipts),
+        Tables::CompiledClassHashes => fetch!(tables::CompiledClassHashes),
+        Tables::Classes => fetch!(tables::Classes),
+        Tables::ContractInfo => fetch!(tables::ContractInfo),
+        Tables::ContractStorage => fetch!(debug tables::ContractStorage),
+        Tables::ClassDeclarationBlock => fetch!(tables::ClassDeclarationBlock),
+        Tables::ClassDeclarations => fetch!(tables::ClassDeclarations),
+        Tables::MigratedCompiledClassHashes => fetch!(tables::MigratedCompiledClassHashes),
+        Tables::ContractInfoChangeSet => fetch!(tables::ContractInfoChangeSet),
+        Tables::NonceChangeHistory => fetch!(tables::NonceChangeHistory),
+        Tables::ClassChangeHistory => fetch!(tables::ClassChangeHistory),
+        Tables::StorageChangeHistory => fetch!(debug tables::StorageChangeHistory),
+        Tables::StorageChangeSet => fetch!(debug tables::StorageChangeSet),
+        Tables::StageExecutionCheckpoints => fetch!(tables::StageExecutionCheckpoints),
+        Tables::StagePruningCheckpoints => fetch!(tables::StagePruningCheckpoints),
+        Tables::StateHistoryRetention => fetch!(tables::StateHistoryRetention),
+        Tables::MigrationCheckpoints => fetch!(tables::MigrationCheckpoints),
+        // State trie tables are excluded from the inspector
+        _ => Vec::new(),
+    }
+}
+
+// -- Application state --
+
+enum Screen {
+    TableList,
+    EntryView,
+}
+
+struct App {
+    screen: Screen,
+    /// Table list state
+    table_list: ListState,
+    /// Entry counts per table (indexed same as INSPECT_TABLES).
+    /// `None` means the table doesn't exist in the database.
+    table_counts: Vec<Option<usize>>,
+    /// Currently loaded entries for the open table (key, value) Debug strings
+    entries: Vec<(String, String)>,
+    /// Total entry count for the currently open table
+    current_table_count: usize,
+    /// Current offset into the table for pagination
+    entry_offset: usize,
+    /// Entry list selection state
+    entry_list: ListState,
+    /// Scroll offset for the value panel
+    value_scroll: u16,
+    /// Should quit
+    quit: bool,
+}
+
+const PAGE_SIZE: usize = 500;
+
+impl App {
+    fn new(table_counts: Vec<Option<usize>>) -> Self {
+        let mut table_list = ListState::default();
+        table_list.select(Some(0));
+        Self {
+            screen: Screen::TableList,
+            table_list,
+            table_counts,
+            entries: Vec::new(),
+            current_table_count: 0,
+            entry_offset: 0,
+            entry_list: ListState::default(),
+            value_scroll: 0,
+            quit: false,
+        }
+    }
+
+    fn selected_table_index(&self) -> usize {
+        self.table_list.selected().unwrap_or(0)
+    }
+
+    fn selected_entry_index(&self) -> usize {
+        self.entry_list.selected().unwrap_or(0)
+    }
+
+    /// Open a table: load its first page of entries.
+    /// Does nothing if the table doesn't exist in the database.
+    fn open_table<Tx: DbTx>(&mut self, tx: &Tx) {
+        let idx = self.selected_table_index();
+        let Some(count) = self.table_counts[idx] else {
+            return; // Table doesn't exist
+        };
+        let table = INSPECT_TABLES[idx];
+        self.current_table_count = count;
+        self.entry_offset = 0;
+        self.entries = fetch_entries(tx, table, 0, PAGE_SIZE);
+        self.entry_list = ListState::default();
+        if !self.entries.is_empty() {
+            self.entry_list.select(Some(0));
+        }
+        self.value_scroll = 0;
+        self.screen = Screen::EntryView;
+    }
+
+    /// Ensure the selected entry is within the loaded page, re-fetching if needed.
+    fn ensure_entry_loaded<Tx: DbTx>(&mut self, tx: &Tx, absolute_index: usize) {
+        let page_end = self.entry_offset + self.entries.len();
+        if absolute_index >= page_end || absolute_index < self.entry_offset {
+            // Re-fetch a page centered around the target
+            let new_offset = absolute_index.saturating_sub(PAGE_SIZE / 4);
+            let idx = self.selected_table_index();
+            let table = INSPECT_TABLES[idx];
+            self.entries = fetch_entries(tx, table, new_offset, PAGE_SIZE);
+            self.entry_offset = new_offset;
+        }
+    }
+
+    fn move_entry_selection<Tx: DbTx>(&mut self, tx: &Tx, delta: isize) {
+        if self.current_table_count == 0 {
+            return;
+        }
+        let current = self.entry_offset + self.selected_entry_index();
+        let new_abs = if delta < 0 {
+            current.saturating_sub(delta.unsigned_abs())
+        } else {
+            (current + delta as usize).min(self.current_table_count - 1)
+        };
+        self.ensure_entry_loaded(tx, new_abs);
+        self.entry_list.select(Some(new_abs - self.entry_offset));
+        self.value_scroll = 0;
+    }
+
+    fn jump_entry_first<Tx: DbTx>(&mut self, tx: &Tx) {
+        if self.current_table_count == 0 {
+            return;
+        }
+        self.ensure_entry_loaded(tx, 0);
+        self.entry_list.select(Some(0));
+        self.value_scroll = 0;
+    }
+
+    fn jump_entry_last<Tx: DbTx>(&mut self, tx: &Tx) {
+        if self.current_table_count == 0 {
+            return;
+        }
+        let last = self.current_table_count - 1;
+        self.ensure_entry_loaded(tx, last);
+        self.entry_list.select(Some(last - self.entry_offset));
+        self.value_scroll = 0;
+    }
+}
+
+impl InspectArgs {
+    pub fn execute(self) -> Result<()> {
+        let db = open_db_ro(&self.path)?;
+
+        // Warn about version mismatch and let user decide whether to continue
+        if db.require_migration() {
+            let current = db.version();
+            let latest = katana_db::version::LATEST_DB_VERSION;
+
+            eprintln!(
+                "WARNING: Database version ({current}) is older than the current version \
+                 ({latest}). Some tables may be missing or incompatible."
+            );
+
+            let proceed = inquire::Confirm::new("Continue anyway?").with_default(true).prompt()?;
+
+            if !proceed {
+                return Ok(());
+            }
+        }
+        let tx = db.tx()?;
+
+        // Collect entry counts for all tables (None if table doesn't exist)
+        let mut table_counts = Vec::with_capacity(INSPECT_TABLES.len());
+        for &table in INSPECT_TABLES {
+            table_counts.push(try_count_entries!(table, tx));
+        }
+
+        let mut app = App::new(table_counts);
+
+        // Setup terminal
+        enable_raw_mode()?;
+        io::stdout().execute(EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(io::stdout());
+        let mut terminal = Terminal::new(backend)?;
+
+        let result = run_event_loop(&mut terminal, &mut app, &tx);
+
+        // Restore terminal
+        disable_raw_mode()?;
+        io::stdout().execute(LeaveAlternateScreen)?;
+
+        result
+    }
+}
+
+fn run_event_loop<Tx: DbTx>(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+    tx: &Tx,
+) -> Result<()> {
+    loop {
+        terminal.draw(|f| draw(f, app))?;
+
+        if app.quit {
+            return Ok(());
+        }
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            // Global quit
+            if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                app.quit = true;
+                continue;
+            }
+
+            match app.screen {
+                Screen::TableList => match key.code {
+                    KeyCode::Char('q') => app.quit = true,
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        let i = app.selected_table_index();
+                        if i + 1 < INSPECT_TABLES.len() {
+                            app.table_list.select(Some(i + 1));
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        let i = app.selected_table_index();
+                        app.table_list.select(Some(i.saturating_sub(1)));
+                    }
+                    KeyCode::Char('g') => {
+                        app.table_list.select(Some(0));
+                    }
+                    KeyCode::Char('G') => {
+                        app.table_list.select(Some(INSPECT_TABLES.len() - 1));
+                    }
+                    KeyCode::Enter => {
+                        app.open_table(tx);
+                    }
+                    KeyCode::Esc => app.quit = true,
+                    _ => {}
+                },
+                Screen::EntryView => match key.code {
+                    KeyCode::Char('q') => app.quit = true,
+                    KeyCode::Esc => {
+                        app.screen = Screen::TableList;
+                        app.entries.clear();
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        app.move_entry_selection(tx, 1);
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        app.move_entry_selection(tx, -1);
+                    }
+                    KeyCode::Char('g') => {
+                        app.jump_entry_first(tx);
+                    }
+                    KeyCode::Char('G') => {
+                        app.jump_entry_last(tx);
+                    }
+                    KeyCode::Char('h') | KeyCode::Left => {
+                        app.value_scroll = app.value_scroll.saturating_sub(4);
+                    }
+                    KeyCode::Char('l') | KeyCode::Right => {
+                        app.value_scroll = app.value_scroll.saturating_add(4);
+                    }
+                    _ => {}
+                },
+            }
+        }
+    }
+}
+
+fn draw(f: &mut ratatui::Frame<'_>, app: &mut App) {
+    match app.screen {
+        Screen::TableList => draw_table_list(f, app),
+        Screen::EntryView => draw_entry_view(f, app),
+    }
+}
+
+fn draw_table_list(f: &mut ratatui::Frame<'_>, app: &mut App) {
+    let area = f.area();
+
+    let items: Vec<ListItem<'_>> = INSPECT_TABLES
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            let count_str = match app.table_counts[i] {
+                Some(count) => format_number(count),
+                None => "-".to_string(),
+            };
+            let content = format!("{:<40} {:>10}", t.name(), count_str);
+            let style = if app.table_counts[i].is_none() {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(content)).style(style)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" katana db inspect ")
+                .title_bottom(Line::from(" q:quit  \u{2191}\u{2193}:nav  Enter:open ").centered()),
+        )
+        .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+        .highlight_symbol("> ");
+
+    f.render_stateful_widget(list, area, &mut app.table_list);
+}
+
+fn draw_entry_view(f: &mut ratatui::Frame<'_>, app: &mut App) {
+    let area = f.area();
+    let idx = app.selected_table_index();
+    let table = INSPECT_TABLES[idx];
+    let count = app.current_table_count;
+
+    let title = format!(" {} ({} entries) ", table.name(), format_number(count));
+
+    let outer_block = Block::default().borders(Borders::ALL).title(title).title_bottom(
+        Line::from(" Esc:back  \u{2191}\u{2193}:nav  h/l:scroll value  g/G:first/last  q:quit ")
+            .centered(),
+    );
+
+    let inner = outer_block.inner(area);
+    f.render_widget(outer_block, area);
+
+    // Split vertically: 1-line header + remaining content
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
+        .split(inner);
+
+    // Split both header and content into the same column proportions
+    let header_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+        .split(rows[0]);
+
+    let content_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+        .split(rows[1]);
+
+    // Render column headers
+    let header_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    let num_width = 6u16;
+    let key_header_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(num_width), Constraint::Min(1)])
+        .split(header_cols[0]);
+
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("    # ", header_style))),
+        key_header_cols[0],
+    );
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("Key", header_style))),
+        key_header_cols[1],
+    );
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled("Value", header_style))),
+        header_cols[1],
+    );
+
+    draw_key_panel(f, app, content_cols[0]);
+    draw_value_panel(f, app, content_cols[1]);
+}
+
+fn draw_key_panel(f: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
+    // Split into fixed-width line number column and key list
+    let num_width = 6u16; // enough for "99999 "
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(num_width), Constraint::Min(1)])
+        .split(area);
+
+    // Line numbers (rendered as plain Paragraph, scrolled in sync with the key list)
+    let selected = app.selected_entry_index();
+    let num_lines: Vec<Line<'_>> = app
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(i, _)| {
+            let abs_index = app.entry_offset + i;
+            let style = if i == selected {
+                Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            Line::from(Span::styled(format!("{abs_index:>5} "), style))
+        })
+        .collect();
+
+    // Offset the paragraph to keep line numbers in sync with the list scroll.
+    // ListState handles its own viewport scroll; we replicate the offset here.
+    let visible_height = cols[0].height as usize;
+    let scroll_offset = selected.saturating_sub(visible_height.saturating_sub(1));
+    let num_paragraph = Paragraph::new(num_lines).scroll((scroll_offset as u16, 0));
+    f.render_widget(num_paragraph, cols[0]);
+
+    // Key list
+    let key_area = cols[1];
+    let items: Vec<ListItem<'_>> = app
+        .entries
+        .iter()
+        .map(|(key, _)| {
+            let display = truncate_str(key, key_area.width.saturating_sub(4) as usize);
+            ListItem::new(Line::from(display))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::RIGHT))
+        .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+        .highlight_symbol("> ");
+
+    f.render_stateful_widget(list, key_area, &mut app.entry_list);
+}
+
+fn draw_value_panel(f: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
+    let selected = app.selected_entry_index();
+    let value_text = app.entries.get(selected).map(|(_, v)| v.as_str()).unwrap_or("");
+
+    // Apply horizontal scroll by trimming each line
+    let lines: Vec<Line<'_>> = value_text
+        .lines()
+        .map(|line| {
+            let scroll = app.value_scroll as usize;
+            let visible = if scroll < line.len() { &line[scroll..] } else { "" };
+            Line::from(Span::raw(visible.to_string()))
+        })
+        .collect();
+
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+
+    f.render_widget(paragraph, area);
+}
+
+/// Truncate a string to fit within `max_len` characters, adding "..." if truncated.
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else if max_len > 3 {
+        format!("{}...", &s[..max_len - 3])
+    } else {
+        s[..max_len].to_string()
+    }
+}
+
+/// Format a number with comma separators.
+fn format_number(n: usize) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}

--- a/bin/katana/src/cli/db/mod.rs
+++ b/bin/katana/src/cli/db/mod.rs
@@ -5,6 +5,7 @@ use clap::{Args, Subcommand};
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::Table;
+mod inspect;
 mod migrate;
 mod prune;
 mod stats;
@@ -35,6 +36,9 @@ enum Commands {
 
     /// Inspect trie roots stored in the database.
     Trie(trie::TrieArgs),
+
+    /// Interactively inspect database table contents.
+    Inspect(inspect::InspectArgs),
 }
 
 impl DbArgs {
@@ -45,6 +49,7 @@ impl DbArgs {
             Commands::Stats(args) => args.execute(),
             Commands::Version(args) => args.execute(),
             Commands::Trie(args) => args.execute(),
+            Commands::Inspect(args) => args.execute(),
         }
     }
 }


### PR DESCRIPTION
Add an interactive terminal UI for browsing and inspecting database table contents via `katana db inspect`. The inspector opens the database read-only and presents a two-screen interface: a scrollable table list showing all non-trie tables with entry counts, and a split-panel entry browser with a key list on the left and formatted value display on the right.

Value types with simple struct fields (20 tables) are displayed in a `comfy-table` field/value table showing the type name and exact field names. Complex types like transactions, receipts, and classes fall back to pretty-printed Debug output with horizontal scrolling. The Header type is fully tabularized by converting `VersionedHeader` to `Header` for field access.

Entries are loaded lazily in pages to handle large tables without excessive memory usage. Older database versions trigger a warning with a prompt to continue, and missing tables are handled gracefully by showing a dash in the entry count column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)