### PR TITLE
test(rpc): test `tee_getEventProof` RPC method

### DIFF
--- a/crates/rpc/rpc-server/src/tee.rs
+++ b/crates/rpc/rpc-server/src/tee.rs
@@ -491,3 +491,421 @@ fn compute_report_data_appchain(
 
     report_data
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use katana_primitives::block::{
+        Block, BlockHash, BlockHashOrNumber, BlockNumber, FinalityStatus, Header,
+    };
+    use katana_primitives::contract::ContractAddress;
+    use katana_primitives::execution::{
+        CallEntryPointVariant, CallInfo, TransactionExecutionInfo, TypedTransactionExecutionInfo,
+    };
+    use katana_primitives::fee::FeeInfo;
+    use katana_primitives::receipt::{Event, InvokeTxReceipt, Receipt};
+    use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber, TxWithHash};
+    use katana_primitives::{address, Felt};
+    use katana_provider::api::block::{BlockHashProvider, BlockNumberProvider, BlockWriter};
+    use katana_provider::{
+        DbProviderFactory, MutableProvider, ProviderError, ProviderFactory, ProviderResult,
+    };
+    use katana_tee::TeeError;
+    use katana_trie::compute_merkle_root;
+    use rstest::rstest;
+    use starknet::macros::felt;
+    use starknet_types_core::hash::StarkHash;
+
+    use super::*;
+
+    // JSON-RPC error codes exposed by `TeeApiError`. Mirrored here because the
+    // constants in `katana_rpc_api::error::tee` are module-private.
+    const TEE_PROVIDER_ERROR_CODE: i32 = 102;
+    const TEE_EVENT_PROOF_ERROR_CODE: i32 = 103;
+
+    // --- Test doubles ---
+
+    /// TEE provider stub. `get_event_proof` never calls `generate_quote`.
+    #[derive(Debug)]
+    struct StubTeeProvider;
+
+    impl TeeProvider for StubTeeProvider {
+        fn generate_quote(&self, _: &[u8; 64]) -> Result<Vec<u8>, TeeError> {
+            unreachable!("get_event_proof does not call generate_quote")
+        }
+        fn provider_type(&self) -> &'static str {
+            "Stub"
+        }
+    }
+
+    /// Shared state behind the fake provider. Each slot is consumed on first
+    /// call; unused trait methods panic with `unimplemented!`.
+    #[derive(Debug, Default)]
+    struct FakeState {
+        header: Mutex<Option<ProviderResult<Option<Header>>>>,
+        receipts: Mutex<Option<ProviderResult<Option<Vec<Receipt>>>>>,
+        transactions: Mutex<Option<ProviderResult<Option<Vec<TxWithHash>>>>>,
+    }
+
+    /// Handle into `FakeState`. A newtype (not `Arc<FakeState>`) so we can
+    /// legally `impl MutableProvider` for it under Rust's orphan rules.
+    #[derive(Debug, Default, Clone)]
+    struct FakeProvider(Arc<FakeState>);
+
+    impl FakeProvider {
+        fn with_header(self, result: ProviderResult<Option<Header>>) -> Self {
+            *self.0.header.lock().unwrap() = Some(result);
+            self
+        }
+        fn with_receipts(self, result: ProviderResult<Option<Vec<Receipt>>>) -> Self {
+            *self.0.receipts.lock().unwrap() = Some(result);
+            self
+        }
+        fn with_transactions(self, result: ProviderResult<Option<Vec<TxWithHash>>>) -> Self {
+            *self.0.transactions.lock().unwrap() = Some(result);
+            self
+        }
+    }
+
+    impl HeaderProvider for FakeProvider {
+        fn header(&self, _: BlockHashOrNumber) -> ProviderResult<Option<Header>> {
+            self.0.header.lock().unwrap().take().expect("header not configured")
+        }
+    }
+
+    impl ReceiptProvider for FakeProvider {
+        fn receipt_by_hash(&self, _: TxHash) -> ProviderResult<Option<Receipt>> {
+            unimplemented!()
+        }
+        fn receipts_by_block(&self, _: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+            self.0.receipts.lock().unwrap().take().expect("receipts not configured")
+        }
+    }
+
+    impl TransactionProvider for FakeProvider {
+        fn transaction_by_hash(&self, _: TxHash) -> ProviderResult<Option<TxWithHash>> {
+            unimplemented!()
+        }
+        fn transactions_by_block(
+            &self,
+            _: BlockHashOrNumber,
+        ) -> ProviderResult<Option<Vec<TxWithHash>>> {
+            self.0.transactions.lock().unwrap().take().expect("transactions not configured")
+        }
+        fn transaction_by_block_and_idx(
+            &self,
+            _: BlockHashOrNumber,
+            _: u64,
+        ) -> ProviderResult<Option<TxWithHash>> {
+            unimplemented!()
+        }
+        fn transaction_count_by_block(&self, _: BlockHashOrNumber) -> ProviderResult<Option<u64>> {
+            unimplemented!()
+        }
+        fn transaction_block_num_and_hash(
+            &self,
+            _: TxHash,
+        ) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
+            unimplemented!()
+        }
+        fn transaction_in_range(
+            &self,
+            _: std::ops::Range<TxNumber>,
+        ) -> ProviderResult<Vec<TxWithHash>> {
+            unimplemented!()
+        }
+    }
+
+    impl BlockHashProvider for FakeProvider {
+        fn latest_hash(&self) -> ProviderResult<BlockHash> {
+            unimplemented!()
+        }
+        fn block_hash_by_num(&self, _: BlockNumber) -> ProviderResult<Option<BlockHash>> {
+            unimplemented!()
+        }
+    }
+
+    impl BlockNumberProvider for FakeProvider {
+        fn latest_number(&self) -> ProviderResult<BlockNumber> {
+            unimplemented!()
+        }
+        fn block_number_by_hash(&self, _: BlockHash) -> ProviderResult<Option<BlockNumber>> {
+            unimplemented!()
+        }
+    }
+
+    impl MutableProvider for FakeProvider {
+        fn commit(self) -> ProviderResult<()> {
+            unreachable!("FakeProvider commit is not used by get_event_proof")
+        }
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct FakeFactory(FakeProvider);
+
+    impl FakeFactory {
+        fn new(provider: FakeProvider) -> Self {
+            Self(provider)
+        }
+    }
+
+    impl ProviderFactory for FakeFactory {
+        type Provider = FakeProvider;
+        type ProviderMut = FakeProvider;
+
+        fn provider(&self) -> Self::Provider {
+            self.0.clone()
+        }
+        fn provider_mut(&self) -> Self::ProviderMut {
+            self.0.clone()
+        }
+    }
+
+    // --- Helpers ---
+
+    fn build_api<PF>(factory: PF) -> TeeApi<PF>
+    where
+        PF: ProviderFactory,
+    {
+        TeeApi::new(factory, Arc::new(StubTeeProvider), None)
+    }
+
+    fn make_tx(hash: Felt) -> TxWithHash {
+        TxWithHash { hash, transaction: Tx::Invoke(InvokeTx::V1(Default::default())) }
+    }
+
+    fn make_event(from: ContractAddress, keys: Vec<Felt>, data: Vec<Felt>) -> Event {
+        Event { from_address: from, keys, data }
+    }
+
+    fn make_invoke_receipt(events: Vec<Event>) -> Receipt {
+        Receipt::Invoke(InvokeTxReceipt {
+            fee: FeeInfo::default(),
+            events,
+            messages_sent: Vec::new(),
+            revert_error: None,
+            execution_resources: Default::default(),
+        })
+    }
+
+    /// Recomputes `events_commitment` the same way tee.rs:320-333 does.
+    fn compute_events_commitment(txs: &[TxWithHash], receipts: &[Receipt]) -> Felt {
+        let mut event_hashes = Vec::new();
+        for (tx, receipt) in txs.iter().zip(receipts.iter()) {
+            for event in receipt.events() {
+                let keys_hash = Poseidon::hash_array(&event.keys);
+                let data_hash = Poseidon::hash_array(&event.data);
+                event_hashes.push(Poseidon::hash_array(&[
+                    tx.hash,
+                    event.from_address.into(),
+                    keys_hash,
+                    data_hash,
+                ]));
+            }
+        }
+        compute_merkle_root::<Poseidon>(&event_hashes).unwrap()
+    }
+
+    /// Dummy executions sized to match `txs` — `insert_block_with_states_and_receipts`
+    /// expects one entry per transaction.
+    fn dummy_executions(count: usize) -> Vec<TypedTransactionExecutionInfo> {
+        (0..count)
+            .map(|_| {
+                TypedTransactionExecutionInfo::Invoke(TransactionExecutionInfo {
+                    revert_error: None,
+                    execute_call_info: Some(CallInfo {
+                        call: CallEntryPointVariant {
+                            class_hash: Some(Default::default()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+            })
+            .collect()
+    }
+
+    /// Seeds a fresh in-memory provider with a single block whose header carries
+    /// the correct `events_commitment` for the supplied txs + receipts.
+    fn seed_block(
+        block_number: BlockNumber,
+        txs: Vec<TxWithHash>,
+        receipts: Vec<Receipt>,
+    ) -> DbProviderFactory {
+        let factory = DbProviderFactory::new_in_memory();
+        let events_commitment = compute_events_commitment(&txs, &receipts);
+
+        let header = Header { number: block_number, events_commitment, ..Default::default() };
+        let executions = dummy_executions(txs.len());
+        let sealed = Block { header, body: txs }
+            .seal_with_hash_and_status(Felt::from(block_number + 1), FinalityStatus::AcceptedOnL2);
+
+        let provider_mut = factory.provider_mut();
+        provider_mut
+            .insert_block_with_states_and_receipts(sealed, Default::default(), receipts, executions)
+            .unwrap();
+        provider_mut.commit().unwrap();
+        factory
+    }
+
+    // --- Error-path tests (one per early-return branch) ---
+
+    #[tokio::test]
+    async fn header_provider_error_maps_to_provider_error() {
+        let factory = FakeFactory::new(
+            FakeProvider::default().with_header(Err(ProviderError::Other("boom".into()))),
+        );
+        let err = build_api(factory).get_event_proof(0, 0).await.unwrap_err();
+        assert_eq!(err.code(), TEE_PROVIDER_ERROR_CODE);
+        assert!(err.message().contains("boom"), "message was: {}", err.message());
+    }
+
+    #[tokio::test]
+    async fn missing_header_maps_to_event_proof_error() {
+        let factory = FakeFactory::new(FakeProvider::default().with_header(Ok(None)));
+        let err = build_api(factory).get_event_proof(42, 0).await.unwrap_err();
+        assert_eq!(err.code(), TEE_EVENT_PROOF_ERROR_CODE);
+        assert!(err.message().contains("Block 42 not found"), "message was: {}", err.message());
+    }
+
+    #[tokio::test]
+    async fn receipts_provider_error_maps_to_provider_error() {
+        let factory = FakeFactory::new(
+            FakeProvider::default()
+                .with_header(Ok(Some(Header::default())))
+                .with_receipts(Err(ProviderError::Other("receipt boom".into()))),
+        );
+        let err = build_api(factory).get_event_proof(0, 0).await.unwrap_err();
+        assert_eq!(err.code(), TEE_PROVIDER_ERROR_CODE);
+        assert!(err.message().contains("receipt boom"), "message was: {}", err.message());
+    }
+
+    #[tokio::test]
+    async fn missing_receipts_maps_to_event_proof_error() {
+        let factory = FakeFactory::new(
+            FakeProvider::default()
+                .with_header(Ok(Some(Header::default())))
+                .with_receipts(Ok(None)),
+        );
+        let err = build_api(factory).get_event_proof(7, 0).await.unwrap_err();
+        assert_eq!(err.code(), TEE_EVENT_PROOF_ERROR_CODE);
+        assert!(
+            err.message().contains("No receipts found for block 7"),
+            "message was: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn transactions_provider_error_maps_to_provider_error() {
+        let factory = FakeFactory::new(
+            FakeProvider::default()
+                .with_header(Ok(Some(Header::default())))
+                .with_receipts(Ok(Some(Vec::new())))
+                .with_transactions(Err(ProviderError::Other("tx boom".into()))),
+        );
+        let err = build_api(factory).get_event_proof(0, 0).await.unwrap_err();
+        assert_eq!(err.code(), TEE_PROVIDER_ERROR_CODE);
+        assert!(err.message().contains("tx boom"), "message was: {}", err.message());
+    }
+
+    #[tokio::test]
+    async fn missing_transactions_maps_to_event_proof_error() {
+        let factory = FakeFactory::new(
+            FakeProvider::default()
+                .with_header(Ok(Some(Header::default())))
+                .with_receipts(Ok(Some(Vec::new())))
+                .with_transactions(Ok(None)),
+        );
+        let err = build_api(factory).get_event_proof(9, 0).await.unwrap_err();
+        assert_eq!(err.code(), TEE_EVENT_PROOF_ERROR_CODE);
+        assert!(
+            err.message().contains("No transactions found for block 9"),
+            "message was: {}",
+            err.message()
+        );
+    }
+
+    /// Covers the bounds check for both an empty-events block (any index) and
+    /// a non-empty block asked for an index past the last event.
+    #[rstest]
+    #[case::empty_block(vec![], vec![], 0)]
+    #[case::past_last(
+        vec![make_tx(felt!("0xaa"))],
+        vec![make_invoke_receipt(vec![make_event(address!("0x1"), vec![felt!("0x1")], vec![])])],
+        5,
+    )]
+    #[tokio::test]
+    async fn event_index_out_of_bounds(
+        #[case] txs: Vec<TxWithHash>,
+        #[case] receipts: Vec<Receipt>,
+        #[case] event_index: u32,
+    ) {
+        let factory = seed_block(0, txs, receipts);
+        let err = build_api(factory).get_event_proof(0, event_index).await.unwrap_err();
+        assert_eq!(err.code(), TEE_EVENT_PROOF_ERROR_CODE);
+        assert!(err.message().contains("out of bounds"), "message was: {}", err.message());
+    }
+
+    // --- Success path ---
+
+    /// Round-trip proof for an interior event that sits on a receipt boundary:
+    /// receipt[1] has no events, so the picked index (2) maps to receipt[2]'s
+    /// first event, exercising the zip/flatten ordering. Also includes an event
+    /// with empty keys/data to exercise `Poseidon::hash_array(&[])`.
+    #[tokio::test]
+    async fn get_event_proof_round_trip() {
+        let tx0 = make_tx(felt!("0xaaaa"));
+        let tx1 = make_tx(felt!("0xbbbb"));
+        let tx2 = make_tx(felt!("0xcccc"));
+
+        let addr_a = address!("0x111");
+        let addr_b = address!("0x222");
+
+        let receipt0 = make_invoke_receipt(vec![
+            // Event with empty keys + empty data.
+            make_event(addr_a, vec![], vec![]),
+            make_event(addr_a, vec![felt!("0x1")], vec![felt!("0xdead")]),
+        ]);
+        let receipt1 = make_invoke_receipt(vec![]);
+        let receipt2 = make_invoke_receipt(vec![
+            // Event we'll pick (index 2 overall).
+            make_event(addr_b, vec![felt!("0x42")], vec![felt!("0xbeef"), felt!("0xcafe")]),
+            make_event(addr_b, vec![felt!("0x43")], vec![felt!("0xf00d")]),
+        ]);
+
+        let txs = vec![tx0.clone(), tx1, tx2.clone()];
+        let receipts = vec![receipt0, receipt1, receipt2];
+        let expected_commitment = compute_events_commitment(&txs, &receipts);
+        let factory = seed_block(3, txs, receipts.clone());
+
+        let response = build_api(factory).get_event_proof(3, 2).await.unwrap();
+
+        assert_eq!(response.block_number, 3);
+        assert_eq!(response.event_index, 2);
+        assert_eq!(response.events_count, 4);
+        assert_eq!(response.events_commitment, expected_commitment);
+        assert_eq!(response.tx_hash, tx2.hash);
+
+        // Picked event fields match receipts[2].events[0].
+        let picked = &receipts[2].events()[0];
+        assert_eq!(response.from_address, picked.from_address.into());
+        assert_eq!(response.keys, picked.keys);
+        assert_eq!(response.data, picked.data);
+
+        // Recomputing the event hash externally must match what the method returned.
+        let expected_event_hash = Poseidon::hash_array(&[
+            tx2.hash,
+            picked.from_address.into(),
+            Poseidon::hash_array(&picked.keys),
+            Poseidon::hash_array(&picked.data),
+        ]);
+        assert_eq!(response.event_hash, expected_event_hash);
+
+        // Proof must be non-trivial; the method's internal invariant check
+        // (computed_root == header.events_commitment) guarantees it verifies.
+        assert!(!response.merkle_proof.0.is_empty(), "merkle proof should be non-empty");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `#[cfg(test)]` module to `crates/rpc/rpc-server/src/tee.rs` covering every distinct execution path of `get_event_proof`. Six error-path tests use a hand-rolled `FakeProvider` to exercise each early-return branch (provider `Err` and missing `Option` for header/receipts/transactions); one parameterized test covers the bounds check (empty-events block and oversized index); one success test uses `DbProviderFactory::new_in_memory()` with a block that crosses a receipt boundary and includes an event with empty keys/data, asserting all response fields plus an externally recomputed event hash.

Paths for a trie error or events-root mismatch are intentionally skipped — both only fire on bugs inside `katana_trie`, and the success test's round-trip covers the healthy case.

## Test plan

- [x] `cargo nextest run -p katana-rpc-server tee::` — 9 tests pass
- [x] `cargo +nightly-2025-02-20 fmt --all`