### PR TITLE
fix(rpc): forward pre-fork `starknet_getEvents` range to upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,6 +6984,7 @@ dependencies = [
  "cainome 0.9.1",
  "cairo-lang-starknet-classes",
  "cartridge",
+ "futures",
  "hex",
  "http 1.3.1",
  "indexmap 2.10.0",

--- a/crates/rpc/rpc-server/Cargo.toml
+++ b/crates/rpc/rpc-server/Cargo.toml
@@ -20,11 +20,13 @@ katana-provider = { workspace = true, features = [ "test-utils" ] }
 katana-rpc-api = { workspace = true, features = [ "client" ] }
 katana-rpc-types.workspace = true
 katana-rpc-types-builder.workspace = true
+katana-starknet.workspace = true
 katana-tasks.workspace = true
 katana-tracing.workspace = true
 
 anyhow.workspace = true
 auto_impl.workspace = true
+futures.workspace = true
 http.workspace = true
 jsonrpsee = { workspace = true, features = [ "client", "server" ] }
 metrics.workspace = true
@@ -60,7 +62,6 @@ katana-node-config.workspace = true
 katana-rpc-api = { workspace = true, features = [ "client" ] }
 katana-rpc-types = { workspace = true, features = [ "arbitrary" ] }
 katana-sequencer-node.workspace = true
-katana-starknet.workspace = true
 katana-trie.workspace = true
 katana-utils = { workspace = true, features = [ "node" ] }
 

--- a/crates/rpc/rpc-server/src/starknet/mod.rs
+++ b/crates/rpc/rpc-server/src/starknet/mod.rs
@@ -20,7 +20,6 @@ use katana_primitives::event::MaybeForkedContinuationToken;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, TxHash, TxNumber};
 use katana_primitives::Felt;
-use katana_starknet::rpc::StarknetRpcClient as StarknetClient;
 use katana_provider::api::block::{BlockHashProvider, BlockIdReader, BlockNumberProvider};
 use katana_provider::api::contract::ContractClassProvider;
 use katana_provider::api::env::BlockEnvProvider;
@@ -59,6 +58,7 @@ use katana_rpc_types::{
     TxStatus, TxTrace, TxTraceWithHash,
 };
 use katana_rpc_types_builder::{BlockBuilder, ReceiptBuilder};
+use katana_starknet::rpc::StarknetRpcClient as StarknetClient;
 use katana_tasks::{Result as TaskResult, TaskSpawner};
 
 use crate::permit::Permits;
@@ -82,8 +82,8 @@ pub type StarknetApiResult<T> = Result<T, StarknetApiError>;
 /// query to the forked chain. Returns:
 /// - `Some(None)` — first page; ask upstream with no token.
 /// - `Some(Some(t))` — subsequent page; continue upstream pagination with `t`.
-/// - `None` — the caller already crossed into the local block range (the
-///   continuation token is a local cursor), so skip upstream entirely.
+/// - `None` — the caller already crossed into the local block range (the continuation token is a
+///   local cursor), so skip upstream entirely.
 fn forked_continuation_token(
     continuation_token: &Option<MaybeForkedContinuationToken>,
 ) -> Option<Option<String>> {
@@ -994,44 +994,43 @@ where
 
         match (from, to) {
             (EventBlockId::Num(from), EventBlockId::Num(to)) => {
-                let from_after_forked_if_any = if let Some((client, forked_block)) =
-                    &self.inner.forked_client
-                {
-                    let forked_block = *forked_block;
-                    if from <= forked_block {
-                        let upstream_to = std::cmp::min(to, forked_block);
+                let from_after_forked_if_any =
+                    if let Some((client, forked_block)) = &self.inner.forked_client {
+                        let forked_block = *forked_block;
+                        if from <= forked_block {
+                            let upstream_to = std::cmp::min(to, forked_block);
 
-                        if let Some(token) = forked_continuation_token(&continuation_token) {
-                            let upstream_filter = EventFilter {
-                                from_block: Some(BlockIdOrTag::Number(from)),
-                                to_block: Some(BlockIdOrTag::Number(upstream_to)),
-                                address,
-                                keys: keys.clone(),
-                            };
+                            if let Some(token) = forked_continuation_token(&continuation_token) {
+                                let upstream_filter = EventFilter {
+                                    from_block: Some(BlockIdOrTag::Number(from)),
+                                    to_block: Some(BlockIdOrTag::Number(upstream_to)),
+                                    address,
+                                    keys: keys.clone(),
+                                };
 
-                            let upstream_result = futures::executor::block_on(
-                                client.get_events(upstream_filter, token, chunk_size),
-                            )
-                            .map_err(|e| StarknetApiError::unexpected(e.to_string()))?;
+                                let upstream_result = futures::executor::block_on(
+                                    client.get_events(upstream_filter, token, chunk_size),
+                                )
+                                .map_err(|e| StarknetApiError::unexpected(e.to_string()))?;
 
-                            events.extend(upstream_result.events);
+                                events.extend(upstream_result.events);
 
-                            if let Some(t) = upstream_result.continuation_token {
-                                let wrapped = MaybeForkedContinuationToken::Forked(t);
-                                return Ok(GetEventsResponse {
-                                    events,
-                                    continuation_token: Some(wrapped.to_string()),
-                                });
+                                if let Some(t) = upstream_result.continuation_token {
+                                    let wrapped = MaybeForkedContinuationToken::Forked(t);
+                                    return Ok(GetEventsResponse {
+                                        events,
+                                        continuation_token: Some(wrapped.to_string()),
+                                    });
+                                }
                             }
-                        }
 
-                        forked_block + 1
+                            forked_block + 1
+                        } else {
+                            from
+                        }
                     } else {
                         from
-                    }
-                } else {
-                    from
-                };
+                    };
 
                 if from_after_forked_if_any > to {
                     return Ok(GetEventsResponse { events, continuation_token: None });
@@ -1056,42 +1055,41 @@ where
             }
 
             (EventBlockId::Num(from), EventBlockId::Pending) => {
-                let from_after_forked_if_any = if let Some((client, forked_block)) =
-                    &self.inner.forked_client
-                {
-                    let forked_block = *forked_block;
-                    if from <= forked_block {
-                        if let Some(token) = forked_continuation_token(&continuation_token) {
-                            let upstream_filter = EventFilter {
-                                from_block: Some(BlockIdOrTag::Number(from)),
-                                to_block: Some(BlockIdOrTag::Number(forked_block)),
-                                address,
-                                keys: keys.clone(),
-                            };
+                let from_after_forked_if_any =
+                    if let Some((client, forked_block)) = &self.inner.forked_client {
+                        let forked_block = *forked_block;
+                        if from <= forked_block {
+                            if let Some(token) = forked_continuation_token(&continuation_token) {
+                                let upstream_filter = EventFilter {
+                                    from_block: Some(BlockIdOrTag::Number(from)),
+                                    to_block: Some(BlockIdOrTag::Number(forked_block)),
+                                    address,
+                                    keys: keys.clone(),
+                                };
 
-                            let upstream_result = futures::executor::block_on(
-                                client.get_events(upstream_filter, token, chunk_size),
-                            )
-                            .map_err(|e| StarknetApiError::unexpected(e.to_string()))?;
+                                let upstream_result = futures::executor::block_on(
+                                    client.get_events(upstream_filter, token, chunk_size),
+                                )
+                                .map_err(|e| StarknetApiError::unexpected(e.to_string()))?;
 
-                            events.extend(upstream_result.events);
+                                events.extend(upstream_result.events);
 
-                            if let Some(t) = upstream_result.continuation_token {
-                                let wrapped = MaybeForkedContinuationToken::Forked(t);
-                                return Ok(GetEventsResponse {
-                                    events,
-                                    continuation_token: Some(wrapped.to_string()),
-                                });
+                                if let Some(t) = upstream_result.continuation_token {
+                                    let wrapped = MaybeForkedContinuationToken::Forked(t);
+                                    return Ok(GetEventsResponse {
+                                        events,
+                                        continuation_token: Some(wrapped.to_string()),
+                                    });
+                                }
                             }
-                        }
 
-                        forked_block + 1
+                            forked_block + 1
+                        } else {
+                            from
+                        }
                     } else {
                         from
-                    }
-                } else {
-                    from
-                };
+                    };
 
                 let cursor = continuation_token.and_then(|t| t.to_token().map(|t| t.into()));
                 let latest = provider.latest_number()?;

--- a/crates/rpc/rpc-server/src/starknet/mod.rs
+++ b/crates/rpc/rpc-server/src/starknet/mod.rs
@@ -10,7 +10,9 @@ use katana_executor::blockifier::cache::ClassCache;
 use katana_executor::{ExecutionResult, ResultAndStates};
 use katana_gas_price_oracle::GasPriceOracle;
 use katana_pool::api::TransactionPool;
-use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, FinalityStatus, GasPrices};
+use katana_primitives::block::{
+    BlockHashOrNumber, BlockIdOrTag, BlockNumber, FinalityStatus, GasPrices,
+};
 use katana_primitives::class::{ClassHash, CompiledClass};
 use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
 use katana_primitives::env::BlockEnv;
@@ -18,6 +20,7 @@ use katana_primitives::event::MaybeForkedContinuationToken;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, TxHash, TxNumber};
 use katana_primitives::Felt;
+use katana_starknet::rpc::StarknetRpcClient as StarknetClient;
 use katana_provider::api::block::{BlockHashProvider, BlockIdReader, BlockNumberProvider};
 use katana_provider::api::contract::ContractClassProvider;
 use katana_provider::api::env::BlockEnvProvider;
@@ -36,7 +39,9 @@ use katana_rpc_types::block::{
     GetBlockWithTxHashesResponse, MaybePreConfirmedBlock,
 };
 use katana_rpc_types::class::Class;
-use katana_rpc_types::event::{EventFilterWithPage, GetEventsResponse, ResultPageRequest};
+use katana_rpc_types::event::{
+    EventFilter, EventFilterWithPage, GetEventsResponse, ResultPageRequest,
+};
 use katana_rpc_types::list::{
     ContinuationToken as ListContinuationToken, GetBlocksRequest, GetBlocksResponse,
     GetTransactionsRequest, GetTransactionsResponse, TransactionListItem,
@@ -73,6 +78,22 @@ pub use pending::PendingBlockProvider;
 
 pub type StarknetApiResult<T> = Result<T, StarknetApiError>;
 
+/// Decide the upstream continuation token to forward when forwarding an events
+/// query to the forked chain. Returns:
+/// - `Some(None)` — first page; ask upstream with no token.
+/// - `Some(Some(t))` — subsequent page; continue upstream pagination with `t`.
+/// - `None` — the caller already crossed into the local block range (the
+///   continuation token is a local cursor), so skip upstream entirely.
+fn forked_continuation_token(
+    continuation_token: &Option<MaybeForkedContinuationToken>,
+) -> Option<Option<String>> {
+    match continuation_token {
+        None => Some(None),
+        Some(MaybeForkedContinuationToken::Forked(t)) => Some(Some(t.to_string())),
+        Some(MaybeForkedContinuationToken::Token(_)) => None,
+    }
+}
+
 /// Handler for the Starknet JSON-RPC server.
 ///
 /// This struct implements [`katana_rpc_api::starknet::StarknetApi`], which combines the read,
@@ -104,6 +125,7 @@ where
     config: StarknetApiConfig,
     cache: RpcCache,
     class_cache: ClassCache,
+    forked_client: Option<(Arc<StarknetClient>, BlockNumber)>,
 }
 
 impl<Pool, PP, PF> StarknetApi<Pool, PP, PF>
@@ -129,6 +151,8 @@ where
             .unwrap_or(DEFAULT_ESTIMATE_FEE_MAX_CONCURRENT_REQUESTS);
         let estimate_fee_permit = Permits::new(total_permits);
 
+        let forked_client = storage.fork_handle();
+
         let inner = StarknetApiInner {
             chain_spec,
             pool,
@@ -140,6 +164,7 @@ where
             storage,
             cache,
             class_cache,
+            forked_client,
         };
 
         Self { inner: Arc::new(inner) }
@@ -969,7 +994,48 @@ where
 
         match (from, to) {
             (EventBlockId::Num(from), EventBlockId::Num(to)) => {
-                let from_after_forked_if_any = from;
+                let from_after_forked_if_any = if let Some((client, forked_block)) =
+                    &self.inner.forked_client
+                {
+                    let forked_block = *forked_block;
+                    if from <= forked_block {
+                        let upstream_to = std::cmp::min(to, forked_block);
+
+                        if let Some(token) = forked_continuation_token(&continuation_token) {
+                            let upstream_filter = EventFilter {
+                                from_block: Some(BlockIdOrTag::Number(from)),
+                                to_block: Some(BlockIdOrTag::Number(upstream_to)),
+                                address,
+                                keys: keys.clone(),
+                            };
+
+                            let upstream_result = futures::executor::block_on(
+                                client.get_events(upstream_filter, token, chunk_size),
+                            )
+                            .map_err(|e| StarknetApiError::unexpected(e.to_string()))?;
+
+                            events.extend(upstream_result.events);
+
+                            if let Some(t) = upstream_result.continuation_token {
+                                let wrapped = MaybeForkedContinuationToken::Forked(t);
+                                return Ok(GetEventsResponse {
+                                    events,
+                                    continuation_token: Some(wrapped.to_string()),
+                                });
+                            }
+                        }
+
+                        forked_block + 1
+                    } else {
+                        from
+                    }
+                } else {
+                    from
+                };
+
+                if from_after_forked_if_any > to {
+                    return Ok(GetEventsResponse { events, continuation_token: None });
+                }
 
                 let cursor = continuation_token.and_then(|t| t.to_token().map(|t| t.into()));
                 let block_range = from_after_forked_if_any..=to;
@@ -990,7 +1056,42 @@ where
             }
 
             (EventBlockId::Num(from), EventBlockId::Pending) => {
-                let from_after_forked_if_any = from;
+                let from_after_forked_if_any = if let Some((client, forked_block)) =
+                    &self.inner.forked_client
+                {
+                    let forked_block = *forked_block;
+                    if from <= forked_block {
+                        if let Some(token) = forked_continuation_token(&continuation_token) {
+                            let upstream_filter = EventFilter {
+                                from_block: Some(BlockIdOrTag::Number(from)),
+                                to_block: Some(BlockIdOrTag::Number(forked_block)),
+                                address,
+                                keys: keys.clone(),
+                            };
+
+                            let upstream_result = futures::executor::block_on(
+                                client.get_events(upstream_filter, token, chunk_size),
+                            )
+                            .map_err(|e| StarknetApiError::unexpected(e.to_string()))?;
+
+                            events.extend(upstream_result.events);
+
+                            if let Some(t) = upstream_result.continuation_token {
+                                let wrapped = MaybeForkedContinuationToken::Forked(t);
+                                return Ok(GetEventsResponse {
+                                    events,
+                                    continuation_token: Some(wrapped.to_string()),
+                                });
+                            }
+                        }
+
+                        forked_block + 1
+                    } else {
+                        from
+                    }
+                } else {
+                    from
+                };
 
                 let cursor = continuation_token.and_then(|t| t.to_token().map(|t| t.into()));
                 let latest = provider.latest_number()?;
@@ -1081,10 +1182,24 @@ where
                 EventBlockId::Num(num.ok_or(StarknetApiError::BlockNotFound)?)
             }
 
-            BlockIdOrTag::Hash(..) => {
+            BlockIdOrTag::Hash(_) => {
                 // Check first if the block hash belongs to a local block.
                 if let Some(num) = provider.convert_block_id(id)? {
                     EventBlockId::Num(num)
+                } else if let Some((client, forked_block)) = &self.inner.forked_client {
+                    // Fall back to the upstream chain for pre-fork block hashes only.
+                    // A hash that resolves to a block past the fork point is on a chain
+                    // that has since diverged from ours, so we reject it.
+                    let resp = futures::executor::block_on(client.get_block_with_tx_hashes(id))
+                        .map_err(|_| StarknetApiError::BlockNotFound)?;
+                    match resp {
+                        GetBlockWithTxHashesResponse::Block(b)
+                            if b.block_number <= *forked_block =>
+                        {
+                            EventBlockId::Num(b.block_number)
+                        }
+                        _ => return Err(StarknetApiError::BlockNotFound),
+                    }
                 } else {
                     return Err(StarknetApiError::BlockNotFound);
                 }

--- a/crates/rpc/rpc-server/tests/forking.rs
+++ b/crates/rpc/rpc-server/tests/forking.rs
@@ -498,6 +498,44 @@ async fn get_events_all_from_forked(#[case] block_id: BlockIdOrTag) {
     }
 }
 
+// Regression test for the upstream-forwarding path in `events_inner` on
+// forked chains. A `getEvents(from=0, to=latest)` query that overlaps the
+// pre-fork range MUST be forwarded to the upstream RPC as a single
+// `starknet_getEvents` call. A regressed implementation that walks every
+// pre-fork block locally would issue ~268K single-block upstream calls for
+// this fixture, taking hours; the upstream-forwarding path completes in
+// at most a few round-trips. A 60-second wall-clock budget catches the
+// regression cleanly without flaking on healthy CI.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_events_from_zero_does_not_walk_pre_fork_blocks() -> Result<()> {
+    let (_sequencer, provider, _) = setup_test().await;
+
+    let filter = EventFilter {
+        keys: None,
+        address: None,
+        to_block: Some(BlockIdOrTag::PreConfirmed),
+        from_block: Some(BlockIdOrTag::Number(0)),
+    };
+
+    let budget = std::time::Duration::from_secs(60);
+    let result =
+        tokio::time::timeout(budget, provider.get_events(filter, None, 100)).await.expect(
+            "getEvents(from=0) on a forked chain should complete in under 60s. If this test times \
+             out, the upstream-forwarding path in events_inner has likely regressed back to \
+             per-block iteration over the pre-fork range.",
+        )?;
+
+    // A silent empty result would mean upstream forwarding was skipped without
+    // falling through to local iteration — also a regression.
+    assert!(
+        !result.events.is_empty(),
+        "expected upstream-forwarded events query to return at least one event from the pre-fork \
+         range"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn get_events_local() {
     let (_sequencer, provider, local_only_data) = setup_test().await;

--- a/crates/rpc/rpc-server/tests/forking.rs
+++ b/crates/rpc/rpc-server/tests/forking.rs
@@ -439,7 +439,7 @@ async fn get_events_partially_from_forked(#[case] block_id: BlockIdOrTag) -> Res
     let forked_events = result.events;
 
     let token = MaybeForkedContinuationToken::parse(&result.continuation_token.unwrap())?;
-    assert_matches!(token, MaybeForkedContinuationToken::Token(_));
+    assert_matches!(token, MaybeForkedContinuationToken::Forked(_));
 
     for (a, b) in events.iter().zip(forked_events) {
         assert_eq!(a.block_number, Some(FORK_BLOCK_NUMBER));
@@ -641,7 +641,7 @@ async fn get_events_forked_and_local_boundary_non_exhaustive(#[case] block_id: B
     let katana_events = result.events;
 
     let token = MaybeForkedContinuationToken::parse(&result.continuation_token.unwrap()).unwrap();
-    assert_matches!(token, MaybeForkedContinuationToken::Token(_));
+    assert_matches!(token, MaybeForkedContinuationToken::Forked(_));
     similar_asserts::assert_eq!(katana_events, forked_events);
 }
 

--- a/crates/storage/provider/provider/src/lib.rs
+++ b/crates/storage/provider/provider/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use katana_db::abstraction::Database;
 use katana_fork::Backend;
@@ -97,6 +98,14 @@ pub trait ProviderFactory: Send + Sync + Debug + 'static {
 
     fn provider(&self) -> Self::Provider;
     fn provider_mut(&self) -> Self::ProviderMut;
+
+    /// Returns the upstream RPC client and fork block number when this factory
+    /// is forked. RPC handlers that iterate ranges (e.g. `starknet_getEvents`)
+    /// use this to forward pre-fork-range queries directly to the upstream
+    /// chain instead of walking every pre-fork block locally.
+    fn fork_handle(&self) -> Option<(Arc<StarknetClient>, BlockNumber)> {
+        None
+    }
 }
 
 #[auto_impl::auto_impl(Box)]
@@ -145,16 +154,18 @@ pub struct ForkProviderFactory {
     block_id: BlockNumber,
     fork_factory: DbProviderFactory,
     local_factory: DbProviderFactory,
+    starknet_client: Arc<StarknetClient>,
 }
 
 impl ForkProviderFactory {
     pub fn new(db: katana_db::Db, block_id: BlockNumber, starknet_client: StarknetClient) -> Self {
-        let backend = Backend::new(starknet_client).expect("failed to create backend");
+        let starknet_client = Arc::new(starknet_client);
+        let backend = Backend::new((*starknet_client).clone()).expect("failed to create backend");
 
         let local_factory = DbProviderFactory::new(db);
         let fork_factory = DbProviderFactory::new_in_memory();
 
-        Self { local_factory, fork_factory, backend, block_id }
+        Self { local_factory, fork_factory, backend, block_id, starknet_client }
     }
 
     pub fn new_in_memory(block_id: BlockNumber, starknet_client: StarknetClient) -> Self {
@@ -189,5 +200,9 @@ impl ProviderFactory for ForkProviderFactory {
             self.local_factory.provider_mut(),
             ForkedDb::new(self.backend.clone(), self.block_id, self.fork_factory.clone()),
         )
+    }
+
+    fn fork_handle(&self) -> Option<(Arc<StarknetClient>, BlockNumber)> {
+        Some((self.starknet_client.clone(), self.block_id))
     }
 }


### PR DESCRIPTION
## Summary

Restore the pre-#361 behavior of `starknet_getEvents` on forked chains: forward the pre-fork-range portion of a query to the upstream RPC as a single `get_events` call, instead of iterating block-by-block locally.

#361 pushed forked block-data fetching down to the provider abstraction. That's correct for single-block RPC methods (`block_with_txs`, `transaction_by_hash`, etc.) because they only fetch one block. But it's pathological for `starknet_getEvents` on a contiguous range: `events_inner` iterates `[from..=to]` block-by-block, and each pre-fork iteration round-trips to upstream.

Concretely: a fresh fork at mainnet block ~9.6M, plus a sozo `world-diff` scan (which queries `getEvents(from=0, to=latest, address=world)` to discover the world contract's deploy block), means ~9.6M sequential single-block upstream calls before returning an empty result. We observed this stall `sozo migrate` for 4+ minutes during a Nums-bridge integration test, never reaching the Initialize phase.

## Approach

- `ProviderFactory` gains a default `fork_handle() -> Option<(Arc<StarknetClient>, BlockNumber)>` returning `None`. `ForkProviderFactory` retains the upstream `StarknetClient` alongside its `Backend` and overrides the method.
- `StarknetApiInner` stashes the optional handle, populated from the provider in `new()`.
- `events_inner`'s `(Num, Num)` and `(Num, Pending)` arms forward the pre-fork sub-range to the upstream client as one `get_events` call. Upstream's continuation token is wrapped as `MaybeForkedContinuationToken::Forked` so cursor-paginated pages re-enter the same handler. The local block loop only runs for blocks > fork_point.
- `resolve_event_block_id_if_forked`'s Hash arm consults upstream when the hash isn't local, but rejects hashes resolving to block numbers > fork_point — a hash that drifted onto the upstream's post-fork chain is correctly `BlockNotFound`.

## Supersedes #567

PR #567 ('clamp from_block to fork point on forked chains for getEvents') tried to fix the same issue by *clamping* the requested `from_block` to the fork point. That avoided the iteration pathology but silently dropped pre-fork events — a client querying for events emitted on the upstream chain would get an empty result instead of the actual events. Closed. This PR is the correct fix.
