### PR TITLE
ci(docker): pre-install scarb 2.13.1 in the dev image

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -117,10 +117,12 @@ ENV PATH="$ASDF_DATA_DIR/shims:$PATH"
 # - 2.8.2: main contracts
 # - 2.11.4: AVNU contracts
 # - 2.12.2: VRF contracts
+# - 2.13.1: Piltover submodule (cartridge-gg/piltover#feat/tee-persistent)
 RUN asdf plugin add scarb && \
 	asdf install scarb 2.8.2 && \
 	asdf install scarb 2.11.4 && \
 	asdf install scarb 2.12.2 && \
+	asdf install scarb 2.13.1 && \
 	asdf set scarb 2.8.2
 
 # Install sozo via asdf


### PR DESCRIPTION
## Summary

Pre-installs `scarb 2.13.1` in `ghcr.io/dojoengine/katana-dev:latest` so the Piltover submodule build doesn't fall into a runtime install that OOMs the container's overlay disk.

## Why

The Piltover submodule (`cartridge-gg/piltover#feat/tee-persistent`) pins `scarb 2.13.1` in its `.tool-versions`. The dev image only bakes in `2.8.2 / 2.11.4 / 2.12.2`, so `make install-scarb` falls into the runtime install path for `2.13.1`. The asdf-scarb plugin lies — every file copy fails with \"No space left on device\" but the script still prints \"installation was successful!\". Then when `cd piltover && asdf exec scarb build` runs, asdf can't find a real `scarb` binary, prints `No version is set for command scarb`, and `make contracts` fails.

Repro from PR #556's most recent CI run:

```
Installing scarb 2.13.1...
* Downloading scarb release 2.13.1...
cp: error copying ... 'scarb-verify' ... No space left on device
cp: error copying ... 'scarb' ... No space left on device
cp: error copying ... 'SECURITY.md' ... No space left on device
scarb 2.13.1 installation was successful!   ← lying
[later, from the piltover build dir]
No version is set for command scarb
Consider adding one of the following versions ... scarb 2.8.2 / 2.12.2 / 2.11.4
make: *** [Makefile:132: contracts] Error 1
```

The Makefile already calls this out (lines 51-52):
> Keeping the build path on 2.12.2 avoids installing an extra 2.13.1 toolchain in CI, which was exhausting disk space.

## Fix

Add \`asdf install scarb 2.13.1\` to the existing \`RUN asdf plugin add scarb && ...\` block in \`.github/Dockerfile\`. Image grows by ~150-300MB; CI runtime install path for 2.13.1 becomes a cache hit (no disk pressure).

## Trigger

This push touches \`.github/Dockerfile\`, so on merge \`.github/workflows/build-and-push-docker.yml\` rebuilds and re-tags \`ghcr.io/dojoengine/katana-dev:latest\`. PR #556 (the trigger for this fix) and any other branch that pulls in piltover submodule's new pin will go green once the new image is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)