### PR TITLE
fix(init): use Blake2s compiled class hash on Starknet >= 0.14.1

### DIFF
--- a/bin/katana/src/cli/init/deployment.rs
+++ b/bin/katana/src/cli/init/deployment.rs
@@ -6,9 +6,11 @@ use katana_chain_spec::settlement_check::{
 use katana_chain_spec::tee::compute_katana_tee_config_hash;
 use katana_chain_spec::SettlementProofKind;
 use katana_contracts::piltover::Appchain;
-use katana_primitives::block::{BlockHash, BlockNumber};
+use katana_primitives::block::{BlockHash, BlockIdOrTag, BlockNumber};
 use katana_primitives::class::ContractClass;
+use katana_primitives::version::StarknetVersion;
 use katana_primitives::{felt, ContractAddress, Felt};
+use katana_rpc_types::block::GetBlockWithTxHashesResponse;
 use katana_rpc_types::class::Class;
 use katana_starknet::rpc::StarknetRpcClient as StarknetClient;
 use katana_utils::{TxWaiter, TxWaitingError};
@@ -106,10 +108,26 @@ pub async fn deploy_settlement_contract(
             Err(ProviderError::StarknetError(StarknetError::ClassHashNotFound)) => {
                 sp.update_text("Declaring contract...");
                 let class = (*Appchain::CLASS).clone();
+
+                // Starknet >= 0.14.1 switched the canonical compiled class hash from Poseidon
+                // to Blake2s and rejects declares using the old algorithm; older chains still
+                // expect Poseidon. Read the chain's protocol version and pick accordingly.
+                let chain_version = settlement_chain_starknet_version(&starknet_client).await?;
+                let casm_hash = if chain_version >= StarknetVersion::V0_14_1 {
+                    class
+                        .clone()
+                        .compile()
+                        .map_err(|e| ContractInitError::Other(anyhow!(e)))?
+                        .class_hash_blake2s()
+                        .map_err(|e| ContractInitError::Other(anyhow!(e)))?
+                } else {
+                    Appchain::CASM_HASH
+                };
+
                 let rpc_class = prepare_contract_declaration_params(class)?;
 
                 let res = account
-                    .declare_v3(rpc_class.into(), Appchain::CASM_HASH)
+                    .declare_v3(rpc_class.into(), casm_hash)
                     .send()
                     .await
                     .inspect(|res| {
@@ -364,4 +382,19 @@ fn prepare_contract_declaration_params(class: ContractClass) -> Result<Flattened
     let rpc_class = Class::try_from(class).expect("should be valid");
     let Class::Sierra(class) = rpc_class else { unreachable!("unexpected legacy class") };
     Ok(class.try_into()?)
+}
+
+/// Reads the Starknet protocol version of the settlement chain from the latest block header.
+async fn settlement_chain_starknet_version(
+    client: &StarknetClient,
+) -> Result<StarknetVersion, ContractInitError> {
+    let block = client
+        .get_block_with_tx_hashes(BlockIdOrTag::Latest)
+        .await
+        .map_err(|e| ContractInitError::Other(anyhow!(e)))?;
+    let version_str = match block {
+        GetBlockWithTxHashesResponse::Block(b) => b.starknet_version,
+        GetBlockWithTxHashesResponse::PreConfirmed(b) => b.starknet_version,
+    };
+    StarknetVersion::parse(&version_str).map_err(|e| ContractInitError::Other(anyhow!(e)))
 }

--- a/crates/primitives/src/class.rs
+++ b/crates/primitives/src/class.rs
@@ -301,6 +301,23 @@ impl CompiledClass {
         }
     }
 
+    /// Computes the Blake2s-based hash of the compiled class.
+    ///
+    /// Starknet >= 0.14.1 replaced Poseidon with Blake2s as the canonical hash function
+    /// for the compiled class hash that `declare` transactions commit to. For legacy
+    /// (Cairo 0) classes the returned value is identical to [`Self::class_hash`] since
+    /// they predate the Sierra/CASM split.
+    pub fn class_hash_blake2s(&self) -> Result<CompiledClassHash, ComputeClassHashError> {
+        use starknet_api::contract_class::compiled_class_hash::{
+            HashVersion, HashableCompiledClass,
+        };
+
+        match self {
+            Self::Class(class) => Ok(class.hash(&HashVersion::V2).0),
+            Self::Legacy(class) => Ok(compute_legacy_class_hash(class)?),
+        }
+    }
+
     /// Checks if the compiled contract class is a legacy (Cairo 0) class.
     ///
     /// Returns `true` if the compiled contract class is a legacy class, `false` otherwise.

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -36,6 +36,11 @@ impl StarknetVersion {
     pub const V0_13_2: Self = Self::new([0, 13, 2, 0]);
     /// Starknet version 0.13.4.
     pub const V0_13_4: Self = Self::new([0, 13, 4, 0]);
+    /// Starknet version 0.14.1.
+    ///
+    /// First release that requires `declare` transactions to commit to the Blake2s-based
+    /// compiled class hash; Poseidon-based hashes are rejected from this version onward.
+    pub const V0_14_1: Self = Self::new([0, 14, 1, 0]);
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Summary

Starknet v0.14.1 switched the canonical compiled class hash from Poseidon to Blake2s, and **declares using the old hash are rejected** (per the [release notes](https://community.starknet.io/t/starknet-v0-14-1-pre-release-notes/115690)):

> Declare transactions will now expect `compiled_class_hash` to be computed with the new hash function, and will be rejected otherwise.

`katana init rollup` against a 0.14.1+ settlement chain (mainnet, and Sepolia post-upgrade) therefore fails — the Piltover Appchain declare submits `Appchain::CASM_HASH`, a Poseidon hash baked in at compile time by the `contract!` macro.

## Approach

The declare path now reads the settlement chain's protocol version from the latest block's `starknet_version` and picks the matching hash:

- **`>= 0.14.1`** — compile Sierra → CASM and hash with Blake2s via `starknet_api`'s `HashableCompiledClass` (already a transitive dep through blockifier).
- **otherwise** — use the existing precomputed Poseidon `Appchain::CASM_HASH` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)