### PR TITLE
test(grpc): add integration tests for uncovered Starknet read methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6588,6 +6588,7 @@ dependencies = [
  "katana-rpc-api",
  "katana-rpc-server",
  "katana-rpc-types",
+ "katana-starknet",
  "katana-utils",
  "num-bigint",
  "prost 0.12.6",

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -43,6 +43,7 @@ tower-service.workspace = true
 
 [dev-dependencies]
 hex = "0.4"
+katana-starknet.workspace = true
 katana-utils = { workspace = true, features = [ "node" ] }
 tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
 

--- a/crates/grpc/tests/starknet.rs
+++ b/crates/grpc/tests/starknet.rs
@@ -7,18 +7,20 @@ use katana_grpc::proto::{
     GetTransactionReceiptRequest, GetTransactionStatusRequest, SpecVersionRequest, SyncingRequest,
 };
 use katana_grpc::GrpcClient;
-use katana_primitives::Felt;
-use katana_utils::node::TestNode;
-use starknet::core::types::{
-    BlockId, BlockTag as StarknetBlockTag, EventFilter, ExecutionResult, FunctionCall,
-    TransactionStatus,
+use katana_primitives::block::BlockIdOrTag;
+use katana_primitives::{ContractAddress, Felt};
+use katana_rpc_types::block::{
+    GetBlockWithReceiptsResponse, GetBlockWithTxHashesResponse, MaybePreConfirmedBlock,
 };
+use katana_rpc_types::state_update::StateUpdate;
+use katana_rpc_types::transaction::{RpcTx, TxStatus};
+use katana_rpc_types::{EventFilter, ExecutionResult, FunctionCall, SyncingResponse};
+use katana_starknet::rpc::StarknetRpcClient;
+use katana_utils::node::TestNode;
 use starknet::core::utils::get_selector_from_name;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider, Url};
 use tonic::{Code, Request};
 
-async fn setup() -> (TestNode, GrpcClient, JsonRpcClient<HttpTransport>) {
+async fn setup() -> (TestNode, GrpcClient, StarknetRpcClient) {
     let node = TestNode::new_with_spawn_and_move_db().await;
 
     let grpc_addr = *node.grpc_addr().expect("grpc not enabled");
@@ -26,9 +28,7 @@ async fn setup() -> (TestNode, GrpcClient, JsonRpcClient<HttpTransport>) {
         .await
         .expect("failed to connect to gRPC server");
 
-    let rpc_addr = *node.rpc_addr();
-    let url = Url::parse(&format!("http://{rpc_addr}")).expect("failed to parse url");
-    let rpc = JsonRpcClient::new(HttpTransport::new(url));
+    let rpc = node.starknet_rpc_client();
 
     (node, grpc, rpc)
 }
@@ -88,7 +88,7 @@ async fn test_chain_id() {
 async fn test_block_number() {
     let (_node, mut grpc, rpc) = setup().await;
 
-    let rpc_block_number = rpc.block_number().await.expect("rpc block_number failed");
+    let rpc_block_number = rpc.block_number().await.expect("rpc block_number failed").block_number;
 
     let grpc_block_number = grpc
         .block_number(Request::new(BlockNumberRequest {}))
@@ -122,7 +122,7 @@ async fn test_block_hash_and_number() {
 async fn test_get_block_with_txs() {
     let (_node, mut grpc, rpc) = setup().await;
 
-    let rpc_block = rpc.get_block_with_txs(BlockId::Number(0)).await.expect("rpc failed");
+    let rpc_block = rpc.get_block_with_txs(BlockIdOrTag::Number(0)).await.expect("rpc failed");
 
     let grpc_result = grpc
         .get_block_with_txs(Request::new(GetBlockRequest { block_id: grpc_block_id_number(0) }))
@@ -131,7 +131,7 @@ async fn test_get_block_with_txs() {
         .into_inner();
 
     let rpc_block = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxs::Block(b) => b,
+        MaybePreConfirmedBlock::Confirmed(b) => b,
         _ => panic!("Expected confirmed block from rpc"),
     };
 
@@ -153,7 +153,8 @@ async fn test_get_block_with_txs() {
 async fn test_get_block_with_tx_hashes() {
     let (_node, mut grpc, rpc) = setup().await;
 
-    let rpc_block = rpc.get_block_with_tx_hashes(BlockId::Number(0)).await.expect("rpc failed");
+    let rpc_block =
+        rpc.get_block_with_tx_hashes(BlockIdOrTag::Number(0)).await.expect("rpc failed");
 
     let grpc_result = grpc
         .get_block_with_tx_hashes(Request::new(GetBlockRequest {
@@ -164,7 +165,7 @@ async fn test_get_block_with_tx_hashes() {
         .into_inner();
 
     let rpc_block = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => b,
+        GetBlockWithTxHashesResponse::Block(b) => b,
         _ => panic!("Expected confirmed block from rpc"),
     };
 
@@ -192,8 +193,7 @@ async fn test_get_block_with_tx_hashes() {
 async fn test_get_block_with_txs_latest() {
     let (_node, mut grpc, rpc) = setup().await;
 
-    let rpc_block =
-        rpc.get_block_with_txs(BlockId::Tag(StarknetBlockTag::Latest)).await.expect("rpc failed");
+    let rpc_block = rpc.get_block_with_txs(BlockIdOrTag::Latest).await.expect("rpc failed");
 
     let grpc_result = grpc
         .get_block_with_txs(Request::new(GetBlockRequest { block_id: grpc_block_id_latest() }))
@@ -202,7 +202,7 @@ async fn test_get_block_with_txs_latest() {
         .into_inner();
 
     let rpc_block = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxs::Block(b) => b,
+        MaybePreConfirmedBlock::Confirmed(b) => b,
         _ => panic!("Expected confirmed block from rpc"),
     };
 
@@ -222,7 +222,7 @@ async fn test_get_class_at() {
     let address = genesis_address(&node);
 
     let rpc_class = rpc
-        .get_class_at(BlockId::Tag(StarknetBlockTag::Latest), address)
+        .get_class_at(BlockIdOrTag::Latest, ContractAddress::from(address))
         .await
         .expect("rpc get_class_at failed");
 
@@ -237,7 +237,7 @@ async fn test_get_class_at() {
 
     // Verify both return a Sierra class (not Legacy)
     assert!(
-        matches!(rpc_class, starknet::core::types::ContractClass::Sierra(_)),
+        matches!(rpc_class, katana_rpc_types::class::Class::Sierra(_)),
         "Expected Sierra class from rpc"
     );
     assert!(
@@ -255,7 +255,7 @@ async fn test_get_class_hash_at() {
     let address = genesis_address(&node);
 
     let rpc_class_hash = rpc
-        .get_class_hash_at(BlockId::Tag(StarknetBlockTag::Latest), address)
+        .get_class_hash_at(BlockIdOrTag::Latest, ContractAddress::from(address))
         .await
         .expect("rpc get_class_hash_at failed");
 
@@ -278,7 +278,7 @@ async fn test_get_storage_at() {
     let address = genesis_address(&node);
 
     let rpc_value = rpc
-        .get_storage_at(address, Felt::ZERO, BlockId::Tag(StarknetBlockTag::Latest))
+        .get_storage_at(ContractAddress::from(address), Felt::ZERO, BlockIdOrTag::Latest)
         .await
         .expect("rpc get_storage_at failed");
 
@@ -302,7 +302,7 @@ async fn test_get_nonce() {
     let address = genesis_address(&node);
 
     let rpc_nonce = rpc
-        .get_nonce(BlockId::Tag(StarknetBlockTag::Latest), address)
+        .get_nonce(BlockIdOrTag::Latest, ContractAddress::from(address))
         .await
         .expect("rpc get_nonce failed");
 
@@ -349,7 +349,7 @@ async fn test_syncing() {
         .into_inner();
 
     assert!(
-        matches!(rpc_syncing, starknet::core::types::SyncStatusType::NotSyncing),
+        matches!(rpc_syncing, SyncingResponse::NotSyncing),
         "Expected rpc to report not syncing"
     );
     assert!(
@@ -366,7 +366,7 @@ async fn test_get_block_transaction_count() {
     let (_node, mut grpc, rpc) = setup().await;
 
     let rpc_count = rpc
-        .get_block_transaction_count(BlockId::Number(0))
+        .get_block_transaction_count(BlockIdOrTag::Number(0))
         .await
         .expect("rpc get_block_transaction_count failed");
 
@@ -387,7 +387,7 @@ async fn test_get_state_update() {
     let (_node, mut grpc, rpc) = setup().await;
 
     let rpc_state =
-        rpc.get_state_update(BlockId::Number(0)).await.expect("rpc get_state_update failed");
+        rpc.get_state_update(BlockIdOrTag::Number(0)).await.expect("rpc get_state_update failed");
 
     let grpc_result = grpc
         .get_state_update(Request::new(GetBlockRequest { block_id: grpc_block_id_number(0) }))
@@ -396,7 +396,7 @@ async fn test_get_state_update() {
         .into_inner();
 
     let rpc_state = match rpc_state {
-        starknet::core::types::MaybePreConfirmedStateUpdate::Update(s) => s,
+        StateUpdate::Confirmed(s) => s,
         _ => panic!("Expected confirmed state update from rpc"),
     };
 
@@ -426,8 +426,8 @@ async fn test_get_events() {
     let rpc_events = rpc
         .get_events(
             EventFilter {
-                from_block: Some(BlockId::Number(0)),
-                to_block: Some(BlockId::Tag(StarknetBlockTag::Latest)),
+                from_block: Some(BlockIdOrTag::Number(0)),
+                to_block: Some(BlockIdOrTag::Latest),
                 address: None,
                 keys: None,
             },
@@ -460,7 +460,7 @@ async fn test_get_events() {
 
     assert_eq!(
         proto_to_felt(grpc_event.from_address.as_ref().expect("grpc missing from_address")),
-        rpc_event.from_address
+        Felt::from(rpc_event.from_address)
     );
     assert_eq!(
         proto_to_felt(grpc_event.transaction_hash.as_ref().expect("grpc missing tx_hash")),
@@ -476,10 +476,10 @@ async fn test_get_transaction_by_hash() {
 
     // Get a transaction hash from block 1
     let rpc_block =
-        rpc.get_block_with_tx_hashes(BlockId::Number(1)).await.expect("rpc get_block failed");
+        rpc.get_block_with_tx_hashes(BlockIdOrTag::Number(1)).await.expect("rpc get_block failed");
 
     let tx_hash = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => {
+        GetBlockWithTxHashesResponse::Block(b) => {
             *b.transactions.first().expect("no transactions in block 1")
         }
         _ => panic!("Expected confirmed block"),
@@ -499,7 +499,7 @@ async fn test_get_transaction_by_hash() {
         .into_inner();
 
     // Verify RPC returned the correct hash
-    assert_eq!(*rpc_tx.transaction_hash(), tx_hash);
+    assert_eq!(rpc_tx.transaction_hash, tx_hash);
 
     // Verify gRPC returned a valid transaction
     let grpc_tx = grpc_result.transaction.expect("grpc missing transaction");
@@ -512,10 +512,10 @@ async fn test_get_transaction_receipt() {
 
     // Get a transaction hash from block 1
     let rpc_block =
-        rpc.get_block_with_tx_hashes(BlockId::Number(1)).await.expect("rpc get_block failed");
+        rpc.get_block_with_tx_hashes(BlockIdOrTag::Number(1)).await.expect("rpc get_block failed");
 
     let tx_hash = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => {
+        GetBlockWithTxHashesResponse::Block(b) => {
             *b.transactions.first().expect("no transactions in block 1")
         }
         _ => panic!("Expected confirmed block"),
@@ -537,22 +537,30 @@ async fn test_get_transaction_receipt() {
     let grpc_receipt = grpc_result.receipt.expect("grpc missing receipt");
 
     // Compare transaction hash
-    assert_eq!(*rpc_receipt.receipt.transaction_hash(), tx_hash);
+    assert_eq!(rpc_receipt.transaction_hash, tx_hash);
     assert_eq!(
         proto_to_felt(&grpc_receipt.transaction_hash.expect("grpc missing tx_hash")),
         tx_hash
     );
 
-    // Compare block number
-    assert_eq!(grpc_receipt.block_number, rpc_receipt.block.block_number());
+    // Compare block number: the receipt's ReceiptBlockInfo is either Block{block_number, ..}
+    // or PreConfirmed{block_number}; pattern match to extract.
+    use katana_rpc_types::receipt::ReceiptBlockInfo;
+    let rpc_block_number = match rpc_receipt.block {
+        ReceiptBlockInfo::Block { block_number, .. } => block_number,
+        ReceiptBlockInfo::PreConfirmed { block_number } => block_number,
+    };
+    assert_eq!(grpc_receipt.block_number, rpc_block_number);
 }
 
 #[tokio::test]
 async fn test_get_block_with_receipts() {
     let (_node, mut grpc, rpc) = setup().await;
 
-    let rpc_block =
-        rpc.get_block_with_receipts(BlockId::Number(0)).await.expect("rpc get_block_with_receipts");
+    let rpc_block = rpc
+        .get_block_with_receipts(BlockIdOrTag::Number(0))
+        .await
+        .expect("rpc get_block_with_receipts");
 
     let grpc_result = grpc
         .get_block_with_receipts(Request::new(GetBlockRequest {
@@ -563,7 +571,7 @@ async fn test_get_block_with_receipts() {
         .into_inner();
 
     let rpc_block = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithReceipts::Block(b) => b,
+        GetBlockWithReceiptsResponse::Block(b) => b,
         _ => panic!("Expected confirmed block from rpc"),
     };
 
@@ -595,7 +603,7 @@ async fn test_get_block_with_receipts() {
         let grpc_hash = proto_to_felt(
             grpc_receipt.transaction_hash.as_ref().expect("grpc receipt missing tx_hash"),
         );
-        assert_eq!(grpc_hash, *rpc_twr.receipt.transaction_hash());
+        assert_eq!(grpc_hash, rpc_twr.receipt.transaction_hash);
     }
 }
 
@@ -604,9 +612,9 @@ async fn test_get_transaction_status() {
     let (_node, mut grpc, rpc) = setup().await;
 
     let rpc_block =
-        rpc.get_block_with_tx_hashes(BlockId::Number(1)).await.expect("rpc get_block failed");
+        rpc.get_block_with_tx_hashes(BlockIdOrTag::Number(1)).await.expect("rpc get_block failed");
     let tx_hash = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => {
+        GetBlockWithTxHashesResponse::Block(b) => {
             *b.transactions.first().expect("no tx in block 1")
         }
         _ => panic!("Expected confirmed block"),
@@ -624,11 +632,11 @@ async fn test_get_transaction_status() {
         .into_inner();
 
     let (expected_finality, expected_execution) = match rpc_status {
-        TransactionStatus::Received => ("RECEIVED", ""),
-        TransactionStatus::Candidate => ("CANDIDATE", ""),
-        TransactionStatus::PreConfirmed(ref e) => ("PRE_CONFIRMED", execution_result_str(e)),
-        TransactionStatus::AcceptedOnL2(ref e) => ("ACCEPTED_ON_L2", execution_result_str(e)),
-        TransactionStatus::AcceptedOnL1(ref e) => ("ACCEPTED_ON_L1", execution_result_str(e)),
+        TxStatus::Received => ("RECEIVED", ""),
+        TxStatus::Candidate => ("CANDIDATE", ""),
+        TxStatus::PreConfirmed(ref e) => ("PRE_CONFIRMED", execution_result_str(e)),
+        TxStatus::AcceptedOnL2(ref e) => ("ACCEPTED_ON_L2", execution_result_str(e)),
+        TxStatus::AcceptedOnL1(ref e) => ("ACCEPTED_ON_L1", execution_result_str(e)),
     };
 
     assert_eq!(grpc_resp.finality_status, expected_finality);
@@ -647,7 +655,7 @@ async fn test_get_transaction_by_block_id_and_index() {
     let (_node, mut grpc, rpc) = setup().await;
 
     let rpc_tx = rpc
-        .get_transaction_by_block_id_and_index(BlockId::Number(1), 0)
+        .get_transaction_by_block_id_and_index(BlockIdOrTag::Number(1), 0)
         .await
         .expect("rpc get_transaction_by_block_id_and_index failed");
 
@@ -664,19 +672,18 @@ async fn test_get_transaction_by_block_id_and_index() {
 
     // Cross-ref: the tx at (block 1, index 0) matches the first hash in the block's tx list.
     let block = match rpc
-        .get_block_with_tx_hashes(BlockId::Number(1))
+        .get_block_with_tx_hashes(BlockIdOrTag::Number(1))
         .await
         .expect("rpc get_block_with_tx_hashes failed")
     {
-        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => b,
+        GetBlockWithTxHashesResponse::Block(b) => b,
         _ => panic!("Expected confirmed block"),
     };
-    assert_eq!(*rpc_tx.transaction_hash(), *block.transactions.first().expect("no tx at index 0"));
+    assert_eq!(rpc_tx.transaction_hash, *block.transactions.first().expect("no tx at index 0"));
 
     // Variant-kind parity: handler could otherwise return an arbitrary non-None tx of
     // the wrong kind and this test would pass on `is_some()` alone.
     use katana_grpc::proto::transaction::Transaction as GrpcTxVariant;
-    use starknet::core::types::Transaction as RpcTx;
     let grpc_kind = match grpc_variant {
         GrpcTxVariant::InvokeV1(_) | GrpcTxVariant::InvokeV3(_) => "invoke",
         GrpcTxVariant::DeclareV1(_) | GrpcTxVariant::DeclareV2(_) | GrpcTxVariant::DeclareV3(_) => {
@@ -686,7 +693,7 @@ async fn test_get_transaction_by_block_id_and_index() {
         GrpcTxVariant::L1Handler(_) => "l1_handler",
         GrpcTxVariant::Deploy(_) => "deploy",
     };
-    let rpc_kind = match rpc_tx {
+    let rpc_kind = match rpc_tx.transaction {
         RpcTx::Invoke(_) => "invoke",
         RpcTx::Declare(_) => "declare",
         RpcTx::DeployAccount(_) => "deploy_account",
@@ -702,7 +709,7 @@ async fn test_get_class() {
     let address = genesis_address(&node);
 
     let class_hash = rpc
-        .get_class_hash_at(BlockId::Tag(StarknetBlockTag::Latest), address)
+        .get_class_hash_at(BlockIdOrTag::Latest, ContractAddress::from(address))
         .await
         .expect("rpc get_class_hash_at failed");
 
@@ -756,14 +763,15 @@ async fn test_call() {
     let rpc_result = rpc
         .call(
             FunctionCall {
-                contract_address: strk_token,
+                contract_address: ContractAddress::from(strk_token),
                 entry_point_selector: selector,
                 calldata: vec![genesis],
             },
-            BlockId::Tag(StarknetBlockTag::Latest),
+            BlockIdOrTag::Latest,
         )
         .await
-        .expect("rpc call failed");
+        .expect("rpc call failed")
+        .result;
 
     let grpc_resp = grpc
         .call(Request::new(CallRequest {
@@ -970,8 +978,10 @@ async fn test_get_block_with_txs_by_hash() {
     let hash = proto_to_felt(&bh.block_hash.expect("missing block_hash"));
     let number = bh.block_number;
 
-    let rpc_block =
-        rpc.get_block_with_txs(BlockId::Hash(hash)).await.expect("rpc get_block_with_txs failed");
+    let rpc_block = rpc
+        .get_block_with_txs(BlockIdOrTag::Hash(hash))
+        .await
+        .expect("rpc get_block_with_txs failed");
 
     let grpc_result = grpc
         .get_block_with_txs(Request::new(GetBlockRequest { block_id: grpc_block_id_hash(hash) }))
@@ -980,7 +990,7 @@ async fn test_get_block_with_txs_by_hash() {
         .into_inner();
 
     let rpc_block = match rpc_block {
-        starknet::core::types::MaybePreConfirmedBlockWithTxs::Block(b) => b,
+        MaybePreConfirmedBlock::Confirmed(b) => b,
         _ => panic!("Expected confirmed block from rpc"),
     };
     let grpc_block = match grpc_result.result {

--- a/crates/grpc/tests/starknet.rs
+++ b/crates/grpc/tests/starknet.rs
@@ -1,16 +1,22 @@
 use katana_grpc::proto::{
-    BlockHashAndNumberRequest, BlockNumberRequest, BlockTag, ChainIdRequest, GetBlockRequest,
-    GetClassAtRequest, GetClassHashAtRequest, GetEventsRequest, GetNonceRequest,
-    GetStorageAtRequest, GetTransactionByHashRequest, GetTransactionReceiptRequest,
-    SpecVersionRequest, SyncingRequest,
+    BlockHashAndNumberRequest, BlockNumberRequest, BlockTag, CallRequest, ChainIdRequest,
+    EstimateFeeRequest, EstimateMessageFeeRequest, GetBlockRequest, GetClassAtRequest,
+    GetClassHashAtRequest, GetClassRequest, GetCompiledCasmRequest, GetEventsRequest,
+    GetNonceRequest, GetStorageAtRequest, GetStorageProofRequest,
+    GetTransactionByBlockIdAndIndexRequest, GetTransactionByHashRequest,
+    GetTransactionReceiptRequest, GetTransactionStatusRequest, SpecVersionRequest, SyncingRequest,
 };
 use katana_grpc::GrpcClient;
 use katana_primitives::Felt;
 use katana_utils::node::TestNode;
-use starknet::core::types::{BlockId, BlockTag as StarknetBlockTag, EventFilter};
+use starknet::core::types::{
+    BlockId, BlockTag as StarknetBlockTag, EventFilter, ExecutionResult, FunctionCall,
+    TransactionStatus,
+};
+use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider, Url};
-use tonic::Request;
+use tonic::{Code, Request};
 
 async fn setup() -> (TestNode, GrpcClient, JsonRpcClient<HttpTransport>) {
     let node = TestNode::new_with_spawn_and_move_db().await;
@@ -50,6 +56,12 @@ fn grpc_block_id_number(n: u64) -> Option<katana_grpc::proto::BlockId> {
 fn grpc_block_id_latest() -> Option<katana_grpc::proto::BlockId> {
     Some(katana_grpc::proto::BlockId {
         identifier: Some(katana_grpc::proto::block_id::Identifier::Tag(BlockTag::Latest as i32)),
+    })
+}
+
+fn grpc_block_id_hash(hash: Felt) -> Option<katana_grpc::proto::BlockId> {
+    Some(katana_grpc::proto::BlockId {
+        identifier: Some(katana_grpc::proto::block_id::Identifier::Hash(felt_to_proto(hash))),
     })
 }
 
@@ -533,4 +545,466 @@ async fn test_get_transaction_receipt() {
 
     // Compare block number
     assert_eq!(grpc_receipt.block_number, rpc_receipt.block.block_number());
+}
+
+#[tokio::test]
+async fn test_get_block_with_receipts() {
+    let (_node, mut grpc, rpc) = setup().await;
+
+    let rpc_block =
+        rpc.get_block_with_receipts(BlockId::Number(0)).await.expect("rpc get_block_with_receipts");
+
+    let grpc_result = grpc
+        .get_block_with_receipts(Request::new(GetBlockRequest {
+            block_id: grpc_block_id_number(0),
+        }))
+        .await
+        .expect("grpc get_block_with_receipts failed")
+        .into_inner();
+
+    let rpc_block = match rpc_block {
+        starknet::core::types::MaybePreConfirmedBlockWithReceipts::Block(b) => b,
+        _ => panic!("Expected confirmed block from rpc"),
+    };
+
+    let grpc_block = match grpc_result.result {
+        Some(katana_grpc::proto::get_block_with_receipts_response::Result::Block(b)) => b,
+        _ => panic!("Expected confirmed block from grpc"),
+    };
+
+    let grpc_header = grpc_block.header.expect("grpc missing header");
+    assert_eq!(grpc_header.block_number, rpc_block.block_number);
+    assert_eq!(
+        proto_to_felt(&grpc_header.block_hash.expect("grpc missing block_hash")),
+        rpc_block.block_hash
+    );
+    assert_eq!(
+        proto_to_felt(&grpc_header.parent_hash.expect("grpc missing parent_hash")),
+        rpc_block.parent_hash
+    );
+    assert_eq!(
+        proto_to_felt(&grpc_header.new_root.expect("grpc missing new_root")),
+        rpc_block.new_root
+    );
+    assert_eq!(grpc_block.transactions.len(), rpc_block.transactions.len());
+
+    // Element-wise receipt hash parity: a handler that returns empty/garbage receipts
+    // but the right length would otherwise pass silently.
+    for (grpc_twr, rpc_twr) in grpc_block.transactions.iter().zip(rpc_block.transactions.iter()) {
+        let grpc_receipt = grpc_twr.receipt.as_ref().expect("grpc missing receipt");
+        let grpc_hash = proto_to_felt(
+            grpc_receipt.transaction_hash.as_ref().expect("grpc receipt missing tx_hash"),
+        );
+        assert_eq!(grpc_hash, *rpc_twr.receipt.transaction_hash());
+    }
+}
+
+#[tokio::test]
+async fn test_get_transaction_status() {
+    let (_node, mut grpc, rpc) = setup().await;
+
+    let rpc_block =
+        rpc.get_block_with_tx_hashes(BlockId::Number(1)).await.expect("rpc get_block failed");
+    let tx_hash = match rpc_block {
+        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => {
+            *b.transactions.first().expect("no tx in block 1")
+        }
+        _ => panic!("Expected confirmed block"),
+    };
+
+    let rpc_status =
+        rpc.get_transaction_status(tx_hash).await.expect("rpc get_transaction_status failed");
+
+    let grpc_resp = grpc
+        .get_transaction_status(Request::new(GetTransactionStatusRequest {
+            transaction_hash: Some(felt_to_proto(tx_hash)),
+        }))
+        .await
+        .expect("grpc get_transaction_status failed")
+        .into_inner();
+
+    let (expected_finality, expected_execution) = match rpc_status {
+        TransactionStatus::Received => ("RECEIVED", ""),
+        TransactionStatus::Candidate => ("CANDIDATE", ""),
+        TransactionStatus::PreConfirmed(ref e) => ("PRE_CONFIRMED", execution_result_str(e)),
+        TransactionStatus::AcceptedOnL2(ref e) => ("ACCEPTED_ON_L2", execution_result_str(e)),
+        TransactionStatus::AcceptedOnL1(ref e) => ("ACCEPTED_ON_L1", execution_result_str(e)),
+    };
+
+    assert_eq!(grpc_resp.finality_status, expected_finality);
+    assert_eq!(grpc_resp.execution_status, expected_execution);
+}
+
+fn execution_result_str(e: &ExecutionResult) -> &'static str {
+    match e {
+        ExecutionResult::Succeeded => "SUCCEEDED",
+        ExecutionResult::Reverted { .. } => "REVERTED",
+    }
+}
+
+#[tokio::test]
+async fn test_get_transaction_by_block_id_and_index() {
+    let (_node, mut grpc, rpc) = setup().await;
+
+    let rpc_tx = rpc
+        .get_transaction_by_block_id_and_index(BlockId::Number(1), 0)
+        .await
+        .expect("rpc get_transaction_by_block_id_and_index failed");
+
+    let grpc_resp = grpc
+        .get_transaction_by_block_id_and_index(Request::new(
+            GetTransactionByBlockIdAndIndexRequest { block_id: grpc_block_id_number(1), index: 0 },
+        ))
+        .await
+        .expect("grpc get_transaction_by_block_id_and_index failed")
+        .into_inner();
+
+    let grpc_tx = grpc_resp.transaction.expect("grpc missing transaction");
+    let grpc_variant = grpc_tx.transaction.as_ref().expect("grpc transaction missing variant");
+
+    // Cross-ref: the tx at (block 1, index 0) matches the first hash in the block's tx list.
+    let block = match rpc
+        .get_block_with_tx_hashes(BlockId::Number(1))
+        .await
+        .expect("rpc get_block_with_tx_hashes failed")
+    {
+        starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(b) => b,
+        _ => panic!("Expected confirmed block"),
+    };
+    assert_eq!(*rpc_tx.transaction_hash(), *block.transactions.first().expect("no tx at index 0"));
+
+    // Variant-kind parity: handler could otherwise return an arbitrary non-None tx of
+    // the wrong kind and this test would pass on `is_some()` alone.
+    use katana_grpc::proto::transaction::Transaction as GrpcTxVariant;
+    use starknet::core::types::Transaction as RpcTx;
+    let grpc_kind = match grpc_variant {
+        GrpcTxVariant::InvokeV1(_) | GrpcTxVariant::InvokeV3(_) => "invoke",
+        GrpcTxVariant::DeclareV1(_) | GrpcTxVariant::DeclareV2(_) | GrpcTxVariant::DeclareV3(_) => {
+            "declare"
+        }
+        GrpcTxVariant::DeployAccount(_) | GrpcTxVariant::DeployAccountV3(_) => "deploy_account",
+        GrpcTxVariant::L1Handler(_) => "l1_handler",
+        GrpcTxVariant::Deploy(_) => "deploy",
+    };
+    let rpc_kind = match rpc_tx {
+        RpcTx::Invoke(_) => "invoke",
+        RpcTx::Declare(_) => "declare",
+        RpcTx::DeployAccount(_) => "deploy_account",
+        RpcTx::L1Handler(_) => "l1_handler",
+        RpcTx::Deploy(_) => "deploy",
+    };
+    assert_eq!(grpc_kind, rpc_kind, "grpc tx variant kind should match rpc");
+}
+
+#[tokio::test]
+async fn test_get_class() {
+    let (node, mut grpc, rpc) = setup().await;
+    let address = genesis_address(&node);
+
+    let class_hash = rpc
+        .get_class_hash_at(BlockId::Tag(StarknetBlockTag::Latest), address)
+        .await
+        .expect("rpc get_class_hash_at failed");
+
+    let grpc_resp = grpc
+        .get_class(Request::new(GetClassRequest {
+            block_id: grpc_block_id_latest(),
+            class_hash: Some(felt_to_proto(class_hash)),
+        }))
+        .await
+        .expect("grpc get_class failed")
+        .into_inner();
+
+    // NOTE: handler is lossy — it serializes the whole class to JSON into the `abi`
+    // field and leaves sierra_program/entry_points_by_type empty. This assertion
+    // verifies the Sierra variant is returned AND the abi field is valid, non-trivial
+    // JSON (catches silent `unwrap_or_default` empty-string failures). When the
+    // handler is rewritten to populate sierra_program properly, strengthen this test.
+    match grpc_resp.result {
+        Some(katana_grpc::proto::get_class_response::Result::ContractClass(cc)) => {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&cc.abi).expect("abi must parse as JSON");
+            let obj = parsed.as_object().expect("expected JSON object (class shape)");
+            // A Sierra class JSON must contain at least one of these top-level keys.
+            // Guards against the handler returning `{}` via `unwrap_or_default` or
+            // stuffing unrelated JSON into the abi field.
+            let has_class_shape = obj.contains_key("sierra_program")
+                || obj.contains_key("abi")
+                || obj.contains_key("entry_points_by_type");
+            assert!(
+                has_class_shape,
+                "abi JSON must be class-shaped (sierra_program/abi/entry_points_by_type), got \
+                 keys: {:?}",
+                obj.keys().collect::<Vec<_>>()
+            );
+        }
+        other => panic!("expected ContractClass variant, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_call() {
+    let (node, mut grpc, rpc) = setup().await;
+    let genesis = genesis_address(&node);
+
+    // STRK fee token address (katana_genesis::constant::DEFAULT_STRK_FEE_TOKEN_ADDRESS)
+    let strk_token = Felt::from_hex_unchecked(
+        "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+    );
+    let selector = get_selector_from_name("balanceOf").expect("selector");
+
+    let rpc_result = rpc
+        .call(
+            FunctionCall {
+                contract_address: strk_token,
+                entry_point_selector: selector,
+                calldata: vec![genesis],
+            },
+            BlockId::Tag(StarknetBlockTag::Latest),
+        )
+        .await
+        .expect("rpc call failed");
+
+    let grpc_resp = grpc
+        .call(Request::new(CallRequest {
+            block_id: grpc_block_id_latest(),
+            request: Some(katana_grpc::proto::FunctionCall {
+                contract_address: Some(felt_to_proto(strk_token)),
+                entry_point_selector: Some(felt_to_proto(selector)),
+                calldata: vec![felt_to_proto(genesis)],
+            }),
+        }))
+        .await
+        .expect("grpc call failed")
+        .into_inner();
+
+    assert_eq!(grpc_resp.result.len(), rpc_result.len());
+    for (g, r) in grpc_resp.result.iter().zip(rpc_result.iter()) {
+        assert_eq!(proto_to_felt(g), *r);
+    }
+    // balanceOf returns a u256 = 2 felts (low, high); genesis is prefunded so low should be > 0.
+    assert!(
+        rpc_result.len() >= 2,
+        "balanceOf should return at least 2 felts, got {}",
+        rpc_result.len()
+    );
+    assert_ne!(rpc_result[0], Felt::ZERO, "prefunded genesis balance low should be non-zero");
+}
+
+#[tokio::test]
+async fn test_get_storage_proof() {
+    let (node, mut grpc, _rpc) = setup().await;
+    let address = genesis_address(&node);
+
+    // Cross-reference: the proof's block_hash should match the latest block.
+    let bh = grpc
+        .block_hash_and_number(Request::new(BlockHashAndNumberRequest {}))
+        .await
+        .expect("block_hash_and_number failed")
+        .into_inner();
+    let latest_hash = proto_to_felt(&bh.block_hash.expect("missing block_hash"));
+
+    let resp = grpc
+        .get_storage_proof(Request::new(GetStorageProofRequest {
+            block_id: grpc_block_id_latest(),
+            class_hashes: vec![],
+            contract_addresses: vec![felt_to_proto(address)],
+            contracts_storage_keys: vec![],
+        }))
+        .await
+        .expect("grpc get_storage_proof failed")
+        .into_inner();
+
+    let proof = resp.proof.expect("missing proof");
+    let roots = proof.global_roots.expect("missing global_roots");
+    assert_eq!(
+        proto_to_felt(&roots.block_hash.expect("missing roots.block_hash")),
+        latest_hash,
+        "storage proof block_hash should match latest block"
+    );
+    assert_ne!(
+        proto_to_felt(&roots.contracts_tree_root.expect("missing contracts_tree_root")),
+        Felt::ZERO,
+        "contracts_tree_root should be non-zero on a migrated chain"
+    );
+
+    let contracts_proof = proof.contracts_proof.expect("missing contracts_proof");
+    assert_eq!(
+        contracts_proof.contract_leaves_data.len(),
+        1,
+        "expected one contract leaf for the requested address"
+    );
+}
+
+#[tokio::test]
+async fn test_estimate_fee_unimplemented() {
+    let (_node, mut grpc, _rpc) = setup().await;
+
+    let status = grpc
+        .estimate_fee(Request::new(EstimateFeeRequest {
+            transactions: vec![],
+            simulation_flags: vec![],
+            block_id: grpc_block_id_latest(),
+        }))
+        .await
+        .expect_err("estimate_fee should return Unimplemented");
+
+    assert_eq!(
+        status.code(),
+        Code::Unimplemented,
+        "expected Unimplemented, got: {:?}",
+        status.code()
+    );
+}
+
+#[tokio::test]
+async fn test_estimate_message_fee_unimplemented() {
+    let (_node, mut grpc, _rpc) = setup().await;
+
+    let status = grpc
+        .estimate_message_fee(Request::new(EstimateMessageFeeRequest {
+            message: None,
+            block_id: grpc_block_id_latest(),
+        }))
+        .await
+        .expect_err("estimate_message_fee should return Unimplemented");
+
+    assert_eq!(status.code(), Code::Unimplemented);
+}
+
+#[tokio::test]
+async fn test_get_compiled_casm_unimplemented() {
+    let (_node, mut grpc, _rpc) = setup().await;
+
+    let status = grpc
+        .get_compiled_casm(Request::new(GetCompiledCasmRequest {
+            class_hash: Some(felt_to_proto(Felt::ZERO)),
+        }))
+        .await
+        .expect_err("get_compiled_casm should return Unimplemented");
+
+    assert_eq!(status.code(), Code::Unimplemented);
+}
+
+#[tokio::test]
+async fn test_get_events_pagination() {
+    let (_node, mut grpc, _rpc) = setup().await;
+
+    // Baseline: fetch with the largest chunk the server accepts (100 is the server cap;
+    // larger chunks return ResourceExhausted). A dev chain has well under 100 events
+    // so this is effectively "fetch all" for comparison purposes.
+    let baseline = grpc
+        .get_events(Request::new(GetEventsRequest {
+            filter: Some(katana_grpc::proto::EventFilter {
+                from_block: grpc_block_id_number(0),
+                to_block: grpc_block_id_latest(),
+                address: None,
+                keys: vec![],
+            }),
+            chunk_size: 100,
+            continuation_token: String::new(),
+        }))
+        .await
+        .expect("baseline get_events failed")
+        .into_inner();
+
+    assert!(
+        baseline.events.len() >= 4,
+        "need at least 4 events to exercise pagination, got {}",
+        baseline.events.len()
+    );
+    assert!(baseline.continuation_token.is_empty(), "baseline fetch should be the final page");
+
+    // Walk the same query with chunk_size = 2 and compare order+length.
+    let mut paginated = Vec::new();
+    let mut token = String::new();
+    let mut guard = 0;
+    loop {
+        let resp = grpc
+            .get_events(Request::new(GetEventsRequest {
+                filter: Some(katana_grpc::proto::EventFilter {
+                    from_block: grpc_block_id_number(0),
+                    to_block: grpc_block_id_latest(),
+                    address: None,
+                    keys: vec![],
+                }),
+                chunk_size: 2,
+                continuation_token: token.clone(),
+            }))
+            .await
+            .expect("paginated get_events failed")
+            .into_inner();
+
+        paginated.extend(resp.events);
+        if resp.continuation_token.is_empty() {
+            break;
+        }
+        token = resp.continuation_token;
+
+        guard += 1;
+        assert!(guard < 1000, "pagination did not terminate");
+    }
+
+    assert_eq!(
+        paginated.len(),
+        baseline.events.len(),
+        "paginated event count should match baseline"
+    );
+    for (p, b) in paginated.iter().zip(baseline.events.iter()) {
+        assert_eq!(p.transaction_hash, b.transaction_hash);
+        assert_eq!(p.block_number, b.block_number);
+        assert_eq!(p.keys.len(), b.keys.len());
+        assert_eq!(p.data.len(), b.data.len());
+    }
+}
+
+#[tokio::test]
+async fn test_get_block_with_txs_by_hash() {
+    let (_node, mut grpc, rpc) = setup().await;
+
+    let bh = grpc
+        .block_hash_and_number(Request::new(BlockHashAndNumberRequest {}))
+        .await
+        .expect("block_hash_and_number failed")
+        .into_inner();
+    let hash = proto_to_felt(&bh.block_hash.expect("missing block_hash"));
+    let number = bh.block_number;
+
+    let rpc_block =
+        rpc.get_block_with_txs(BlockId::Hash(hash)).await.expect("rpc get_block_with_txs failed");
+
+    let grpc_result = grpc
+        .get_block_with_txs(Request::new(GetBlockRequest { block_id: grpc_block_id_hash(hash) }))
+        .await
+        .expect("grpc get_block_with_txs failed")
+        .into_inner();
+
+    let rpc_block = match rpc_block {
+        starknet::core::types::MaybePreConfirmedBlockWithTxs::Block(b) => b,
+        _ => panic!("Expected confirmed block from rpc"),
+    };
+    let grpc_block = match grpc_result.result {
+        Some(katana_grpc::proto::get_block_with_txs_response::Result::Block(b)) => b,
+        _ => panic!("Expected confirmed block from grpc"),
+    };
+
+    let grpc_header = grpc_block.header.expect("grpc missing header");
+    assert_eq!(grpc_header.block_number, rpc_block.block_number);
+    assert_eq!(grpc_header.block_number, number);
+    assert_eq!(
+        proto_to_felt(&grpc_header.block_hash.expect("grpc missing block_hash")),
+        hash,
+        "hash-fetched block should have the requested hash"
+    );
+    // Header-integrity parity: without these, a handler that routed Hash -> Number
+    // or returned a different-but-same-length-txs block could pass silently.
+    assert_eq!(
+        proto_to_felt(&grpc_header.parent_hash.expect("grpc missing parent_hash")),
+        rpc_block.parent_hash
+    );
+    assert_eq!(
+        proto_to_felt(&grpc_header.new_root.expect("grpc missing new_root")),
+        rpc_block.new_root
+    );
+    assert_eq!(grpc_block.transactions.len(), rpc_block.transactions.len());
 }


### PR DESCRIPTION
## Summary

Adds 11 integration tests to `crates/grpc/tests/starknet.rs` covering `katana-grpc` Starknet read-service methods that previously had no test coverage, plus two cross-cutting gaps (events pagination, `BlockId::Hash` form).

This is **Workstream 1 of 4** in a planned test-coverage expansion; the write service (`StarknetWrite`), trace service (`StarknetTrace`), and error-path / pending-block tests will land in follow-up PRs.

**Parity tests** (gRPC vs JSON-RPC on a migrated spawn-and-move chain):

- `get_block_with_receipts` — header + per-receipt `transaction_hash` parity
- `get_transaction_status` — maps RPC `TransactionStatus` to handler's `(finality_status, execution_status)` strings
- `get_transaction_by_block_id_and_index` — cross-ref against block's tx hash list + variant-kind (invoke/declare/deploy_account/...) match
- `get_class` — asserts `ContractClass` variant and that handler's JSON-in-`abi` field contains class-shaped keys. The handler is lossy on purpose; test guards against silent `unwrap_or_default` regressions and flags for rewrite
- `call` — `balanceOf(genesis)` against STRK fee token, result parity
- `get_storage_proof` — `global_roots.block_hash` parity + non-zero `contracts_tree_root` + one contract leaf for requested address
- `get_events` pagination — walks `continuation_token` with `chunk_size=2` and compares order + count against a single-page baseline
- `get_block_with_txs` by hash — exercises `BlockId::Hash` proto oneof arm with `parent_hash` + `new_root` header parity

**`Unimplemented`-handler lock-ins** (assert `Code::Unimplemented`; flip to parity tests when implemented):

- `estimate_fee`, `estimate_message_fee`, `get_compiled_casm`

**New inline helper** alongside existing `grpc_block_id_*`:

- `grpc_block_id_hash(Felt)` — constructs the `Hash` oneof arm

## Test Coverage

Before: 17 integration tests covering 16 of 32 gRPC server methods.
After: **28 integration tests covering 25 of 32** (11 of 15 previously-uncovered methods addressed).

Remaining uncovered (shipped in follow-up workstreams):
- W2 (write): `add_invoke_transaction`, `add_declare_transaction`, `add_deploy_account_transaction`
- W3 (trace): `trace_transaction`, `trace_block_transactions` (+ `simulate_transactions` Unimplemented)
- W4 (cross-cutting): error paths (`NotFound` / `InvalidArgument`), `BlockTag::Pending` / `PreConfirmed`

## Pre-Landing Review

Pre-landing review + adversarial review surfaced 4 weak assertions that would let broken handlers pass silently. All four strengthened before this PR:

- `test_get_block_with_receipts` — added per-receipt `transaction_hash` parity + header `parent_hash`/`new_root` checks (was length-only)
- `test_get_transaction_by_block_id_and_index` — added variant-kind match (was `is_some()` only)
- `test_get_class` — JSON assertion now checks for class-shaped top-level keys (was "any non-empty JSON")
- `test_get_block_with_txs_by_hash` — added `parent_hash` + `new_root` parity (was block_hash + tx count only)

## Not in scope (flagged for follow-up)

- `get_class` handler is lossy (class serialized into `abi` field as JSON, `sierra_program` left empty). Test matches current shape with a TODO comment; handler rewrite is a separate concern.
- `event.rs:29-39` proto→`EventFilterWithPage` conversion maps each flat key to `vec![key]` (exact-match-at-position) rather than `[[k]]` (any-of); test uses empty keys so doesn't exercise this. Worth verifying but out of scope for this PR.

## Test plan

- [x] `cargo nextest run -p katana-grpc --test starknet` — 28/28 pass on merged-main state
- [x] `cargo +nightly-2025-02-20 fmt --all -- --check` clean
- [x] `cargo clippy -p katana-grpc --tests` clean
- [x] Each new test verified to actually fail when the relevant assertion is broken (adversarial review fed back into test strengthening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)