### PR TITLE
feat(bin): add `txpool`, `node`, `tee` subcommands to `katana rpc`

### DIFF
--- a/bin/katana/src/cli/rpc/client.rs
+++ b/bin/katana/src/cli/rpc/client.rs
@@ -3,7 +3,7 @@ use jsonrpsee::core::client::{ClientT, Error as ClientError};
 use jsonrpsee::core::traits::ToRpcParams;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
-use katana_primitives::block::{BlockIdOrTag, ConfirmedBlockIdOrTag};
+use katana_primitives::block::{BlockIdOrTag, BlockNumber, ConfirmedBlockIdOrTag};
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, StorageKey};
 use katana_primitives::transaction::TxHash;
@@ -225,5 +225,69 @@ impl Client {
             rpc_params!(block_id, class_hashes, contract_addresses, contracts_storage_keys),
         )
         .await
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TxPool JSON-RPC API
+////////////////////////////////////////////////////////////////////////////////
+
+const TXPOOL_STATUS: &str = "txpool_status";
+const TXPOOL_CONTENT: &str = "txpool_content";
+const TXPOOL_CONTENT_FROM: &str = "txpool_contentFrom";
+const TXPOOL_INSPECT: &str = "txpool_inspect";
+
+impl Client {
+    pub async fn txpool_status(&self) -> Result<Value> {
+        self.send_request(TXPOOL_STATUS, rpc_params!()).await
+    }
+
+    pub async fn txpool_content(&self) -> Result<Value> {
+        self.send_request(TXPOOL_CONTENT, rpc_params!()).await
+    }
+
+    pub async fn txpool_content_from(&self, address: ContractAddress) -> Result<Value> {
+        self.send_request(TXPOOL_CONTENT_FROM, rpc_params!(address)).await
+    }
+
+    pub async fn txpool_inspect(&self) -> Result<Value> {
+        self.send_request(TXPOOL_INSPECT, rpc_params!()).await
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Node JSON-RPC API
+////////////////////////////////////////////////////////////////////////////////
+
+const NODE_GET_INFO: &str = "node_getInfo";
+
+impl Client {
+    pub async fn node_get_info(&self) -> Result<Value> {
+        self.send_request(NODE_GET_INFO, rpc_params!()).await
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEE JSON-RPC API
+////////////////////////////////////////////////////////////////////////////////
+
+const TEE_GENERATE_QUOTE: &str = "tee_generateQuote";
+const TEE_GET_EVENT_PROOF: &str = "tee_getEventProof";
+
+impl Client {
+    pub async fn tee_generate_quote(
+        &self,
+        prev_block_id: Option<BlockNumber>,
+        block_id: BlockNumber,
+    ) -> Result<Value> {
+        self.send_request(TEE_GENERATE_QUOTE, rpc_params!(prev_block_id, block_id)).await
+    }
+
+    pub async fn tee_get_event_proof(
+        &self,
+        block_number: BlockNumber,
+        event_index: u32,
+    ) -> Result<Value> {
+        self.send_request(TEE_GET_EVENT_PROOF, rpc_params!(block_number, event_index)).await
     }
 }

--- a/bin/katana/src/cli/rpc/mod.rs
+++ b/bin/katana/src/cli/rpc/mod.rs
@@ -1,24 +1,57 @@
 use anyhow::{Context, Result};
-use clap::Args;
+use clap::{Args, Subcommand};
 use url::Url;
 
 mod client;
+mod node;
 mod starknet;
+mod tee;
+mod txpool;
 
 #[derive(Debug, Args)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct RpcArgs {
     #[command(subcommand)]
-    command: starknet::StarknetCommands,
+    command: Commands,
 
     #[command(flatten)]
     server: ServerOptions,
 }
 
+#[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+enum Commands {
+    /// Starknet JSON-RPC methods
+    Starknet {
+        #[command(subcommand)]
+        command: starknet::StarknetCommands,
+    },
+    /// Transaction pool JSON-RPC methods
+    Txpool {
+        #[command(subcommand)]
+        command: txpool::TxpoolCommands,
+    },
+    /// Node JSON-RPC methods
+    Node {
+        #[command(subcommand)]
+        command: node::NodeCommands,
+    },
+    /// TEE JSON-RPC methods
+    Tee {
+        #[command(subcommand)]
+        command: tee::TeeCommands,
+    },
+}
+
 impl RpcArgs {
     pub async fn execute(self) -> Result<()> {
         let client = self.client().context("Failed to create client")?;
-        self.command.execute(&client).await
+        match self.command {
+            Commands::Starknet { command } => command.execute(&client).await,
+            Commands::Txpool { command } => command.execute(&client).await,
+            Commands::Node { command } => command.execute(&client).await,
+            Commands::Tee { command } => command.execute(&client).await,
+        }
     }
 
     fn client(&self) -> Result<client::Client> {

--- a/bin/katana/src/cli/rpc/node.rs
+++ b/bin/katana/src/cli/rpc/node.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use super::client::Client;
+
+#[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub enum NodeCommands {
+    /// Get node identity and build information
+    Info,
+}
+
+impl NodeCommands {
+    pub async fn execute(self, client: &Client) -> Result<()> {
+        match self {
+            NodeCommands::Info => {
+                let result = client.node_get_info().await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bin/katana/src/cli/rpc/tee.rs
+++ b/bin/katana/src/cli/rpc/tee.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use katana_primitives::block::BlockNumber;
+
+use super::client::Client;
+
+#[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub enum TeeCommands {
+    /// Generate a TEE attestation quote for a block's state
+    #[command(name = "generate-quote")]
+    GenerateQuote(GenerateQuoteArgs),
+
+    /// Get the Merkle inclusion proof for an event
+    #[command(name = "event-proof")]
+    EventProof(EventProofArgs),
+}
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct GenerateQuoteArgs {
+    /// Block number to attest to
+    #[arg(long)]
+    block_id: BlockNumber,
+
+    /// Previous block number to chain the attestation against
+    #[arg(long)]
+    prev_block_id: Option<BlockNumber>,
+}
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct EventProofArgs {
+    /// Block number containing the event
+    #[arg(long)]
+    block_number: BlockNumber,
+
+    /// Index of the event within the block
+    #[arg(long)]
+    event_index: u32,
+}
+
+impl TeeCommands {
+    pub async fn execute(self, client: &Client) -> Result<()> {
+        match self {
+            TeeCommands::GenerateQuote(args) => {
+                let result =
+                    client.tee_generate_quote(args.prev_block_id, args.block_id).await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+
+            TeeCommands::EventProof(args) => {
+                let result =
+                    client.tee_get_event_proof(args.block_number, args.event_index).await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bin/katana/src/cli/rpc/tee.rs
+++ b/bin/katana/src/cli/rpc/tee.rs
@@ -44,8 +44,7 @@ impl TeeCommands {
     pub async fn execute(self, client: &Client) -> Result<()> {
         match self {
             TeeCommands::GenerateQuote(args) => {
-                let result =
-                    client.tee_generate_quote(args.prev_block_id, args.block_id).await?;
+                let result = client.tee_generate_quote(args.prev_block_id, args.block_id).await?;
                 println!("{}", colored_json::to_colored_json_auto(&result)?);
             }
 

--- a/bin/katana/src/cli/rpc/txpool.rs
+++ b/bin/katana/src/cli/rpc/txpool.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use katana_primitives::ContractAddress;
+
+use super::client::Client;
+
+#[derive(Debug, Subcommand)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub enum TxpoolCommands {
+    /// Get pending and queued transaction counts
+    Status,
+
+    /// Get all transactions in the pool, grouped by sender and nonce
+    Content,
+
+    /// Get pool contents filtered by sender address
+    #[command(name = "content-from")]
+    ContentFrom(AddressArgs),
+
+    /// Get a human-readable summary of the pool
+    Inspect,
+}
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct AddressArgs {
+    /// Sender address
+    #[arg(value_name = "ADDRESS")]
+    address: ContractAddress,
+}
+
+impl TxpoolCommands {
+    pub async fn execute(self, client: &Client) -> Result<()> {
+        match self {
+            TxpoolCommands::Status => {
+                let result = client.txpool_status().await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+
+            TxpoolCommands::Content => {
+                let result = client.txpool_content().await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+
+            TxpoolCommands::ContentFrom(args) => {
+                let result = client.txpool_content_from(args.address).await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+
+            TxpoolCommands::Inspect => {
+                let result = client.txpool_inspect().await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

The `katana rpc` CLI client only exposed Starknet methods, even though the node serves multiple JSON-RPC namespaces. This PR adds client-side subcommands for `txpool`, `node`, and `tee`, and reorganizes the existing Starknet methods under `katana rpc starknet <method>` so future namespaces can be added without flag collisions.

## Breaking change

Every existing `katana rpc <method>` invocation moves under `katana rpc starknet <method>` (e.g. `katana rpc spec` → `katana rpc starknet spec`).

## New commands

- `katana rpc txpool status|content|content-from <addr>|inspect`
- `katana rpc node info`
- `katana rpc tee generate-quote --block-id <n> [--prev-block-id <n>]`
- `katana rpc tee event-proof --block-number <n> --event-index <n>`

Write-path methods and the `katana`/`dev`/`cartridge`/`paymaster` namespaces are out of scope for this PR.
