### PR TITLE
feat(sync): configurable pipeline stages and per-stage batch sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6347,6 +6347,8 @@ dependencies = [
  "parking_lot",
  "serde",
  "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",

--- a/crates/cli/src/full.rs
+++ b/crates/cli/src/full.rs
@@ -4,7 +4,6 @@ use katana_full_node::config::db::DbConfig;
 use katana_full_node::config::gateway::GatewayConfig;
 use katana_full_node::config::metrics::MetricsConfig;
 use katana_full_node::config::rpc::RpcConfig;
-use katana_full_node::config::trie::TrieConfig;
 use katana_full_node::{Network, SyncConfig, SyncSource};
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -55,13 +54,13 @@ pub struct FullNodeArgs {
     pub gateway: GatewayOptions,
 
     #[command(flatten)]
-    pub trie: TrieOptions,
-
-    #[command(flatten)]
     pub pruning: PruningOptions,
 
     #[command(flatten)]
     pub sync: SyncOptions,
+
+    #[command(flatten)]
+    pub stage: StageOptions,
 }
 
 impl FullNodeArgs {
@@ -122,12 +121,15 @@ impl FullNodeArgs {
             gateway,
             network: self.network,
             gateway_api_key: self.gateway_api_key.clone(),
-            trie: TrieConfig { compute: !self.trie.disable },
             sync: SyncConfig {
                 max_tip: self.sync.tip,
                 source: self.sync_source(),
                 chunk_size: Some(self.sync.chunk_size),
-                download_batch_size: Some(self.sync.download_batch_size),
+                stages: self.sync.stages.clone().unwrap_or_default(),
+                stage: katana_full_node::StageConfig {
+                    blocks_batch_size: self.stage.blocks_batch_size,
+                    classes_batch_size: self.stage.classes_batch_size,
+                },
             },
         })
     }

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -13,6 +13,7 @@ use std::num::NonZeroU128;
 use std::path::PathBuf;
 
 use clap::Args;
+use katana_full_node::SyncStagesList;
 use katana_genesis::Genesis;
 #[cfg(feature = "server")]
 use katana_node_config::gateway::{
@@ -966,18 +967,6 @@ impl TracerOptions {
     }
 }
 
-#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[command(next_help_heading = "Trie options")]
-pub struct TrieOptions {
-    /// Disable state trie computation.
-    ///
-    /// By default, the node computes and verifies state roots against expected values
-    /// from block headers during synchronization. Use this flag to skip trie computation.
-    #[arg(long = "trie.disable")]
-    #[serde(default)]
-    pub disable: bool,
-}
-
 #[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Sync options")]
 pub struct SyncOptions {
@@ -1015,13 +1004,14 @@ pub struct SyncOptions {
     #[arg(value_parser = clap::value_parser!(u64).range(1..))]
     pub chunk_size: u64,
 
-    /// Number of blocks or classes to download concurrently within each
-    /// chunk.
-    #[arg(long = "sync.download-batch-size")]
-    #[arg(value_name = "COUNT")]
-    #[arg(default_value_t = katana_full_node::DEFAULT_DOWNLOAD_BATCH_SIZE)]
-    #[arg(value_parser = parse_nonzero_usize)]
-    pub download_batch_size: usize,
+    /// Pipeline stages to run during sync.
+    ///
+    /// Comma-separated list of stages. Available stages: blocks, classes,
+    /// indexhistory, statetrie. By default, all stages are enabled.
+    #[arg(long = "sync.stages", value_name = "STAGES")]
+    #[arg(value_parser = SyncStagesList::parse)]
+    #[serde(default)]
+    pub stages: Option<SyncStagesList>,
 }
 
 impl Default for SyncOptions {
@@ -1030,8 +1020,37 @@ impl Default for SyncOptions {
             tip: None,
             gateway: None,
             rpc: None,
+            stages: None,
             chunk_size: katana_full_node::DEFAULT_SYNC_CHUNK_SIZE,
-            download_batch_size: katana_full_node::DEFAULT_DOWNLOAD_BATCH_SIZE,
+        }
+    }
+}
+
+#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
+#[command(next_help_heading = "Stage options")]
+pub struct StageOptions {
+    /// Number of blocks to download concurrently within each chunk
+    /// in the Blocks stage.
+    #[arg(long = "stage.blocks.batch-size")]
+    #[arg(value_name = "COUNT")]
+    #[arg(default_value_t = katana_full_node::DEFAULT_BLOCKS_BATCH_SIZE)]
+    #[arg(value_parser = parse_nonzero_usize)]
+    pub blocks_batch_size: usize,
+
+    /// Number of classes to download concurrently within each chunk
+    /// in the Classes stage.
+    #[arg(long = "stage.classes.batch-size")]
+    #[arg(value_name = "COUNT")]
+    #[arg(default_value_t = katana_full_node::DEFAULT_CLASSES_BATCH_SIZE)]
+    #[arg(value_parser = parse_nonzero_usize)]
+    pub classes_batch_size: usize,
+}
+
+impl Default for StageOptions {
+    fn default() -> Self {
+        Self {
+            blocks_batch_size: katana_full_node::DEFAULT_BLOCKS_BATCH_SIZE,
+            classes_batch_size: katana_full_node::DEFAULT_CLASSES_BATCH_SIZE,
         }
     }
 }

--- a/crates/node/full/Cargo.toml
+++ b/crates/node/full/Cargo.toml
@@ -35,6 +35,8 @@ jsonrpsee.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 strum.workspace = true
+strum_macros.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = [ "time" ] }
 url.workspace = true

--- a/crates/node/full/src/config.rs
+++ b/crates/node/full/src/config.rs
@@ -1,16 +1,1 @@
 pub use katana_node_config::{db, gateway, metrics, rpc};
-
-pub mod trie {
-    /// Configuration for state trie computation.
-    #[derive(Debug, Clone)]
-    pub struct TrieConfig {
-        /// Whether to compute and verify state roots during synchronization.
-        pub compute: bool,
-    }
-
-    impl Default for TrieConfig {
-        fn default() -> Self {
-            Self { compute: true }
-        }
-    }
-}

--- a/crates/node/full/src/lib.rs
+++ b/crates/node/full/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config;
 
+use std::collections::HashSet;
 use std::future::IntoFuture;
 use std::sync::Arc;
 
@@ -12,7 +13,6 @@ use config::db::DbConfig;
 use config::gateway::GatewayConfig;
 use config::metrics::MetricsConfig;
 use config::rpc::{RpcConfig, RpcModuleKind};
-use config::trie::TrieConfig;
 use http::header::CONTENT_TYPE;
 use http::Method;
 use jsonrpsee::RpcModule;
@@ -72,6 +72,86 @@ pub enum Network {
 
 pub use katana_pipeline::{PipelineConfig, PruningConfig};
 
+/// Available sync pipeline stages.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::EnumString,
+    strum_macros::Display,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[strum(ascii_case_insensitive)]
+pub enum SyncStageKind {
+    Blocks,
+    Classes,
+    IndexHistory,
+    StateTrie,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid sync stage: {0}")]
+pub struct InvalidSyncStageError(String);
+
+/// A set of sync stages to run in the pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct SyncStagesList(HashSet<SyncStageKind>);
+
+impl SyncStagesList {
+    /// Creates an empty stages list.
+    pub fn new() -> Self {
+        Self(HashSet::new())
+    }
+
+    /// Creates a list with all available stages.
+    pub fn all() -> Self {
+        Self(HashSet::from([
+            SyncStageKind::Blocks,
+            SyncStageKind::Classes,
+            SyncStageKind::IndexHistory,
+            SyncStageKind::StateTrie,
+        ]))
+    }
+
+    /// Returns `true` if the list contains the specified `stage`.
+    pub fn contains(&self, stage: &SyncStageKind) -> bool {
+        self.0.contains(stage)
+    }
+
+    /// Used as the value parser for `clap`.
+    pub fn parse(value: &str) -> Result<Self, InvalidSyncStageError> {
+        if value.is_empty() {
+            return Ok(Self::new());
+        }
+
+        let mut stages = HashSet::new();
+        for name in value.split(',') {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let stage: SyncStageKind =
+                trimmed.parse().map_err(|_| InvalidSyncStageError(trimmed.to_string()))?;
+
+            stages.insert(stage);
+        }
+
+        Ok(Self(stages))
+    }
+}
+
+impl Default for SyncStagesList {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
 #[derive(Debug)]
 pub struct Config {
     pub db: DbConfig,
@@ -80,7 +160,6 @@ pub struct Config {
     pub metrics: Option<MetricsConfig>,
     pub gateway_api_key: Option<String>,
     pub network: Network,
-    pub trie: TrieConfig,
     pub gateway: Option<GatewayConfig>,
     pub sync: SyncConfig,
 }
@@ -96,13 +175,33 @@ pub struct SyncConfig {
     /// Maximum number of blocks to process per pipeline iteration.
     /// Defaults to 256 if not set.
     pub chunk_size: Option<u64>,
-    /// Number of blocks or classes to download concurrently within each chunk.
-    /// Defaults to 20 if not set.
-    pub download_batch_size: Option<usize>,
+    /// Which pipeline stages to run. Defaults to all stages.
+    pub stages: SyncStagesList,
+    /// Per-stage configuration.
+    pub stage: StageConfig,
+}
+
+/// Per-stage configuration options.
+#[derive(Debug, Clone)]
+pub struct StageConfig {
+    /// Number of blocks to download concurrently within each chunk.
+    pub blocks_batch_size: usize,
+    /// Number of classes to download concurrently within each chunk.
+    pub classes_batch_size: usize,
+}
+
+impl Default for StageConfig {
+    fn default() -> Self {
+        Self {
+            blocks_batch_size: DEFAULT_BLOCKS_BATCH_SIZE,
+            classes_batch_size: DEFAULT_CLASSES_BATCH_SIZE,
+        }
+    }
 }
 
 pub const DEFAULT_SYNC_CHUNK_SIZE: u64 = 256;
-pub const DEFAULT_DOWNLOAD_BATCH_SIZE: usize = 20;
+pub const DEFAULT_BLOCKS_BATCH_SIZE: usize = 20;
+pub const DEFAULT_CLASSES_BATCH_SIZE: usize = 20;
 
 /// The source from which the node downloads blocks and classes.
 #[derive(Debug, Clone)]
@@ -183,7 +282,8 @@ impl Node {
         // --- build pipeline
 
         let chunk_size = config.sync.chunk_size.unwrap_or(DEFAULT_SYNC_CHUNK_SIZE);
-        let batch_size = config.sync.download_batch_size.unwrap_or(DEFAULT_DOWNLOAD_BATCH_SIZE);
+        let blocks_batch_size = config.sync.stage.blocks_batch_size;
+        let classes_batch_size = config.sync.stage.classes_batch_size;
 
         let (mut pipeline, pipeline_handle) = Pipeline::new(storage_provider.clone(), chunk_size);
 
@@ -198,34 +298,50 @@ impl Node {
             Network::Sepolia => katana_primitives::chain::ChainId::SEPOLIA,
         };
 
+        let stages = &config.sync.stages;
+
         if let Some(SyncSource::JsonRpc(ref rpc_url)) = config.sync.source {
             let rpc_client = katana_starknet::rpc::Client::new(rpc_url.clone());
-            let block_downloader =
-                JsonRpcBlockDownloader::new_json_rpc(rpc_client.clone(), batch_size);
-            pipeline.add_stage(Blocks::new(
-                storage_provider.clone(),
-                block_downloader,
-                chain_id,
-                task_spawner.clone(),
-            ));
 
-            let class_downloader = JsonRpcClassDownloader::new(rpc_client, batch_size);
-            pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
+            if stages.contains(&SyncStageKind::Blocks) {
+                let block_downloader =
+                    JsonRpcBlockDownloader::new_json_rpc(rpc_client.clone(), blocks_batch_size);
+                pipeline.add_stage(Blocks::new(
+                    storage_provider.clone(),
+                    block_downloader,
+                    chain_id,
+                    task_spawner.clone(),
+                ));
+            }
+
+            if stages.contains(&SyncStageKind::Classes) {
+                let class_downloader = JsonRpcClassDownloader::new(rpc_client, classes_batch_size);
+                pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
+            }
         } else {
-            let block_downloader =
-                BatchBlockDownloader::new_gateway(gateway_client.clone(), batch_size);
-            pipeline.add_stage(Blocks::new(
-                storage_provider.clone(),
-                block_downloader,
-                chain_id,
-                task_spawner.clone(),
-            ));
+            if stages.contains(&SyncStageKind::Blocks) {
+                let block_downloader =
+                    BatchBlockDownloader::new_gateway(gateway_client.clone(), blocks_batch_size);
+                pipeline.add_stage(Blocks::new(
+                    storage_provider.clone(),
+                    block_downloader,
+                    chain_id,
+                    task_spawner.clone(),
+                ));
+            }
 
-            let class_downloader = GatewayClassDownloader::new(gateway_client.clone(), batch_size);
-            pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
+            if stages.contains(&SyncStageKind::Classes) {
+                let class_downloader =
+                    GatewayClassDownloader::new(gateway_client.clone(), classes_batch_size);
+                pipeline.add_stage(Classes::new(storage_provider.clone(), class_downloader));
+            }
         }
-        pipeline.add_stage(IndexHistory::new(storage_provider.clone(), task_spawner.clone()));
-        if config.trie.compute {
+
+        if stages.contains(&SyncStageKind::IndexHistory) {
+            pipeline.add_stage(IndexHistory::new(storage_provider.clone(), task_spawner.clone()));
+        }
+
+        if stages.contains(&SyncStageKind::StateTrie) {
             pipeline.add_stage(StateTrie::new(storage_provider.clone(), task_spawner.clone()));
         }
 


### PR DESCRIPTION
Add `--sync.stages` flag to select which sync pipeline stages to run at runtime, mirroring how `--http.api` selects RPC modules. Accepts a comma-separated list of stages: `blocks`, `classes`, `indexhistory`, `statetrie`. All stages are enabled by default.

Replace the single `--sync.download-batch-size` with per-stage options `--stage.blocks.batch-size` and `--stage.classes.batch-size`, allowing independent tuning of download concurrency for each stage.

Remove `--trie.disable` as it is now superseded by omitting `statetrie` from `--sync.stages`.
