### PR TITLE
ci: skip workflows on docs and README-only changes

### DIFF
--- a/.github/workflows/amdsev-initrd-test.yml
+++ b/.github/workflows/amdsev-initrd-test.yml
@@ -8,6 +8,7 @@ on:
             - "misc/AMDSEV/**"
             - "scripts/build-musl.sh"
             - ".github/workflows/amdsev-initrd-test.yml"
+            - "!**/README.md"
 
     pull_request:
         types: [opened, synchronize, ready_for_review]
@@ -15,6 +16,7 @@ on:
             - "misc/AMDSEV/**"
             - "scripts/build-musl.sh"
             - ".github/workflows/amdsev-initrd-test.yml"
+            - "!**/README.md"
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "bin/katana/**"
       - "crates/**"
+      - "!**/README.md"
 
   pull_request:
     types: [opened, synchronize, ready_for_review]
@@ -13,6 +14,7 @@ on:
       - "bin/katana/**"
       - "crates/**"
       - ".github/workflows/bench.yml"
+      - "!**/README.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "docs/**"
+      - "**/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
             - ".gitmodules"
             - "Makefile"
             - ".github/workflows/test.yml"
+            - "!**/README.md"
 
     pull_request:
         types: [opened, synchronize, ready_for_review]
@@ -28,6 +29,7 @@ on:
             - ".gitmodules"
             - "Makefile"
             - ".github/workflows/test.yml"
+            - "!**/README.md"
 
 # Cancel in progress workflow when a new one is triggered by running in a concurrency group
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs


### PR DESCRIPTION
## Summary

- Adds `!**/README.md` negation to `test.yml`, `bench.yml`, and `amdsev-initrd-test.yml` `paths` allow-lists, which were broad enough (`crates/**`, `crates/explorer/**`, `misc/AMDSEV/**`) to match crate READMEs.
- Adds `paths-ignore: [docs/**, **/README.md]` to `claude-code-review.yml`, the only workflow with no path filter.
- Applies to both `push` and `pull_request` triggers, so docs/README-only commits skip CI on every branch where push fires (currently `main` / `release/**`).

## Test plan

- [ ] Open a follow-up PR that touches only `docs/**` or a `README.md` and confirm none of `test`, `bench`, `amdsev-initrd-test`, or `Claude Code Review` start.
- [ ] Confirm a normal Rust-only PR still triggers all four workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)