### PR TITLE
chore: make tee feature first class citizen

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,7 +23,7 @@ katana-db.workspace = true
 cartridge.workspace = true
 katana-paymaster.workspace = true
 katana-slot-controller.workspace = true
-katana-tee = { workspace = true, optional = true }
+katana-tee.workspace = true
 
 alloy-primitives.workspace = true
 anyhow.workspace = true
@@ -53,7 +53,7 @@ katana-gas-price-oracle.workspace = true
 starknet.workspace = true
 
 [features]
-default = [ "grpc", "server", "tee" ]
+default = [ "grpc", "server", "tee-snp" ]
 explorer = [
 	"katana-full-node/explorer",
 	"katana-sequencer-node/explorer",
@@ -62,9 +62,4 @@ explorer = [
 grpc = [ "katana-sequencer-node/grpc" ]
 native = [ "katana-sequencer-node/native" ]
 server = [  ]
-tee = [
-	"dep:katana-tee",
-	"katana-sequencer-node/tee",
-	"katana-sequencer-node/tee-snp",
-	"katana-tee/snp",
-]
+tee-snp = [ "katana-sequencer-node/tee-snp", "katana-tee/snp" ]

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -29,7 +29,6 @@ use katana_sequencer_node::config::rpc::RpcConfig;
 #[cfg(feature = "server")]
 use katana_sequencer_node::config::rpc::{RpcModuleKind, RpcModulesList};
 use katana_sequencer_node::config::sequencing::SequencingConfig;
-#[cfg(feature = "tee")]
 use katana_sequencer_node::config::tee::TeeConfig;
 use katana_sequencer_node::config::Config;
 use katana_sequencer_node::Node;
@@ -131,7 +130,6 @@ pub struct SequencerNodeArgs {
     #[command(flatten)]
     pub cartridge: CartridgeOptions,
 
-    #[cfg(feature = "tee")]
     #[command(flatten)]
     pub tee: TeeOptions,
 
@@ -384,7 +382,6 @@ impl SequencerNodeArgs {
             sequencing,
             build_info,
             paymaster,
-            #[cfg(feature = "tee")]
             tee: self.tee_config(),
         })
     }
@@ -436,7 +433,6 @@ impl SequencerNodeArgs {
             // The TEE rpc must be enabled if a TEE provider is specified.
             // We put it here so that even when the individual api are explicitly specified
             // (ie `--rpc.api`) we guarantee that the tee rpc is enabled.
-            #[cfg(feature = "tee")]
             if self.tee.tee_provider.is_some() {
                 modules.add(RpcModuleKind::Tee);
             }
@@ -723,7 +719,6 @@ impl SequencerNodeArgs {
         }
     }
 
-    #[cfg(feature = "tee")]
     fn tee_config(&self) -> Option<TeeConfig> {
         self.tee
             .tee_provider

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -1092,7 +1092,6 @@ fn parse_pruning_mode(s: &str) -> Result<PruningMode, String> {
     }
 }
 
-#[cfg(feature = "tee")]
 #[derive(Debug, Args, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[command(next_help_heading = "TEE options")]
 pub struct TeeOptions {
@@ -1106,7 +1105,6 @@ pub struct TeeOptions {
     pub tee_provider: Option<katana_tee::TeeProviderType>,
 }
 
-#[cfg(feature = "tee")]
 impl TeeOptions {
     pub fn merge(&mut self, other: Option<&Self>) {
         if let Some(other) = other {

--- a/crates/node/config/Cargo.toml
+++ b/crates/node/config/Cargo.toml
@@ -14,4 +14,3 @@ thiserror.workspace = true
 
 [features]
 explorer = [  ]
-tee = [  ]

--- a/crates/node/config/src/rpc.rs
+++ b/crates/node/config/src/rpc.rs
@@ -36,7 +36,6 @@ pub enum RpcModuleKind {
     TxPool,
     Node,
     Cartridge,
-    #[cfg(feature = "tee")]
     Tee,
 }
 
@@ -110,7 +109,6 @@ impl RpcModulesList {
             RpcModuleKind::TxPool,
             RpcModuleKind::Node,
             RpcModuleKind::Cartridge,
-            #[cfg(feature = "tee")]
             RpcModuleKind::Tee,
         ]))
     }

--- a/crates/node/sequencer/Cargo.toml
+++ b/crates/node/sequencer/Cargo.toml
@@ -26,7 +26,7 @@ katana-rpc-types.workspace = true
 katana-stage.workspace = true
 katana-starknet.workspace = true
 katana-tasks.workspace = true
-katana-tee = { workspace = true, optional = true }
+katana-tee.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true
@@ -42,16 +42,10 @@ url.workspace = true
 explorer = [ "katana-node-config/explorer", "katana-rpc-server/explorer" ]
 grpc = [ "dep:katana-grpc" ]
 native = [ "katana-executor/native" ]
-tee = [
-	"dep:katana-tee",
-	"katana-node-config/tee",
-	"katana-rpc-api/tee",
-	"katana-rpc-server/tee",
-]
-tee-snp = [ "katana-tee/snp", "tee" ]
+tee-snp = [ "katana-tee/snp" ]
 # Enables `TeeProviderType::Mock` (software-only attestation provider) for use
 # by integration test crates. Not intended for production binaries.
-tee-mock = [ "katana-tee/tee-mock", "tee" ]
+tee-mock = [ "katana-tee/tee-mock" ]
 
 [dev-dependencies]
 katana-contracts.workspace = true

--- a/crates/node/sequencer/src/config/mod.rs
+++ b/crates/node/sequencer/src/config/mod.rs
@@ -9,8 +9,6 @@ pub mod execution;
 pub mod fork;
 pub mod paymaster;
 pub mod sequencing;
-
-#[cfg(feature = "tee")]
 pub mod tee;
 
 #[cfg(feature = "grpc")]
@@ -72,7 +70,6 @@ pub struct Config {
     pub paymaster: Option<paymaster::PaymasterConfig>,
 
     /// TEE attestation options.
-    #[cfg(feature = "tee")]
     pub tee: Option<tee::TeeConfig>,
 
     /// gRPC options.

--- a/crates/node/sequencer/src/lib.rs
+++ b/crates/node/sequencer/src/lib.rs
@@ -44,7 +44,6 @@ use katana_rpc_api::paymaster::PaymasterApiServer;
 use katana_rpc_api::starknet::StarknetApiServer;
 #[cfg(feature = "explorer")]
 use katana_rpc_api::starknet_ext::StarknetApiExtServer;
-#[cfg(feature = "tee")]
 use katana_rpc_api::tee::TeeApiServer;
 use katana_rpc_server::cartridge::{CartridgeApi, CartridgeConfig};
 use katana_rpc_server::dev::DevApi;
@@ -55,7 +54,6 @@ use katana_rpc_server::middleware::metrics::RpcServerMetricsLayer;
 use katana_rpc_server::node::NodeApi;
 use katana_rpc_server::paymaster::PaymasterProxy;
 use katana_rpc_server::starknet::{RpcCache, StarknetApi, StarknetApiConfig};
-#[cfg(feature = "tee")]
 use katana_rpc_server::tee::TeeApi;
 use katana_rpc_server::{RpcServer, RpcServerHandle, RpcServiceBuilder};
 use katana_rpc_types::node::NodeInfo;
@@ -373,7 +371,6 @@ where
         };
 
         // --- build tee api (if configured)
-        #[cfg(feature = "tee")]
         if config.rpc.apis.contains(&RpcModuleKind::Tee) {
             if let Some(ref tee_config) = config.tee {
                 use katana_tee::{TeeProvider, TeeProviderType};
@@ -593,7 +590,6 @@ impl Node<ForkProviderFactory> {
         let genesis_block_num = block_num + 1;
 
         // Store fork block number in TEE config so report_data includes it
-        #[cfg(feature = "tee")]
         if let Some(ref mut tee_config) = config.tee {
             tee_config.fork_block_number = Some(block_num);
         }

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -25,4 +25,3 @@ rstest.workspace = true
 
 [features]
 client = [ "jsonrpsee/client" ]
-tee = [  ]

--- a/crates/rpc/rpc-api/src/error/mod.rs
+++ b/crates/rpc/rpc-api/src/error/mod.rs
@@ -2,6 +2,4 @@ pub mod cartridge;
 pub mod dev;
 pub mod katana;
 pub mod starknet;
-
-#[cfg(feature = "tee")]
 pub mod tee;

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -13,5 +13,4 @@ pub mod paymaster {
     pub use katana_paymaster::api::*;
 }
 
-#[cfg(feature = "tee")]
 pub mod tee;

--- a/crates/rpc/rpc-server/Cargo.toml
+++ b/crates/rpc/rpc-server/Cargo.toml
@@ -44,11 +44,11 @@ paymaster-rpc.workspace = true
 serde.workspace = true
 url.workspace = true
 
-hex = { workspace = true, optional = true }
-katana-tee = { workspace = true, optional = true }
-katana-trie = { workspace = true, optional = true }
+hex.workspace = true
+katana-tee.workspace = true
+katana-trie.workspace = true
 regex.workspace = true
-starknet-types-core = { workspace = true, optional = true }
+starknet-types-core.workspace = true
 
 [dev-dependencies]
 katana-chain-spec.workspace = true
@@ -92,12 +92,5 @@ url.workspace = true
 
 [features]
 explorer = [ "dep:katana-explorer" ]
-tee = [
-	"dep:hex",
-	"dep:katana-tee",
-	"dep:katana-trie",
-	"dep:starknet-types-core",
-	"katana-rpc-api/tee",
-]
 # Enables `MockProvider` for use by integration tests. Not for production binaries.
-tee-mock = [ "katana-tee/tee-mock", "tee" ]
+tee-mock = [ "katana-tee/tee-mock" ]

--- a/crates/rpc/rpc-server/src/lib.rs
+++ b/crates/rpc/rpc-server/src/lib.rs
@@ -17,9 +17,6 @@ use tower::{Layer, ServiceBuilder};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-#[cfg(feature = "tee")]
-pub mod tee;
-
 pub mod cartridge;
 pub mod dev;
 pub mod health;
@@ -28,6 +25,7 @@ pub mod node;
 pub mod paymaster;
 pub mod permit;
 pub mod starknet;
+pub mod tee;
 pub mod txpool;
 
 mod utils;

--- a/tests/saya-tee/Cargo.toml
+++ b/tests/saya-tee/Cargo.toml
@@ -15,7 +15,7 @@ katana-chain-spec.workspace = true
 katana-genesis.workspace = true
 katana-messaging.workspace = true
 katana-primitives.workspace = true
-katana-sequencer-node = { workspace = true, features = ["tee", "tee-mock"] }
+katana-sequencer-node = { workspace = true, features = ["tee-mock"] }
 katana-tee = { workspace = true, features = ["tee-mock"] }
 katana-utils = { workspace = true, features = ["node"] }
 


### PR DESCRIPTION
Removes the `tee` Cargo feature flag and makes TEE functionality always compiled in, mirroring #543 which did the same for `cartridge`. The `katana-tee` dependency is no longer optional in `cli`, `node/sequencer`, and `rpc/rpc-server`, and every `#[cfg(feature = "tee")]` gate across those crates and `node/config`, `rpc/rpc-api` are removed. Backend-selection flags `tee-snp` (SNP, default via cli) and `tee-mock` (tests only) are kept but no longer depend on the removed `tee` feature.