### PR TITLE
feat(genesis): predeploy OpenZeppelin UDC at new mainnet address

### DIFF
--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -227,17 +227,20 @@ fn add_default_udc(states: &mut StateUpdatesWithClasses) {
     // declare UDC class
     states
         .classes
-        .entry(contracts::UniversalDeployer::HASH)
-        .or_insert_with(|| contracts::UniversalDeployer::CLASS.clone());
+        .entry(contracts::OpenZeppelinUniversalDeployer::HASH)
+        .or_insert_with(|| contracts::OpenZeppelinUniversalDeployer::CLASS.clone());
 
-    states.state_updates.deprecated_declared_classes.insert(contracts::UniversalDeployer::HASH);
+    states.state_updates.declared_classes.insert(
+        contracts::OpenZeppelinUniversalDeployer::HASH,
+        contracts::OpenZeppelinUniversalDeployer::CASM_HASH,
+    );
 
     // deploy UDC contract
     states
         .state_updates
         .deployed_contracts
         .entry(DEFAULT_UDC_ADDRESS)
-        .or_insert(contracts::UniversalDeployer::HASH);
+        .or_insert(contracts::OpenZeppelinUniversalDeployer::HASH);
 }
 
 #[cfg(test)]
@@ -273,8 +276,8 @@ mod tests {
         let classes = BTreeMap::from([
             (contracts::LegacyERC20::HASH, contracts::LegacyERC20::CLASS.clone().into()),
             (
-                contracts::UniversalDeployer::HASH,
-                contracts::UniversalDeployer::CLASS.clone().into(),
+                contracts::OpenZeppelinUniversalDeployer::HASH,
+                contracts::OpenZeppelinUniversalDeployer::CLASS.clone().into(),
             ),
             (contracts::Account::HASH, contracts::Account::CLASS.clone().into()),
         ]);
@@ -400,29 +403,28 @@ mod tests {
         assert_eq!(
             actual_state_updates
                 .state_updates
-                .deprecated_declared_classes
-                .get(&contracts::UniversalDeployer::HASH),
-            Some(&contracts::UniversalDeployer::HASH),
+                .declared_classes
+                .get(&contracts::OpenZeppelinUniversalDeployer::HASH),
+            Some(&contracts::OpenZeppelinUniversalDeployer::CASM_HASH),
             "The default universal deployer class should be declared"
         );
 
         assert_eq!(
             actual_state_updates
                 .state_updates
-                .declared_classes
-                .get(&contracts::UniversalDeployer::HASH),
+                .deprecated_declared_classes
+                .get(&contracts::OpenZeppelinUniversalDeployer::HASH),
             None,
-            "The udc is a legacy class - legacy class should only be in \
-             `deprecated_declared_classes`"
+            "The udc is a Sierra class - it should only be in `declared_classes`"
         );
         assert_eq!(
-            actual_state_updates.classes.get(&contracts::UniversalDeployer::HASH),
-            Some(&contracts::UniversalDeployer::CLASS.clone())
+            actual_state_updates.classes.get(&contracts::OpenZeppelinUniversalDeployer::HASH),
+            Some(&contracts::OpenZeppelinUniversalDeployer::CLASS.clone())
         );
 
         assert_eq!(
             actual_state_updates.state_updates.deployed_contracts.get(&DEFAULT_UDC_ADDRESS),
-            Some(&contracts::UniversalDeployer::HASH),
+            Some(&contracts::OpenZeppelinUniversalDeployer::HASH),
             "The universal deployer contract should be created"
         );
 

--- a/crates/chain-spec/src/dev.rs
+++ b/crates/chain-spec/src/dev.rs
@@ -7,9 +7,9 @@ use katana_genesis::allocation::{DevAllocationsGenerator, GenesisAllocation};
 use katana_genesis::constant::{
     get_fee_token_balance_base_storage_address, DEFAULT_ACCOUNT_CLASS_PUBKEY_STORAGE_SLOT,
     DEFAULT_ETH_FEE_TOKEN_ADDRESS, DEFAULT_FROZEN_DEV_ACCOUNT_ADDRESS_CLASS_HASH,
-    DEFAULT_PREFUNDED_ACCOUNT_BALANCE, DEFAULT_STRK_FEE_TOKEN_ADDRESS, DEFAULT_UDC_ADDRESS,
-    ERC20_DECIMAL_STORAGE_SLOT, ERC20_NAME_STORAGE_SLOT, ERC20_SYMBOL_STORAGE_SLOT,
-    ERC20_TOTAL_SUPPLY_STORAGE_SLOT,
+    DEFAULT_LEGACY_UDC_ADDRESS, DEFAULT_PREFUNDED_ACCOUNT_BALANCE, DEFAULT_STRK_FEE_TOKEN_ADDRESS,
+    DEFAULT_UDC_ADDRESS, ERC20_DECIMAL_STORAGE_SLOT, ERC20_NAME_STORAGE_SLOT,
+    ERC20_SYMBOL_STORAGE_SLOT, ERC20_TOTAL_SUPPLY_STORAGE_SLOT,
 };
 use katana_genesis::Genesis;
 use katana_primitives::block::{ExecutableBlock, GasPrices, PartialHeader};
@@ -224,7 +224,7 @@ fn add_fee_token(
 }
 
 fn add_default_udc(states: &mut StateUpdatesWithClasses) {
-    // declare UDC class
+    // Default UDC: the current OpenZeppelin Sierra class on Starknet mainnet/sepolia.
     states
         .classes
         .entry(contracts::OpenZeppelinUniversalDeployer::HASH)
@@ -235,12 +235,27 @@ fn add_default_udc(states: &mut StateUpdatesWithClasses) {
         contracts::OpenZeppelinUniversalDeployer::CASM_HASH,
     );
 
-    // deploy UDC contract
     states
         .state_updates
         .deployed_contracts
         .entry(DEFAULT_UDC_ADDRESS)
         .or_insert(contracts::OpenZeppelinUniversalDeployer::HASH);
+
+    // Legacy UDC: the earlier Cairo 0 OpenZeppelin class. Predeployed at its canonical
+    // mainnet address so tooling and bootstrap flows that still target the legacy UDC
+    // continue to work against Katana dev.
+    states
+        .classes
+        .entry(contracts::UniversalDeployer::HASH)
+        .or_insert_with(|| contracts::UniversalDeployer::CLASS.clone());
+
+    states.state_updates.deprecated_declared_classes.insert(contracts::UniversalDeployer::HASH);
+
+    states
+        .state_updates
+        .deployed_contracts
+        .entry(DEFAULT_LEGACY_UDC_ADDRESS)
+        .or_insert(contracts::UniversalDeployer::HASH);
 }
 
 #[cfg(test)]
@@ -278,6 +293,10 @@ mod tests {
             (
                 contracts::OpenZeppelinUniversalDeployer::HASH,
                 contracts::OpenZeppelinUniversalDeployer::CLASS.clone().into(),
+            ),
+            (
+                contracts::UniversalDeployer::HASH,
+                contracts::UniversalDeployer::CLASS.clone().into(),
             ),
             (contracts::Account::HASH, contracts::Account::CLASS.clone().into()),
         ]);
@@ -363,7 +382,7 @@ mod tests {
 
         similar_asserts::assert_eq!(actual_block, expected_block);
 
-        assert!(actual_state_updates.classes.len() == 3);
+        assert!(actual_state_updates.classes.len() == 4);
 
         assert_eq!(
             actual_state_updates.state_updates.declared_classes.get(&contracts::LegacyERC20::HASH),
@@ -428,6 +447,26 @@ mod tests {
             "The universal deployer contract should be created"
         );
 
+        // Legacy UDC should also be declared and deployed at its canonical address for
+        // backward compatibility.
+        assert_eq!(
+            actual_state_updates
+                .state_updates
+                .deprecated_declared_classes
+                .get(&contracts::UniversalDeployer::HASH),
+            Some(&contracts::UniversalDeployer::CASM_HASH),
+            "The legacy universal deployer class should be declared"
+        );
+        assert_eq!(
+            actual_state_updates.classes.get(&contracts::UniversalDeployer::HASH),
+            Some(&contracts::UniversalDeployer::CLASS.clone())
+        );
+        assert_eq!(
+            actual_state_updates.state_updates.deployed_contracts.get(&DEFAULT_LEGACY_UDC_ADDRESS),
+            Some(&contracts::UniversalDeployer::HASH),
+            "The legacy universal deployer contract should be created at its canonical address"
+        );
+
         assert_eq!(
             actual_state_updates.state_updates.declared_classes.get(&contracts::Account::HASH),
             Some(&contracts::Account::CASM_HASH),
@@ -444,9 +483,9 @@ mod tests {
 
         assert_eq!(
             actual_state_updates.state_updates.deployed_contracts.len(),
-            6,
-            "6 contracts should be created: STRK fee token, ETH fee token, universal deployer, \
-             and 3 allocations"
+            7,
+            "7 contracts should be created: STRK fee token, ETH fee token, default UDC, legacy \
+             UDC, and 3 allocations"
         );
 
         let alloc_1_addr = allocations[0].0;

--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -315,8 +315,7 @@ impl<'c> GenesisTransactionsBuilder<'c> {
     }
 
     fn build_core_contracts(&mut self) {
-        let udc_class_hash =
-            self.declare(contracts::OpenZeppelinUniversalDeployer::CLASS.clone());
+        let udc_class_hash = self.declare(contracts::OpenZeppelinUniversalDeployer::CLASS.clone());
         self.deploy(udc_class_hash, Vec::new(), Felt::ZERO);
 
         let master_address = *self.master_address.get().expect("must be initialized first");

--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -318,6 +318,12 @@ impl<'c> GenesisTransactionsBuilder<'c> {
         let udc_class_hash = self.declare(contracts::OpenZeppelinUniversalDeployer::CLASS.clone());
         self.deploy(udc_class_hash, Vec::new(), Felt::ZERO);
 
+        // Legacy UDC (Cairo 0): declared and deployed alongside the current one so tooling
+        // that still targets the legacy UDC's canonical address keeps working.
+        let legacy_udc_class_hash =
+            self.legacy_declare(contracts::UniversalDeployer::CLASS.clone());
+        self.deploy(legacy_udc_class_hash, Vec::new(), Felt::ZERO);
+
         let master_address = *self.master_address.get().expect("must be initialized first");
 
         let ctor_args: Vec<Felt> = vec![
@@ -437,6 +443,8 @@ mod tests {
             TxType::DeployAccount, // Master account
             TxType::Declare,       // UDC declare
             TxType::Invoke,        // UDC deploy
+            TxType::Declare,       // Legacy UDC declare
+            TxType::Invoke,        // Legacy UDC deploy
             TxType::Declare,       // ERC20 declare
             TxType::Invoke,        // ERC20 deploy
             TxType::Declare,       // Account class declare (V2)
@@ -478,9 +486,9 @@ mod tests {
             let mut transactions = GenesisTransactionsBuilder::new(&chain_spec).build();
 
             // We only want to check that for each predeployed accounts, there should be a deploy
-            // account and transfer balance (invoke) transactions. So we skip the first 7
-            // transactions (master account, UDC, ERC20, etc).
-            let account_transactions = &transactions.split_off(7);
+            // account and transfer balance (invoke) transactions. So we skip the first 9
+            // transactions (master account, UDC, legacy UDC, ERC20, etc).
+            let account_transactions = &transactions.split_off(9);
 
             if with_balance {
                 assert_eq!(account_transactions.len(), n_accounts * 2);
@@ -510,9 +518,9 @@ mod tests {
             let mut transactions = GenesisTransactionsBuilder::new(&chain_spec).build();
 
             // We only want to check that for each predeployed accounts, there should be a deploy
-            // account and transfer balance (invoke) transactions. So we skip the first 7
-            // transactions (master account, UDC, ERC20, etc).
-            let account_transactions = &transactions.split_off(7);
+            // account and transfer balance (invoke) transactions. So we skip the first 9
+            // transactions (master account, UDC, legacy UDC, ERC20, etc).
+            let account_transactions = &transactions.split_off(9);
 
             if with_balance {
                 assert_eq!(account_transactions.len(), n_accounts as usize * 2);

--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -315,7 +315,8 @@ impl<'c> GenesisTransactionsBuilder<'c> {
     }
 
     fn build_core_contracts(&mut self) {
-        let udc_class_hash = self.legacy_declare(contracts::UniversalDeployer::CLASS.clone());
+        let udc_class_hash =
+            self.declare(contracts::OpenZeppelinUniversalDeployer::CLASS.clone());
         self.deploy(udc_class_hash, Vec::new(), Felt::ZERO);
 
         let master_address = *self.master_address.get().expect("must be initialized first");

--- a/crates/chain-spec/tests/rollup.rs
+++ b/crates/chain-spec/tests/rollup.rs
@@ -101,9 +101,11 @@ fn genesis_states() {
     let erc20_class_hash = contracts::LegacyERC20::HASH;
     assert!(genesis_state.class(erc20_class_hash).unwrap().is_some());
 
-    // check that the default udc class is declared
+    // check that both UDC classes are declared
     let udc_class_hash = contracts::OpenZeppelinUniversalDeployer::HASH;
     assert!(genesis_state.class(udc_class_hash).unwrap().is_some());
+    let legacy_udc_class_hash = contracts::UniversalDeployer::HASH;
+    assert!(genesis_state.class(legacy_udc_class_hash).unwrap().is_some());
 
     // -----------------------------------------------------------------------
     // Contracts
@@ -112,12 +114,17 @@ fn genesis_states() {
     let res = genesis_state.class_hash_of_contract(DEFAULT_APPCHAIN_FEE_TOKEN_ADDRESS).unwrap();
     assert_eq!(res, Some(erc20_class_hash));
 
-    // Rollup mode deploys the UDC via the master account with salt=0 and no ctor args; the
+    // Rollup mode deploys each UDC via the master account with salt=0 and no ctor args; the
     // resulting address is derived from the UDC class hash (not the fixed mainnet address).
     let udc_address: ContractAddress =
         get_contract_address(Felt::ZERO, udc_class_hash, &[], ContractAddress::ZERO).into();
     let res = genesis_state.class_hash_of_contract(udc_address).unwrap();
     assert_eq!(res, Some(udc_class_hash));
+
+    let legacy_udc_address: ContractAddress =
+        get_contract_address(Felt::ZERO, legacy_udc_class_hash, &[], ContractAddress::ZERO).into();
+    let res = genesis_state.class_hash_of_contract(legacy_udc_address).unwrap();
+    assert_eq!(res, Some(legacy_udc_class_hash));
 
     for (address, account) in chain_spec.genesis.accounts() {
         let nonce = genesis_state.nonce(*address).unwrap();
@@ -138,6 +145,8 @@ fn transaction_order() {
         TxType::DeployAccount, // Master account
         TxType::Declare,       // UDC declare
         TxType::Invoke,        // UDC deploy
+        TxType::Declare,       // Legacy UDC declare
+        TxType::Invoke,        // Legacy UDC deploy
         TxType::Declare,       // ERC20 declare
         TxType::Invoke,        // ERC20 deploy
         TxType::Declare,       // Account class declare (V2)
@@ -179,9 +188,9 @@ fn predeployed_acccounts(#[case] with_balance: bool) {
         let mut transactions = GenesisTransactionsBuilder::new(&chain_spec).build();
 
         // We only want to check that for each predeployed accounts, there should be a deploy
-        // account and transfer balance (invoke) transactions. So we skip the first 7
-        // transactions (master account, UDC, ERC20, etc).
-        let account_transactions = &transactions.split_off(7);
+        // account and transfer balance (invoke) transactions. So we skip the first 9
+        // transactions (master account, UDC, legacy UDC, ERC20, etc).
+        let account_transactions = &transactions.split_off(9);
 
         if with_balance {
             assert_eq!(account_transactions.len(), n_accounts * 2);
@@ -211,9 +220,9 @@ fn dev_predeployed_acccounts(#[case] with_balance: bool) {
         let mut transactions = GenesisTransactionsBuilder::new(&chain_spec).build();
 
         // We only want to check that for each predeployed accounts, there should be a deploy
-        // account and transfer balance (invoke) transactions. So we skip the first 7
-        // transactions (master account, UDC, ERC20, etc).
-        let account_transactions = &transactions.split_off(7);
+        // account and transfer balance (invoke) transactions. So we skip the first 9
+        // transactions (master account, UDC, legacy UDC, ERC20, etc).
+        let account_transactions = &transactions.split_off(9);
 
         if with_balance {
             assert_eq!(account_transactions.len(), n_accounts as usize * 2);

--- a/crates/chain-spec/tests/rollup.rs
+++ b/crates/chain-spec/tests/rollup.rs
@@ -11,12 +11,13 @@ use katana_executor::{BlockLimits, ExecutorFactory};
 use katana_genesis::allocation::{
     DevAllocationsGenerator, GenesisAccount, GenesisAccountAlloc, GenesisAllocation,
 };
-use katana_genesis::constant::{DEFAULT_PREFUNDED_ACCOUNT_BALANCE, DEFAULT_UDC_ADDRESS};
+use katana_genesis::constant::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
 use katana_genesis::Genesis;
 use katana_primitives::chain::ChainId;
 use katana_primitives::class::ClassHash;
-use katana_primitives::contract::Nonce;
+use katana_primitives::contract::{ContractAddress, Nonce};
 use katana_primitives::transaction::TxType;
+use katana_primitives::utils::get_contract_address;
 use katana_primitives::Felt;
 use katana_provider::api::state::StateFactoryProvider;
 use katana_provider::{DbProviderFactory, ProviderFactory};
@@ -101,7 +102,7 @@ fn genesis_states() {
     assert!(genesis_state.class(erc20_class_hash).unwrap().is_some());
 
     // check that the default udc class is declared
-    let udc_class_hash = contracts::UniversalDeployer::HASH;
+    let udc_class_hash = contracts::OpenZeppelinUniversalDeployer::HASH;
     assert!(genesis_state.class(udc_class_hash).unwrap().is_some());
 
     // -----------------------------------------------------------------------
@@ -111,8 +112,11 @@ fn genesis_states() {
     let res = genesis_state.class_hash_of_contract(DEFAULT_APPCHAIN_FEE_TOKEN_ADDRESS).unwrap();
     assert_eq!(res, Some(erc20_class_hash));
 
-    // check that the default udc is deployed
-    let res = genesis_state.class_hash_of_contract(DEFAULT_UDC_ADDRESS).unwrap();
+    // Rollup mode deploys the UDC via the master account with salt=0 and no ctor args; the
+    // resulting address is derived from the UDC class hash (not the fixed mainnet address).
+    let udc_address: ContractAddress =
+        get_contract_address(Felt::ZERO, udc_class_hash, &[], ContractAddress::ZERO).into();
+    let res = genesis_state.class_hash_of_contract(udc_address).unwrap();
     assert_eq!(res, Some(udc_class_hash));
 
     for (address, account) in chain_spec.genesis.accounts() {

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -7,7 +7,7 @@ use katana_chain_spec::ChainSpec;
 use katana_db::Db;
 use katana_genesis::allocation::GenesisAccountAlloc;
 use katana_genesis::constant::{
-    DEFAULT_LEGACY_ERC20_CLASS_HASH, DEFAULT_LEGACY_UDC_CLASS_HASH, DEFAULT_UDC_ADDRESS,
+    DEFAULT_LEGACY_ERC20_CLASS_HASH, DEFAULT_UDC_ADDRESS, DEFAULT_UDC_CLASS_HASH,
 };
 use katana_genesis::json::GenesisJson;
 use katana_genesis::Genesis;
@@ -178,7 +178,7 @@ PREDEPLOYED CONTRACTS
         r"
 | Contract        | Universal Deployer
 | Address         | {DEFAULT_UDC_ADDRESS}
-| Class Hash      | {DEFAULT_LEGACY_UDC_CLASS_HASH:#064x}"
+| Class Hash      | {DEFAULT_UDC_CLASS_HASH:#064x}"
     );
 
     if let Some(hash) = account_class_hash {

--- a/crates/executor/tests/fixtures/mod.rs
+++ b/crates/executor/tests/fixtures/mod.rs
@@ -7,6 +7,7 @@ use katana_executor::ExecutionFlags;
 use katana_genesis::allocation::DevAllocationsGenerator;
 use katana_genesis::constant::{
     DEFAULT_FROZEN_DEV_ACCOUNT_ADDRESS_CLASS_HASH, DEFAULT_PREFUNDED_ACCOUNT_BALANCE,
+    DEFAULT_UDC_ADDRESS,
 };
 use katana_primitives::block::{
     Block, ExecutableBlock, FinalityStatus, GasPrices, PartialHeader, SealedBlockWithStatus,
@@ -211,7 +212,7 @@ pub fn valid_blocks() -> [ExecutableBlock; 3] {
                     // the calldata is encoded based on the standard account call encoding
                     calldata: vec![
                         felt!("0x1"),
-                        felt!("0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"),
+                        DEFAULT_UDC_ADDRESS.into(),
                         felt!("0x1987cbd17808b9a23693d4de7e246a443cfe37e6e7fbaeabd7d7e6532b07c3d"),
                         felt!("10"), // the # of felts after this point
                         // --- udc::deployContract arguments

--- a/crates/genesis/src/constant.rs
+++ b/crates/genesis/src/constant.rs
@@ -1,12 +1,24 @@
-use katana_contracts::contracts::{Account, LegacyERC20, UniversalDeployer};
+use katana_contracts::contracts::{Account, LegacyERC20, OpenZeppelinUniversalDeployer};
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, StorageKey};
 use katana_primitives::utils::get_storage_var_address;
 use katana_primitives::{felt, Felt};
 
-/// The default universal deployer contract address.
-pub const DEFAULT_UDC_ADDRESS: ContractAddress =
+/// The address of the legacy OpenZeppelin Universal Deployer Contract on Starknet
+/// mainnet/sepolia.
+///
+/// This is the address of the earlier UDC version. It's retained as a constant so downstream
+/// code can still refer to it, but Katana no longer predeploys the legacy UDC at genesis —
+/// [`DEFAULT_UDC_ADDRESS`] is the address of the currently-deployed default UDC.
+pub const DEFAULT_LEGACY_UDC_ADDRESS: ContractAddress =
     ContractAddress(felt!("0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"));
+
+/// The address of the default OpenZeppelin Universal Deployer Contract predeployed at genesis.
+///
+/// This is the current UDC address on Starknet mainnet/sepolia — distinct from the legacy
+/// UDC address in [`DEFAULT_LEGACY_UDC_ADDRESS`]. Both are OpenZeppelin implementations.
+pub const DEFAULT_UDC_ADDRESS: ContractAddress =
+    ContractAddress(felt!("0x02ceed65a4bd731034c01113685c831b01c15d7d432f71afb1cf1634b53a2125"));
 
 /// The default ETH fee token contract address.
 /// See https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json
@@ -49,8 +61,11 @@ pub const DEFAULT_PREFUNDED_ACCOUNT_BALANCE: u128 = 10 * u128::pow(10, 21);
 /// The class hash of DEFAULT_LEGACY_ERC20_CONTRACT_CASM.
 pub const DEFAULT_LEGACY_ERC20_CLASS_HASH: ClassHash = LegacyERC20::HASH;
 
-/// The class hash of DEFAULT_LEGACY_UDC_CASM.
-pub const DEFAULT_LEGACY_UDC_CLASS_HASH: ClassHash = UniversalDeployer::HASH;
+/// The class hash of the default Universal Deployer Contract.
+///
+/// Pinned to the OpenZeppelin UDC class that's deployed on Starknet mainnet and sepolia so the
+/// Katana dev environment matches production networks.
+pub const DEFAULT_UDC_CLASS_HASH: ClassHash = OpenZeppelinUniversalDeployer::HASH;
 
 /// The class hash of [`DEFAULT_ACCOUNT_CLASS`].
 pub const DEFAULT_ACCOUNT_CLASS_HASH: ClassHash = Account::HASH;

--- a/crates/genesis/src/json.rs
+++ b/crates/genesis/src/json.rs
@@ -594,7 +594,7 @@ mod tests {
     use katana_primitives::{address, felt};
 
     use super::*;
-    use crate::constant::{DEFAULT_LEGACY_ERC20_CLASS_HASH, DEFAULT_LEGACY_UDC_CLASS_HASH};
+    use crate::constant::DEFAULT_LEGACY_ERC20_CLASS_HASH;
 
     #[test]
     fn deserialize_from_json() {
@@ -776,7 +776,7 @@ mod tests {
                     public_key: felt!("0x1"),
                     balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     nonce: Some(felt!("0x1")),
-                    class_hash: DEFAULT_LEGACY_UDC_CLASS_HASH,
+                    class_hash: UniversalDeployer::HASH,
                     storage: Some(BTreeMap::from([
                         (felt!("0x1"), felt!("0x1")),
                         (felt!("0x2"), felt!("0x2")),
@@ -847,7 +847,7 @@ mod tests {
                 GenesisAllocation::Contract(GenesisContractAlloc {
                     balance: None,
                     nonce: None,
-                    class_hash: Some(DEFAULT_LEGACY_UDC_CLASS_HASH),
+                    class_hash: Some(UniversalDeployer::HASH),
                     storage: Some(BTreeMap::from([(felt!("0x1"), felt!("0x1"))])),
                 }),
             ),

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use katana_contracts::contracts::{Account, LegacyERC20, UniversalDeployer};
+use katana_contracts::contracts::{Account, LegacyERC20, OpenZeppelinUniversalDeployer};
 use katana_primitives::block::{BlockHash, BlockNumber, GasPrices};
 use katana_primitives::class::{ClassHash, ContractClass};
 use katana_primitives::contract::ContractAddress;
@@ -71,16 +71,20 @@ impl Genesis {
 
 impl Default for Genesis {
     /// Creates a new [Genesis] with the default configurations and classes. The default
-    /// classes are a legacy ERC20 class for the fee token, a legacy UDC class for the
-    /// universal deployer, and an OpenZeppelin account contract class.
+    /// classes are a legacy ERC20 class for the fee token, the OpenZeppelin UDC class for
+    /// the universal deployer (matching Starknet mainnet/sepolia), and an OpenZeppelin
+    /// account contract class.
     fn default() -> Self {
         let mut classes = BTreeMap::new();
 
         classes.extend(BTreeMap::from([
             // Fee token class
             (LegacyERC20::HASH, LegacyERC20::CLASS.clone().into()),
-            // universal depoyer contract class
-            (UniversalDeployer::HASH, UniversalDeployer::CLASS.clone().into()),
+            // universal deployer contract class
+            (
+                OpenZeppelinUniversalDeployer::HASH,
+                OpenZeppelinUniversalDeployer::CLASS.clone().into(),
+            ),
             // predeployed account class
             (Account::HASH, Account::CLASS.clone().into()),
         ]));

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use katana_contracts::contracts::{Account, LegacyERC20, OpenZeppelinUniversalDeployer};
+use katana_contracts::contracts::{
+    Account, LegacyERC20, OpenZeppelinUniversalDeployer, UniversalDeployer,
+};
 use katana_primitives::block::{BlockHash, BlockNumber, GasPrices};
 use katana_primitives::class::{ClassHash, ContractClass};
 use katana_primitives::contract::ContractAddress;
@@ -71,20 +73,23 @@ impl Genesis {
 
 impl Default for Genesis {
     /// Creates a new [Genesis] with the default configurations and classes. The default
-    /// classes are a legacy ERC20 class for the fee token, the OpenZeppelin UDC class for
-    /// the universal deployer (matching Starknet mainnet/sepolia), and an OpenZeppelin
-    /// account contract class.
+    /// classes are a legacy ERC20 class for the fee token, both the current OpenZeppelin
+    /// Sierra UDC and the legacy Cairo 0 OpenZeppelin UDC (matching Starknet mainnet/sepolia),
+    /// and an OpenZeppelin account contract class.
     fn default() -> Self {
         let mut classes = BTreeMap::new();
 
         classes.extend(BTreeMap::from([
             // Fee token class
             (LegacyERC20::HASH, LegacyERC20::CLASS.clone().into()),
-            // universal deployer contract class
+            // Current OpenZeppelin universal deployer contract class
             (
                 OpenZeppelinUniversalDeployer::HASH,
                 OpenZeppelinUniversalDeployer::CLASS.clone().into(),
             ),
+            // Legacy OpenZeppelin universal deployer contract class (kept for backward
+            // compatibility with tooling that targets the original UDC address)
+            (UniversalDeployer::HASH, UniversalDeployer::CLASS.clone().into()),
             // predeployed account class
             (Account::HASH, Account::CLASS.clone().into()),
         ]));

--- a/crates/rpc/rpc-server/tests/common/mod.rs
+++ b/crates/rpc/rpc-server/tests/common/mod.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 use cainome::rs::abigen_legacy;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
+use katana_genesis::constant::DEFAULT_UDC_ADDRESS;
 use katana_primitives::class::CompiledClass;
 use katana_primitives::Felt;
 use starknet::core::types::contract::SierraClass;
@@ -61,9 +62,7 @@ pub fn build_deploy_cairo1_contract_call(class_hash: Felt, salt: Felt) -> Call {
 
     Call {
         calldata,
-        // devnet UDC address
-        to: Felt::from_hex("0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf")
-            .unwrap(),
+        to: DEFAULT_UDC_ADDRESS.into(),
         selector: get_selector_from_name("deployContract").unwrap(),
     }
 }

--- a/crates/rpc/rpc-server/tests/messaging.rs
+++ b/crates/rpc/rpc-server/tests/messaging.rs
@@ -16,7 +16,7 @@ use katana_rpc_types::{Class, MsgFromL1};
 use katana_utils::{TestNode, TxWaiter};
 use rand::Rng;
 use starknet::accounts::{Account, ConnectedAccount};
-use starknet::contract::ContractFactory;
+use starknet::contract::{ContractFactory, UdcSelector};
 use starknet::core::types::{Hash256, ReceiptBlock, Transaction, TransactionReceipt};
 use starknet::core::utils::get_contract_address;
 use starknet::macros::selector;
@@ -95,8 +95,7 @@ async fn test_messaging() {
         let address = get_contract_address(Felt::ZERO, class_hash, &[], Felt::ZERO);
 
         // Deploy the contract using UDC
-        #[allow(deprecated)]
-        let res = ContractFactory::new(class_hash, &katana_account)
+        let res = ContractFactory::new_with_udc(class_hash, &katana_account, UdcSelector::New)
             .deploy_v3(Vec::new(), Felt::ZERO, false)
             .send()
             .await
@@ -240,8 +239,7 @@ async fn estimate_message_fee() -> Result<()> {
     TxWaiter::new(res.transaction_hash, &rpc_client).await?;
 
     // Deploy the contract using UDC
-    #[allow(deprecated)]
-    let res = ContractFactory::new(class_hash, &account)
+    let res = ContractFactory::new_with_udc(class_hash, &account, UdcSelector::New)
         .deploy_v3(Vec::new(), Felt::ZERO, false)
         .send()
         .await?;


### PR DESCRIPTION
Predeploy the new [UDC](https://docs.openzeppelin.com/contracts-cairo/3.x/udc#udc-contract-address) contract at genesis at the same address as Starknet mainnet: `0x02ceed65a4bd731034c01113685c831b01c15d7d432f71afb1cf1634b53a2125` 