### PR TITLE
feat(sequencer): add `--no-state-trie` flag to disable trie computation

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -68,6 +68,14 @@ pub struct SequencerNodeArgs {
     #[arg(value_name = "TOTAL")]
     pub block_cairo_steps_limit: Option<u64>,
 
+    /// Disable state trie computation during block production.
+    ///
+    /// When set, block headers carry `state_root = 0` and no trie data is
+    /// written to the database. This skips a significant amount of work but
+    /// breaks state proofs (`pathfinder_getProof`) and changes block hashes.
+    #[arg(long)]
+    pub no_state_trie: bool,
+
     /// Configuration file
     #[arg(long)]
     pub config: Option<PathBuf>,
@@ -391,6 +399,7 @@ impl SequencerNodeArgs {
             block_time: self.block_time,
             no_mining: self.no_mining,
             block_cairo_steps_limit: self.block_cairo_steps_limit,
+            no_state_trie: self.no_state_trie,
         }
     }
 
@@ -731,6 +740,10 @@ impl SequencerNodeArgs {
 
         if !self.no_mining {
             self.no_mining = config.no_mining.unwrap_or_default();
+        }
+
+        if !self.no_state_trie {
+            self.no_state_trie = config.no_state_trie.unwrap_or_default();
         }
 
         if self.block_time.is_none() {

--- a/crates/cli/src/file.rs
+++ b/crates/cli/src/file.rs
@@ -13,6 +13,7 @@ pub struct NodeArgsConfig {
     pub no_mining: Option<bool>,
     pub block_time: Option<u64>,
     pub block_cairo_steps_limit: Option<u64>,
+    pub no_state_trie: Option<bool>,
     #[serde(flatten)]
     pub db: Option<DbOptions>,
     pub messaging: Option<MessagingConfig>,
@@ -52,6 +53,7 @@ impl TryFrom<SequencerNodeArgs> for NodeArgsConfig {
             no_mining: if args.no_mining { Some(true) } else { None },
             block_time: args.block_time,
             block_cairo_steps_limit: args.block_cairo_steps_limit,
+            no_state_trie: if args.no_state_trie { Some(true) } else { None },
             db: (!args.db.is_default()).then_some(args.db),
             messaging: args.messaging,
             ..Default::default()

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -45,6 +45,8 @@ pub struct Backend<PF> {
     pub block_context_generator: RwLock<BlockContextGenerator>,
     pub executor_factory: Arc<dyn ExecutorFactory>,
     pub gas_oracle: GasPriceOracle,
+    /// When true, skip state trie computation during block production.
+    pub no_state_trie: bool,
 }
 
 impl<PF> std::fmt::Debug for Backend<PF> {
@@ -65,12 +67,14 @@ impl<PF> Backend<PF> {
         storage: PF,
         gas_oracle: GasPriceOracle,
         executor_factory: Arc<dyn ExecutorFactory>,
+        no_state_trie: bool,
     ) -> Self {
         Self {
             storage,
             chain_spec,
             gas_oracle,
             executor_factory,
+            no_state_trie,
             block_context_generator: RwLock::new(BlockContextGenerator::default()),
         }
     }
@@ -180,6 +184,7 @@ where
             transactions,
             &receipts,
             &mut execution_output.states.state_updates,
+            self.no_state_trie,
         )?;
 
         let block = SealedBlockWithStatus { block, status: FinalityStatus::AcceptedOnL2 };
@@ -365,6 +370,7 @@ pub struct UncommittedBlock<'a, P: TrieWriter> {
     receipts: &'a [ReceiptWithTxHash],
     state_updates: &'a StateUpdates,
     provider: P,
+    no_state_trie: bool,
 }
 
 impl<'a, P: TrieWriter> UncommittedBlock<'a, P> {
@@ -374,8 +380,16 @@ impl<'a, P: TrieWriter> UncommittedBlock<'a, P> {
         receipts: &'a [ReceiptWithTxHash],
         state_updates: &'a StateUpdates,
         trie_provider: P,
+        no_state_trie: bool,
     ) -> Self {
-        Self { header, transactions, receipts, state_updates, provider: trie_provider }
+        Self {
+            header,
+            transactions,
+            receipts,
+            state_updates,
+            provider: trie_provider,
+            no_state_trie,
+        }
     }
 
     pub fn commit(self) -> SealedBlock {
@@ -527,6 +541,10 @@ impl<'a, P: TrieWriter> UncommittedBlock<'a, P> {
 
     // state_commitment = hPos("STARKNET_STATE_V0", contract_trie_root, class_trie_root)
     fn compute_new_state_root(&self) -> Felt {
+        if self.no_state_trie {
+            return Felt::ZERO;
+        }
+
         let class_trie_root = self
             .provider
             .trie_insert_declared_classes(
@@ -601,10 +619,19 @@ fn commit_block<P: BlockHashProvider + TrieWriter>(
     transactions: Vec<TxWithHash>,
     receipts: &[ReceiptWithTxHash],
     state_updates: &mut StateUpdates,
+    no_state_trie: bool,
 ) -> Result<SealedBlock, BlockProductionError> {
     // Update special contract address 0x1
     update_block_hash_registry_contract(&provider, state_updates, header.number)?;
-    Ok(UncommittedBlock::new(header, transactions, receipts, state_updates, provider).commit())
+    Ok(UncommittedBlock::new(
+        header,
+        transactions,
+        receipts,
+        state_updates,
+        provider,
+        no_state_trie,
+    )
+    .commit())
 }
 
 fn commit_genesis_block(
@@ -614,7 +641,11 @@ fn commit_genesis_block(
     receipts: &[ReceiptWithTxHash],
     state_updates: &mut StateUpdates,
 ) -> Result<SealedBlock, BlockProductionError> {
-    Ok(UncommittedBlock::new(header, transactions, receipts, state_updates, provider).commit())
+    // Genesis always computes the state trie so the recomputed genesis hash
+    // matches the chain spec's stored hash; the runtime `no_state_trie` flag
+    // only applies to ongoing block production.
+    Ok(UncommittedBlock::new(header, transactions, receipts, state_updates, provider, false)
+        .commit())
 }
 
 #[derive(Debug)]

--- a/crates/core/src/service/block_producer_tests.rs
+++ b/crates/core/src/service/block_producer_tests.rs
@@ -15,7 +15,7 @@ fn test_backend() -> Arc<Backend<DbProviderFactory>> {
         Arc::new(NoopExecutorFactory::new());
     let storage = DbProviderFactory::new_in_memory();
     let gas_oracle = GasPriceOracle::create_for_testing();
-    let backend = Arc::new(Backend::new(chain_spec, storage, gas_oracle, executor_factory));
+    let backend = Arc::new(Backend::new(chain_spec, storage, gas_oracle, executor_factory, false));
     backend.init_genesis(false).expect("failed to initialize genesis");
     backend
 }

--- a/crates/core/tests/backend.rs
+++ b/crates/core/tests/backend.rs
@@ -46,6 +46,7 @@ fn backend_with_db(
         provider,
         GasPriceOracle::create_for_testing(),
         executor(chain_spec),
+        false,
     )
 }
 

--- a/crates/core/tests/backend.rs
+++ b/crates/core/tests/backend.rs
@@ -12,9 +12,10 @@ use katana_genesis::allocation::DevAllocationsGenerator;
 use katana_genesis::constant::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
 use katana_genesis::Genesis;
 use katana_primitives::chain::ChainId;
-use katana_primitives::env::VersionedConstantsOverrides;
-use katana_primitives::felt;
-use katana_provider::DbProviderFactory;
+use katana_primitives::env::{BlockEnv, VersionedConstantsOverrides};
+use katana_primitives::{felt, Felt};
+use katana_provider::api::block::HeaderProvider;
+use katana_provider::{DbProviderFactory, ProviderFactory};
 use rstest::rstest;
 use url::Url;
 
@@ -41,12 +42,20 @@ fn backend_with_db(
     chain_spec: Arc<ChainSpec>,
     provider: DbProviderFactory,
 ) -> Backend<DbProviderFactory> {
+    backend_with_db_and_flag(chain_spec, provider, false)
+}
+
+fn backend_with_db_and_flag(
+    chain_spec: Arc<ChainSpec>,
+    provider: DbProviderFactory,
+    no_state_trie: bool,
+) -> Backend<DbProviderFactory> {
     Backend::new(
         chain_spec.clone(),
         provider,
         GasPriceOracle::create_for_testing(),
         executor(chain_spec),
-        false,
+        no_state_trie,
     )
 }
 
@@ -115,4 +124,39 @@ fn reinitialize_with_different_rollup_chain_spec() {
     let backend2 = backend_with_db(chain2.into(), db);
     let err = backend2.init_genesis(false).unwrap_err().to_string();
     assert!(err.as_str().contains("Genesis block hash mismatch"));
+}
+
+#[rstest]
+#[case::trie_enabled(false)]
+#[case::trie_disabled(true)]
+fn no_state_trie_flag_controls_state_root(#[case] no_state_trie: bool) {
+    let chain_spec: Arc<ChainSpec> = ChainSpec::Dev(dev_chain_spec()).into();
+    let backend =
+        backend_with_db_and_flag(chain_spec, DbProviderFactory::new_in_memory(), no_state_trie);
+    backend.init_genesis(false).expect("failed to initialize genesis");
+
+    let mut block_env = BlockEnv::default();
+    backend.update_block_env(&mut block_env);
+    let outcome = backend.mine_empty_block(&block_env).expect("failed to mine empty block");
+
+    let header = backend
+        .storage
+        .provider()
+        .header(outcome.block_number.into())
+        .expect("failed to read header")
+        .expect("header missing");
+
+    if no_state_trie {
+        assert_eq!(
+            header.state_root,
+            Felt::ZERO,
+            "state_root must be zero when --no-state-trie is set",
+        );
+    } else {
+        assert_ne!(
+            header.state_root,
+            Felt::ZERO,
+            "state_root must reflect the genesis-populated trie when trie computation is enabled",
+        );
+    }
 }

--- a/crates/node/sequencer/src/config/sequencing.rs
+++ b/crates/node/sequencer/src/config/sequencing.rs
@@ -20,6 +20,13 @@ pub struct SequencingConfig {
     ///
     /// See <https://docs.starknet.io/chain-info/#current_limits>.
     pub block_cairo_steps_limit: Option<u64>,
+
+    /// Disable state trie computation during block production.
+    ///
+    /// When true, block headers carry `state_root = Felt::ZERO` and no
+    /// class/contract/storage trie writes are performed. Block hashes
+    /// will differ from a normal run and storage proofs become unavailable.
+    pub no_state_trie: bool,
 }
 
 impl SequencingConfig {

--- a/crates/node/sequencer/src/lib.rs
+++ b/crates/node/sequencer/src/lib.rs
@@ -211,6 +211,7 @@ where
             executor_factory,
             block_context_generator,
             chain_spec: config.chain.clone(),
+            no_state_trie: config.sequencing.no_state_trie,
         });
 
         let skip_dev_genesis =


### PR DESCRIPTION
Adds a `--no-state-trie` boolean flag to the sequencer node that bypasses class/contract/storage trie writes during block production and stamps `state_root = 0` into block headers, mirroring how the full node disables trie work by dropping the `statetrie` stage from `--sync.stages`. 

Genesis still computes its trie so the chain-spec genesis hash check stays intact. Block hashes diverge from a normal run and the storage proof endpoint (`starknet_getStorageProof`) will not be able to provide any proofs for blocks whose state root aren't computed. 

For example, if the node is run with `--no-state-trie` but the flag is later dropped after a restart and state trie is computed normally. Then, blocks that were produced with `--no-state-trie` will not have storage proofs associated with them.