### PR TITLE
chore(deps): bump blockifier and starknet_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra",
@@ -761,7 +761,7 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "starknet_api",
  "tempfile",
  "thiserror 1.0.69",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_config",
  "serde",
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra_utils"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "indexmap 2.10.0",
  "metrics",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "apollo_proc_macros"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -1882,7 +1882,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -1900,7 +1900,7 @@ dependencies = [
  "pretty_assertions",
  "rstest 0.17.0",
  "serde_json",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
@@ -1937,7 +1937,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
 ]
 
@@ -2484,7 +2484,7 @@ dependencies = [
  "rand 0.9.2",
  "sha2",
  "smol_str",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
 ]
 
@@ -2538,7 +2538,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
 ]
 
@@ -2615,7 +2615,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
 ]
 
@@ -2656,7 +2656,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
  "typetag",
 ]
@@ -2680,7 +2680,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
 ]
 
@@ -2737,7 +2737,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "serde",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
 ]
 
 [[package]]
@@ -2816,7 +2816,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "starknet-curve 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "stats_alloc",
  "tempfile",
  "thiserror 2.0.12",
@@ -2853,7 +2853,7 @@ dependencies = [
  "sha2",
  "sha3",
  "starknet-crypto 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 2.0.12",
  "zip 0.6.6",
 ]
@@ -6271,7 +6271,7 @@ dependencies = [
  "quote",
  "serde_json",
  "starknet-crypto 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "syn 2.0.104",
 ]
 
@@ -6304,7 +6304,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rstest 0.18.2",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6659,7 +6659,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6776,7 +6776,7 @@ dependencies = [
  "serde_json_pythonic",
  "similar-asserts",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
@@ -6790,7 +6790,7 @@ dependencies = [
  "alloy-primitives",
  "proc-macro2",
  "quote",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "syn 2.0.104",
 ]
 
@@ -6823,7 +6823,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6841,7 +6841,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-trie",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 1.0.69",
 ]
 
@@ -6922,7 +6922,7 @@ dependencies = [
  "stark-vrf",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet 0.17.0 (git+https://github.com/xJonathanLEI/starknet-rs?tag=starknet%2Fv0.17.0)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -7068,7 +7068,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde_json",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -7161,7 +7161,7 @@ dependencies = [
  "serde",
  "slab",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "thiserror 1.0.69",
 ]
 
@@ -7271,11 +7271,11 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
+checksum = "fce8f59622ed408c318c9b5eca17f1a1154159e3738b5c4d5a22a0dd3700c906"
 dependencies = [
- "lambdaworks-math 0.13.0",
+ "lambdaworks-math 0.12.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -7295,13 +7295,11 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018a95aa873eb49896a858dee0d925c33f3978d073c64b08dd4f2c9b35a017c6"
+checksum = "405d65a26831650ba348a503a2881ed7a0483ef3ec17f66e0fc8e2f9c97fc7ca"
 dependencies = [
  "getrandom 0.2.16",
- "num-bigint",
- "num-traits",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -10246,7 +10244,7 @@ dependencies = [
  "katana-utils",
  "serde_json",
  "starknet 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "tempfile",
  "tokio",
  "tracing-subscriber",
@@ -10836,20 +10834,6 @@ name = "size-of"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e36eca171fddeda53901b0a436573b3f2391eaa9189d439b2bd8ea8cebd7e3"
-dependencies = [
- "size-of-derive",
-]
-
-[[package]]
-name = "size-of-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefff4890f5308d477f3da563af8bdb8fbb6fabaec4c974bd211896fa7945e68"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "sketches-ddsketch"
@@ -11125,7 +11109,7 @@ dependencies = [
  "sha3",
  "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-crypto 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
 ]
 
 [[package]]
@@ -11147,7 +11131,7 @@ dependencies = [
  "sha3",
  "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?tag=starknet%2Fv0.17.0)",
  "starknet-crypto 0.8.1 (git+https://github.com/xJonathanLEI/starknet-rs?tag=starknet%2Fv0.17.0)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
 ]
 
 [[package]]
@@ -11206,7 +11190,7 @@ dependencies = [
  "rfc6979",
  "sha2",
  "starknet-curve 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "zeroize",
 ]
 
@@ -11224,7 +11208,7 @@ dependencies = [
  "rfc6979",
  "sha2",
  "starknet-curve 0.6.0 (git+https://github.com/xJonathanLEI/starknet-rs?tag=starknet%2Fv0.17.0)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "zeroize",
 ]
 
@@ -11254,7 +11238,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
 dependencies = [
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
 ]
 
 [[package]]
@@ -11262,7 +11246,7 @@ name = "starknet-curve"
 version = "0.6.0"
 source = "git+https://github.com/xJonathanLEI/starknet-rs?tag=starknet%2Fv0.17.0#85906137d634c86b07de20fa33071e5cf186ce21"
 dependencies = [
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
 ]
 
 [[package]]
@@ -11389,15 +11373,15 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab92594a86ac627dd4c8d3350362cc8035e55c548c27c71dfa4c9fc6b3b6ab1a"
+checksum = "92eb6db1a763c350ffa50ed65ea3a92de9888239357cfbcb633e29a4da77f122"
 dependencies = [
  "arbitrary",
  "blake2",
  "digest 0.10.7",
- "lambdaworks-crypto 0.13.0",
- "lambdaworks-math 0.13.0",
+ "lambdaworks-crypto 0.12.0",
+ "lambdaworks-math 0.12.0",
  "lazy_static",
  "num-bigint",
  "num-integer",
@@ -11405,14 +11389,13 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.9.2",
  "serde",
- "size-of",
  "zeroize",
 ]
 
 [[package]]
 name = "starknet_api"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=1abd558#1abd558585d79810f78a0f510c4adbcb3aca3f6f"
 dependencies = [
  "apollo_infra_utils",
  "base64 0.13.1",
@@ -11435,9 +11418,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "size-of",
  "starknet-crypto 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.2.3",
+ "starknet-types-core 0.2.2",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,14 +246,14 @@ opentelemetry-stackdriver = { version = "0.27.0", features = [ "propagator" ] }
 stark-vrf = { git = "https://github.com/dojoengine/stark-vrf.git", rev = "96d6d2a" }
 starknet = "0.17.0"
 starknet-crypto = "0.8.1"
-starknet-types-core = { version = "=0.2.3", features = [ "arbitrary", "hash" ] }
+starknet-types-core = { version = "=0.2.2", features = [ "arbitrary", "hash" ] }
 # Some types that we used from cairo-vm implements the `Arbitrary` trait,
 # only under the `test_utils` feature.
 cairo-vm = { version = "2.5.0", features = [ "test_utils" ] }
 
 # branch: blockifier/v0.16.0-rc.0
-blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb", default-features = false }
-starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb" }
+blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "1abd558", default-features = false }
+starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "1abd558" }
 
 cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1", features = [ "abigen-rs" ] }
 cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1" }


### PR DESCRIPTION
## Summary
- Bumps the `blockifier` and `starknet_api` git rev from `d2591bb` → `1abd558` on the `blockifier/v0.16.0-rc.0` branch of `dojoengine/sequencer`. This pulls in the `feat: remove SizeOf` commit, dropping the orphaned `size-of` crate dependency from `starknet_api`.
- Aligns the workspace pin of `starknet-types-core` to `=0.2.2` to match the sequencer-side constraint introduced in the same commit.
