### PR TITLE
refactor(cli): split init prompt into proof mode + variant

### DIFF
--- a/bin/katana/src/cli/init/prompt.rs
+++ b/bin/katana/src/cli/init/prompt.rs
@@ -59,30 +59,55 @@ pub async fn prompt_rollup() -> Result<PersistentOutcome> {
     // Ask about the proof mode before provider construction so the custom-chain
     // flow can use the TEE registry address as the provider's fact registry
     // (skipping the separate "Facts Registry" prompt).
-    #[derive(Debug, Clone, strum_macros::Display)]
+    #[derive(Debug, Clone, Copy, strum_macros::Display)]
     enum ProofMode {
-        #[strum(serialize = "STARK (Atlantic)")]
-        Stark,
-        #[strum(serialize = "TEE (AMD SEV-SNP + SP1 Groth16)")]
+        #[strum(serialize = "Validity Proof")]
+        ValidityProof,
+        #[strum(serialize = "TEE")]
         Tee,
     }
 
-    let proof_mode = Select::new("Proof mode", vec![ProofMode::Stark, ProofMode::Tee])
+    #[derive(Debug, Clone, Copy, strum_macros::Display)]
+    enum ValidityProofVariant {
+        #[strum(serialize = "STARK (Atlantic)")]
+        Stark,
+    }
+
+    #[derive(Debug, Clone, Copy, strum_macros::Display)]
+    enum TeeVariant {
+        #[strum(serialize = "AMD SEV-SNP + SP1 Groth16")]
+        AmdSevSnpSp1Groth16,
+    }
+
+    let proof_mode = Select::new("Proof mode", vec![ProofMode::ValidityProof, ProofMode::Tee])
         .with_help_message(
-            "STARK settles via Herodotus Atlantic; TEE points Piltover's fact-registry at an \
-             IAMDTeeRegistry contract.",
+            "Validity proofs settle via a fact registry (e.g. Herodotus Atlantic); TEE points \
+             Piltover's fact-registry at an attestation registry contract.",
         )
         .prompt()?;
 
-    let tee_registry_address: Option<ContractAddress> = match proof_mode {
-        ProofMode::Stark => None,
-        ProofMode::Tee => Some(
+    let use_tee = match proof_mode {
+        ProofMode::ValidityProof => {
+            let _ =
+                Select::new("Validity proof type", vec![ValidityProofVariant::Stark]).prompt()?;
+            false
+        }
+        ProofMode::Tee => {
+            let _ = Select::new("TEE type", vec![TeeVariant::AmdSevSnpSp1Groth16]).prompt()?;
+            true
+        }
+    };
+
+    let tee_registry_address: Option<ContractAddress> = if use_tee {
+        Some(
             CustomType::<ContractAddress>::new("TEE registry address")
                 .with_help_message(
                     "Address of the IAMDTeeRegistry contract on the settlement chain.",
                 )
                 .prompt()?,
-        ),
+        )
+    } else {
+        None
     };
 
     let settlement_provider = match network_type {


### PR DESCRIPTION
## Summary

Update the `katana init rollup` interactive flow to ask about the proof mode category (Validity Proof / TEE) **before** the specific provider variant (STARK (Atlantic) / AMD SEV-SNP + SP1 Groth16).

Each category currently has one variant. The two-step prompt makes the categorization explicit and gives the structure a clean place to accept new variants instead of growing a flat list.

## Behavior

- Downstream is **byte-identical** to before.
- `use_tee` is produced exactly as the old `matches!(proof_mode, ProofMode::Tee)`.
- The conditional `TEE registry address` prompt, settlement provider selection, and fact-registry resolution are unchanged.
- The CLI flag path (`--tee <PROVIDER>` / `configure_from_args()`) is **untouched** — non-interactive shipping continues to work the same way.

### New prompt sequence

```
> Id <id>
> Settlement chain: Mainnet | Sepolia | Custom
> Proof mode: Validity Proof | TEE
> Validity proof type: STARK (Atlantic)        # if Validity Proof
  └── (no further proof prompt)
> TEE type: AMD SEV-SNP + SP1 Groth16          # if TEE
  └── TEE registry address: <address>
... (settlement account, contract, etc., unchanged)
```

## Test Coverage

| | |
|---|---|
| Build | `cargo build -p katana` ✓ |
| Lint  | `cargo clippy -p katana --bin katana --no-deps` ✓ |
| Format | `cargo +nightly-2025-02-20 fmt --all` ✓ |
| Tests | `cargo nextest run -p katana` — 60 passed, 0 failed ✓ |

The diff touches only `prompt_rollup()`, an interactive function using `inquire::Select`. The repo has no mock infrastructure for `inquire`, and the change introduces zero new logic paths beyond what existed before — `use_tee` and `tee_registry_address` are produced exactly as before. Coverage gate: PASS (no new branches).

## Pre-Landing Review

No issues found. SQL/auth/data-safety not applicable (local CLI). `Select::prompt()?` propagates Ctrl-C correctly. Help text on the proof-mode prompt was generalized ("Validity proofs settle via a fact registry (e.g. Herodotus Atlantic)") but the IAMDTeeRegistry-specific phrasing is preserved on the registry-address prompt where it matters.

## Manual Verification (for reviewer)

These require a Sepolia/Mainnet RPC and human input — not run as part of /ship.

- [ ] **Validity proof path:** `cargo run --bin katana -- init rollup` → choose Sepolia → **Validity Proof** → **STARK (Atlantic)** → no TEE registry prompt → flow completes against Atlantic.
- [ ] **TEE path:** same command, choose **TEE** → **AMD SEV-SNP + SP1 Groth16** → existing `TEE registry address` prompt fires → Piltover fact-registry pointed at the TEE registry.
- [ ] **Custom settlement chain** (`--features init-custom-settlement-chain`): TEE path skips the `Facts Registry` prompt, validity proof asks for it.
- [ ] **CLI-flag path unaffected:** `katana init rollup --id myrollup --tee piltover --tee-registry-address 0x... ...` (non-interactive) behaves identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)