### PR TITLE
chore(core): use current starknet version for dev genesis and warn on hash mismatch

### DIFF
--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -19,7 +19,7 @@ use katana_primitives::contract::ContractAddress;
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::state::StateUpdatesWithClasses;
 use katana_primitives::utils::split_u256;
-use katana_primitives::version::StarknetVersion;
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::Felt;
 use lazy_static::lazy_static;
 
@@ -54,8 +54,7 @@ impl ChainSpec {
             l2_gas_prices: GasPrices::MIN,
             l1_data_gas_prices: self.genesis.gas_prices.clone(),
             sequencer_address: self.genesis.sequencer_address,
-            // keep at 0.13.1.1 for backward compatibility reason
-            starknet_version: StarknetVersion::new([0, 13, 1, 1]),
+            starknet_version: CURRENT_STARKNET_VERSION,
         };
 
         ExecutableBlock { header, body: Vec::new() }
@@ -338,7 +337,7 @@ mod tests {
                 l1_gas_prices: chain_spec.genesis.gas_prices.clone(),
                 l1_data_gas_prices: chain_spec.genesis.gas_prices.clone(),
                 l1_da_mode: L1DataAvailabilityMode::Calldata,
-                starknet_version: StarknetVersion::new([0, 13, 1, 1]),
+                starknet_version: CURRENT_STARKNET_VERSION,
             },
             body: Vec::new(),
         };

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -31,7 +31,7 @@ use katana_trie::{
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use starknet_types_core::hash::{self, StarkHash};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::env::BlockContextGenerator;
 use crate::service::block_producer::{BlockProductionError, MinedBlockOutcome};
@@ -222,6 +222,11 @@ where
 
         match (local_hash, skip_dev_genesis) {
             (Some(local_hash), false) => {
+                info!(
+                    genesis_hash = format!("{:#x}", local_hash),
+                    "Genesis has already been initialized."
+                );
+
                 let genesis_block = chain_spec.block();
                 let mut genesis_state_updates = chain_spec.state_updates();
 
@@ -238,13 +243,12 @@ where
 
                 // check genesis should be the same
                 if local_hash != committed_block.hash {
-                    return Err(anyhow!(
-                        "Genesis block hash mismatch: expected {:#x}, got {local_hash:#x}",
-                        committed_block.hash
-                    ));
+                    warn!(
+                        local_genesis_hash = format!("{:#x}", local_hash),
+                        computed_genesis_hash = format!("{:#x}", committed_block.hash),
+                        "Genesis block hash mismatch - blockchain state may be corrupted."
+                    );
                 }
-
-                info!(genesis_hash = %local_hash, "Genesis has already been initialized");
             }
 
             // No local genesis and genesis bootstrap is enabled -> initialize


### PR DESCRIPTION
This PR makes two related changes to dev genesis handling.

## Bumping the dev genesis Starknet version

The dev chain spec previously pinned the genesis block's `starknet_version` to `0.13.1.1` for backward compatibility. This change switches it to `CURRENT_STARKNET_VERSION` so that dev nodes report the same protocol version they actually execute against.

It is important to note that this does **not** change the canonical genesis state — the accounts, classes, and storage at genesis are identical. However, because `starknet_version` is part of the block header that feeds into the block hash, the resulting genesis block hash **does** change. Any existing dev database initialized under the old version will therefore have a genesis hash that no longer matches the one computed by the new code.

## Downgrading the genesis hash mismatch from error to warning

Previously, if the locally stored genesis hash did not match the recomputed hash from the chain spec, the node would refuse to start with a hard error. With the version bump above, this would break every existing dev database on first run after upgrading.

Rather than gating the upgrade on a destructive db reset, the mismatch is now logged as a `warn!` indicating that the blockchain state may be corrupted, and startup is allowed to proceed. This keeps existing dev databases usable across the upgrade while still surfacing genuine corruption loudly in the logs.
