### PR TITLE
ci: scope heavy jobs when only the explorer UI changes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,9 +24,31 @@ permissions:
   pull-requests: write
 
 jobs:
-  generate-artifacts:
+  detect-changes:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    outputs:
+      broader-rust: ${{ steps.filter.outputs.broader-rust }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Benchmarks don't exercise the explorer UI, so skip when the only
+          # changes are in crates/explorer or the submodule pointer.
+          filters: |
+            broader-rust:
+              - 'bin/katana/**'
+              - 'crates/**'
+              - '!crates/explorer/**'
+              - '.github/workflows/bench.yml'
+
+  generate-artifacts:
+    needs: [detect-changes]
+    runs-on: ubuntu-latest
+    if: |
+      needs.detect-changes.outputs.broader-rust == 'true' &&
+      (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     steps:
@@ -56,9 +78,11 @@ jobs:
           path: crates/contracts/build
 
   bench-codec:
-    needs: [generate-artifacts]
+    needs: [detect-changes, generate-artifacts]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    if: |
+      needs.detect-changes.outputs.broader-rust == 'true' &&
+      (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     container:
       image: ghcr.io/dojoengine/katana-dev:latest
     steps:
@@ -148,8 +172,11 @@ jobs:
   #         path: output.txt
 
   report:
-    needs: [bench-codec]
+    needs: [detect-changes, bench-codec]
     runs-on: ubuntu-latest
+    if: |
+      needs.detect-changes.outputs.broader-rust == 'true' &&
+      (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
             - "bin/**/Cargo.toml"
             - "crates/**/*.rs"
             - "crates/**/Cargo.toml"
+            - "crates/explorer/**"
+            - ".gitmodules"
+            - "Makefile"
             - ".github/workflows/test.yml"
 
     pull_request:
@@ -21,6 +24,9 @@ on:
             - "bin/**/Cargo.toml"
             - "crates/**/*.rs"
             - "crates/**/Cargo.toml"
+            - "crates/explorer/**"
+            - ".gitmodules"
+            - "Makefile"
             - ".github/workflows/test.yml"
 
 # Cancel in progress workflow when a new one is triggered by running in a concurrency group
@@ -33,7 +39,33 @@ env:
     CARGO_TERM_COLOR: always
 
 jobs:
+    detect-changes:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+        outputs:
+            broader-rust: ${{ steps.filter.outputs.broader-rust }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  # "broader-rust" = Rust / workspace changes outside crates/explorer.
+                  # When false, the PR only touches the Explorer UI submodule or the
+                  # katana-explorer crate, so the workspace-wide test matrix, Dojo /
+                  # VRF / Saya / DB integration tests are skipped — only the
+                  # explorer-scoped jobs run.
+                  filters: |
+                      broader-rust:
+                        - 'Cargo.toml'
+                        - 'bin/**/*.rs'
+                        - 'bin/**/Cargo.toml'
+                        - 'crates/**/*.rs'
+                        - 'crates/**/Cargo.toml'
+                        - '!crates/explorer/**'
+                        - '.github/workflows/test.yml'
+
     fmt:
+        needs: [detect-changes]
         runs-on: ubuntu-latest
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
         container:
@@ -91,7 +123,7 @@ jobs:
                       tests/fixtures/db/snos
 
     build-katana-binary:
-        needs: [fmt, clippy, generate-test-artifacts]
+        needs: [detect-changes, fmt, clippy, generate-test-artifacts]
         runs-on: ${{ matrix.runner }}
         timeout-minutes: ${{ matrix.os == 'macos' && 120 || 30 }}
         strategy:
@@ -103,7 +135,11 @@ jobs:
                     - os: macos
                       runner: macos-latest
                       container: null
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+        # Skip the macOS build on explorer-only changes — its only consumer is
+        # the macOS entry of the `test` matrix, which is also skipped.
+        if: |
+            (matrix.os != 'macos' || needs.detect-changes.outputs.broader-rust == 'true') &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
         container: ${{ matrix.container }}
         env:
             MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
@@ -226,7 +262,7 @@ jobs:
               run: ./scripts/clippy.sh
 
     test:
-        needs: [fmt, clippy, generate-test-artifacts, build-katana-binary]
+        needs: [detect-changes, fmt, clippy, generate-test-artifacts, build-katana-binary]
         runs-on: ${{ matrix.runner }}
         timeout-minutes: ${{ matrix.os == 'macos' && 60 || 30 }}
         strategy:
@@ -238,7 +274,9 @@ jobs:
                     - os: macos
                       runner: macos-latest
                       container: null
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+        if: |
+            needs.detect-changes.outputs.broader-rust == 'true' &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
         container: ${{ matrix.container }}
         env:
             MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
@@ -329,6 +367,44 @@ jobs:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: lcov.info
 
+    # Narrow test variant that runs when only the explorer crate or the UI
+    # submodule changes. Gives signal on katana-explorer unit tests without
+    # paying for the full workspace matrix + integration suite.
+    test-explorer:
+        needs: [detect-changes, fmt, clippy, generate-test-artifacts]
+        runs-on: ubuntu-latest-4-cores
+        if: |
+            needs.detect-changes.outputs.broader-rust == 'false' &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
+        container:
+            image: ghcr.io/dojoengine/katana-dev:latest
+        env:
+            MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+            LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+            TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
+            NEXTEST_PROFILE: ci
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  submodules: recursive
+            - run: git config --global --add safe.directory "*"
+
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  key: ci-${{ github.job }}
+                  shared-key: katana-ci-cache-ubuntu
+
+            - name: Download test artifacts
+              uses: actions/download-artifact@v5
+              with:
+                  name: fixtures
+
+            - name: Build Explorer UI
+              run: make build-explorer
+
+            - name: Run katana-explorer tests
+              run: cargo nextest run -p katana-explorer --all-features
+
     # TODO: re-enable once the snos crate is added back to the workspace
     # snos-integration-test:
     #   needs: [fmt, clippy]
@@ -400,9 +476,11 @@ jobs:
                   KATANA_BIN=./katana ./scripts/reverse-proxy-test.sh
 
     dojo-integration-test:
-        needs: [fmt, clippy, build-katana-binary]
+        needs: [detect-changes, fmt, clippy, build-katana-binary]
         runs-on: ubuntu-latest-32-cores
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+        if: |
+            needs.detect-changes.outputs.broader-rust == 'true' &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
         container:
             image: ghcr.io/dojoengine/katana-dev:latest
         steps:
@@ -467,10 +545,12 @@ jobs:
                   tail -n 50 katana.log
 
     vrf-e2e:
-        needs: [fmt, clippy, generate-test-artifacts]
+        needs: [detect-changes, fmt, clippy, generate-test-artifacts]
         runs-on: ubuntu-latest-32-cores
         timeout-minutes: 30
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+        if: |
+            needs.detect-changes.outputs.broader-rust == 'true' &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
         container:
             image: ghcr.io/dojoengine/katana-dev:latest
         env:
@@ -502,10 +582,12 @@ jobs:
               run: cargo run -p vrf-e2e-test
 
     saya-tee-e2e:
-        needs: [fmt, clippy, generate-test-artifacts]
+        needs: [detect-changes, fmt, clippy, generate-test-artifacts]
         runs-on: ubuntu-latest-32-cores
         timeout-minutes: 45
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+        if: |
+            needs.detect-changes.outputs.broader-rust == 'true' &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
         container:
             image: ghcr.io/dojoengine/katana-dev:latest
         env:
@@ -549,8 +631,11 @@ jobs:
               run: cargo run -p saya-tee-e2e-test
 
     db-compatibility-check:
-        needs: [fmt, clippy, build-katana-binary]
+        needs: [detect-changes, fmt, clippy, build-katana-binary]
         runs-on: ubuntu-latest-4-cores
+        if: |
+            needs.detect-changes.outputs.broader-rust == 'true' &&
+            (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
         container:
             image: ghcr.io/dojoengine/katana-dev:latest
         steps:


### PR DESCRIPTION
Classifies each CI run as **broader-rust** or **explorer-only** via a cheap `detect-changes` job (dorny/paths-filter), then gates the heavy jobs on that output. PRs that only bump the `crates/explorer/ui` submodule or touch the `katana-explorer` crate stop burning CPU-hours on Dojo / VRF / Saya / DB integration suites and codec benchmarks that can't possibly regress from a UI change.

## What runs, when

|  Job | Explorer-only | Broader-rust |
| --- | :---: | :---: |
| `detect-changes` (new) | ✅ | ✅ |
| `fmt` | ✅ | ✅ |
| `clippy` | ✅ | ✅ |
| `generate-test-artifacts` | ✅ | ✅ |
| `build-katana-binary` (ubuntu) | ✅ | ✅ |
| `build-katana-binary` (macos) | ❌ | ✅ |
| `test` (workspace matrix × 2 OS) | ❌ | ✅ |
| `test-explorer` (new, `cargo nextest -p katana-explorer`) | ✅ | ❌ |
| `explorer-reverse-proxy` | ✅ | ✅ |
| `dojo-integration-test` | ❌ | ✅ |
| `vrf-e2e` | ❌ | ✅ |
| `saya-tee-e2e` | ❌ | ✅ |
| `db-compatibility-check` | ❌ | ✅ |
| `bench-codec` + `report` (bench.yml) | ❌ | ✅ |

\"Explorer-only\" means every changed file lives in `crates/explorer/**`, `Makefile`, or `.gitmodules`. The moment any other workspace `.rs` / `Cargo.toml` / the `test.yml` workflow itself changes, the filter flips to `broader-rust` and the full gauntlet runs.

## Why each explorer-only job is still needed

- `fmt` / `clippy` — workspace-wide, catch regressions in the explorer crate that would otherwise bypass review
- `generate-test-artifacts` — provides `make fixtures` inputs consumed by both `build-katana-binary` and `test-explorer`
- `build-katana-binary` (ubuntu) — produces the binary that `explorer-reverse-proxy` downloads and runs
- `test-explorer` — covers the 4 `katana-explorer` unit tests (`get_content_type`, `is_static_asset_path`, `create_response`, `builder_pattern_method_chaining`)
- `explorer-reverse-proxy` — the actual E2E that navigates the embedded UI through both the direct URL and the Caddy proxy, asserting page-level DOM IDs

## Also in this PR

- Adds `crates/explorer/**`, `.gitmodules`, and `Makefile` to the `paths:` trigger filter on `test.yml`, so explorer-only PRs (e.g. submodule pointer bumps) actually trigger CI instead of silently skipping the workflow entirely.
