### PR TITLE
fix(explorer): rewrite asset paths + allow Google Fonts in embedded mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ $(EXPLORER_UI_DIST): $(EXPLORER_UI_DIR)
 	@echo "Building Explorer..."
 	@cd crates/explorer/ui && \
 		bun install && \
-		bun run build || { echo "Explorer build failed!"; exit 1; }
+		IS_EMBEDDED=1 bun run build || { echo "Explorer build failed!"; exit 1; }
 	@echo "Explorer build complete."
 
 $(SNOS_OUTPUT): $(SNOS_DB_DIR)

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -690,7 +690,8 @@ impl<S> ExplorerService<S> {
             "Content-Security-Policy",
             HeaderValue::from_static(
                 "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src \
-                 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:;",
+                 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: \
+                 https:; font-src 'self' data: https://fonts.gstatic.com;",
             ),
         );
         headers


### PR DESCRIPTION
## Summary

Fixes two independent bugs that surface when the Katana binary serves the embedded Explorer UI under `/explorer`:

### 1. 405 Method Not Allowed on Explorer assets

The Explorer's `dynamic-link.ts` Vite plugin — which rewrites HTML asset URLs to be `basePath()`-aware at runtime — is only active when `IS_EMBEDDED=1` is set during the Vite build. `make build-explorer` wasn't setting it, so the built `dist/index.html` kept domain-root absolute paths like:

- `<link rel=\"icon\" href=\"/cartridge.svg\" />`
- `<script src=\"/noflash.js\"></script>`
- `<script type=\"module\" src=\"/assets/index-CCQa5Svm.js\"></script>`
- `<link rel=\"stylesheet\" href=\"/assets/monaco-editor-CpN8rtOO.css\">`

When the HTML is served under `/explorer`, the browser resolves those paths against the domain root (e.g. `http://localhost:5050/noflash.js`), hits the JSON-RPC handler — which only accepts POST — and gets 405.

Passing `IS_EMBEDDED=1` enables the plugin, which strips those tags and injects a runtime `<script>` that creates them dynamically with `basePath() + \"/...\"` prefixed in.

### 2. Google Fonts blocked by CSP

Both the Explorer's `index.html` (`Space Mono`) and `@cartridge/ui/themes/fonts.css` (`IBM Plex Mono`, `Inter`) load fonts from `fonts.googleapis.com` with font files from `fonts.gstatic.com`. The default CSP said:

```
style-src 'self' 'unsafe-inline'; font-src 'self' data:;
```

…which blocks both, producing console errors like:

> Loading the stylesheet 'https://fonts.googleapis.com/css2?family=Space+Mono…' violates the following Content Security Policy directive: \"style-src 'self' 'unsafe-inline'\".

Allowlisted `https://fonts.googleapis.com` in `style-src` and `https://fonts.gstatic.com` in `font-src` so the fonts actually load.
