### PR TITLE
fix(rpc): clamp `from_block` to fork point on forked chains for getEvents

### DIFF
--- a/crates/rpc/rpc-server/src/starknet/mod.rs
+++ b/crates/rpc/rpc-server/src/starknet/mod.rs
@@ -963,6 +963,26 @@ where
         let from = self.resolve_event_block_id_if_forked(from_block)?;
         let to = self.resolve_event_block_id_if_forked(to_block)?;
 
+        // On a forked chain, clamp `from_block` up to the fork point. Pre-fork events live on
+        // the upstream chain and would otherwise force the provider to fetch every pre-fork
+        // block sequentially from the upstream RPC (e.g. ~9.6M blocks for a mainnet fork),
+        // which can hang the handler for hours. Callers that need pre-fork events should query
+        // the upstream RPC directly.
+        //
+        // NOTE: only `from` is clamped. `to` is left alone — if it's also pre-fork the
+        // resulting range `clamp(from)..=to` will be empty and `events_inner` will naturally
+        // return an empty page. Clamping `to` upward would change query semantics.
+        let from = match from {
+            EventBlockId::Num(num) => {
+                if let Some(fork_point) = provider.fork_point()? {
+                    EventBlockId::Num(num.max(fork_point))
+                } else {
+                    EventBlockId::Num(num)
+                }
+            }
+            EventBlockId::Pending => EventBlockId::Pending,
+        };
+
         // reserved buffer to fill up with events to avoid reallocations
         let mut events = Vec::with_capacity(chunk_size as usize);
         let filter = utils::events::Filter { address, keys: keys.clone() };

--- a/crates/storage/provider/provider-api/src/block.rs
+++ b/crates/storage/provider/provider-api/src/block.rs
@@ -78,6 +78,19 @@ pub trait BlockNumberProvider: Send + Sync {
             BlockHashOrNumber::Hash(hash) => self.block_number_by_hash(hash),
         }
     }
+
+    /// Returns the fork point block number if this provider is backed by a forked upstream
+    /// chain.
+    ///
+    /// Returns `Some(N)` only for forked providers where `N` is the upstream block number this
+    /// fork inherits state from. Returns `None` for non-forked providers.
+    ///
+    /// Callers can use this to avoid pathological work on the fork's pre-fork range. For example
+    /// the JSON-RPC `getEvents` handler clamps `from_block` upward to the fork point so it does
+    /// not walk millions of pre-fork blocks one at a time fetching each from upstream.
+    fn fork_point(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(None)
+    }
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]

--- a/crates/storage/provider/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/provider/src/providers/fork/mod.rs
@@ -217,6 +217,10 @@ impl<Tx1: DbTx> BlockNumberProvider for ForkedProvider<Tx1> {
         };
         Ok(local_latest.max(self.block_id()))
     }
+
+    fn fork_point(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(Some(self.block_id()))
+    }
 }
 
 impl<Tx1: DbTx> BlockIdReader for ForkedProvider<Tx1> {}


### PR DESCRIPTION
## Summary

On a forked Katana node (\`--fork.provider <url>\`), an inbound \`starknet_getEvents\` call with a \`from_block\` at or below the fork point causes the events handler to iterate every pre-fork block one at a time. Each pre-fork block triggers \`fetch_historical_blocks\` which makes 2 upstream RPC calls (\`get_block\` + \`get_state_update\`).

On a mainnet fork at block ~9.6M with \`from_block: Number(0)\` (the default for unfiltered \`getEvents\`), that's ~9.6M sequential upstream RPC fetches for a single inbound request. At ~600ms per pair, ~66 hours of work. In practice the client (e.g. \`sozo migrate\`'s world-diff phase) times out long before, but the server is still spinning when it does.

Pre-fork events live on the upstream chain. Callers that need them should query upstream directly, not through the fork. The function \`resolve_event_block_id_if_forked\` is named like it should do this clamping but doesn't today — this PR adds the missing behavior.

## Changes

- Add \`BlockNumberProvider::fork_point() -> Option<BlockNumber>\` to the storage-provider trait with a default \`Ok(None)\`. Non-forked providers get the correct no-clamp behavior automatically.
- \`ForkedProvider\` overrides \`fork_point()\` to return the upstream fork block.
- \`events_inner\` clamps \`from_block\` to \`from.max(fork_point)\` when the provider is forked.

\`to_block\` is **intentionally not clamped**: doing so would change query semantics. If both bounds are pre-fork the resulting empty range is handled naturally by \`fetch_events_at_blocks\`.

## Verified against a real reproducer

A forked settlement Katana running \`sozo migrate\` for a Dojo world.

**Pre-fix** — 608+ sequential pre-fork block fetches during a single inbound \`getEvents\`, sozo timed out after ~6 minutes.

**Post-fix** — only the natural fork-point lookback (10 blocks). Sozo's world-diff phase completes in seconds. World deploys cleanly.

## Test plan

- [x] \`cargo build --release --bin katana\` succeeds
- [x] Run forked Katana against real Cartridge mainnet RPC, observe getEvents no longer iterates pre-fork blocks
- [ ] Existing Katana test suite (please run in CI)