### PR TITLE
refactor(messaging): per-collector error types and in-house Starknet RPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6727,6 +6727,8 @@ dependencies = [
  "katana-pool",
  "katana-primitives",
  "katana-provider",
+ "katana-rpc-types",
+ "katana-starknet",
  "parking_lot",
  "serde",
  "serde_json",

--- a/crates/messaging/Cargo.toml
+++ b/crates/messaging/Cargo.toml
@@ -17,6 +17,8 @@ katana-chain-spec.workspace = true
 katana-pool.workspace = true
 katana-primitives = { workspace = true, features = [ "arbitrary" ] }
 katana-provider.workspace = true
+katana-rpc-types.workspace = true
+katana-starknet.workspace = true
 
 anyhow.workspace = true
 auto_impl.workspace = true

--- a/crates/messaging/src/lib.rs
+++ b/crates/messaging/src/lib.rs
@@ -16,8 +16,6 @@
 pub mod server;
 pub mod stream;
 
-use ::starknet::providers::ProviderError as StarknetProviderError;
-use alloy_transport::TransportError;
 use futures::Stream;
 use katana_primitives::chain::ChainId;
 use katana_primitives::ContractAddress;
@@ -31,42 +29,6 @@ use crate::stream::trigger::IntervalTrigger;
 use crate::stream::MessageStream;
 
 pub(crate) const LOG_TARGET: &str = "messaging";
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Failed to initialize messaging")]
-    InitError,
-
-    #[error("unsupported settlement chain")]
-    UnsupportedChain,
-
-    #[error("failed to gather messages from settlement chain")]
-    GatherError,
-
-    /// A settlement chain log/event was found whose shape didn't match the expected
-    /// schema. Surfaces the specific reason so operators can diagnose contract
-    /// upgrades, RPC bugs, or chain-id mismatches without a stack trace.
-    #[error("malformed settlement chain message: {0}")]
-    MalformedMessage(String),
-
-    #[error(transparent)]
-    Provider(ProviderError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ProviderError {
-    #[error("ethereum provider error: {0}")]
-    Ethereum(TransportError),
-
-    #[error("starknet provider error: {0}")]
-    Starknet(StarknetProviderError),
-}
-
-impl From<TransportError> for Error {
-    fn from(e: TransportError) -> Self {
-        Self::Provider(ProviderError::Ethereum(e))
-    }
-}
 
 /// The outcome yielded by a messenger stream on each successful gather.
 #[derive(Debug)]

--- a/crates/messaging/src/stream/collector/ethereum.rs
+++ b/crates/messaging/src/stream/collector/ethereum.rs
@@ -8,6 +8,7 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, FilterBlockOption, FilterSet, Log, Topic};
 use alloy_sol_types::{sol, SolEvent};
+use alloy_transport::TransportError;
 use anyhow::Result;
 use futures::Future;
 use katana_primitives::chain::ChainId;
@@ -23,7 +24,19 @@ use tracing::{debug, trace};
 use url::Url;
 
 use crate::stream::collector::{GatherResult, MessageCollector, OrderedMessage};
-use crate::{Error, LOG_TARGET};
+use crate::LOG_TARGET;
+
+/// Errors produced by [`EthereumCollector`].
+#[derive(Debug, thiserror::Error)]
+pub enum EthereumCollectorError {
+    #[error("ethereum provider error: {0}")]
+    Provider(#[from] TransportError),
+
+    /// An Ethereum log was found whose shape didn't match the expected
+    /// `LogMessageToL2` schema.
+    #[error("malformed settlement chain message: {0}")]
+    MalformedMessage(String),
+}
 
 sol! {
     #[sol(rpc, rename_all = "snakecase")]
@@ -62,7 +75,7 @@ impl EthereumCollector {
         contract_address: Address,
         from_block: u64,
         to_block: u64,
-    ) -> Result<Vec<Log>, Error> {
+    ) -> Result<Vec<Log>, EthereumCollectorError> {
         trace!(target: LOG_TARGET, from_block, to_block, "Fetching ethereum logs.");
 
         let filters = Filter {
@@ -91,7 +104,9 @@ impl EthereumCollector {
 }
 
 impl MessageCollector for EthereumCollector {
-    fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + '_>> {
+    type Error = EthereumCollectorError;
+
+    fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Self::Error>> + Send + '_>> {
         Box::pin(async { Ok(self.provider.get_block_number().await?) })
     }
 
@@ -101,7 +116,7 @@ impl MessageCollector for EthereumCollector {
         from_tx_index: u64,
         to_block: u64,
         chain_id: ChainId,
-    ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Error>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Self::Error>> + Send + '_>> {
         Box::pin(async move {
             let mut messages = vec![];
 
@@ -137,16 +152,23 @@ impl MessageCollector for EthereumCollector {
 
 // --- Conversion functions ---
 
-fn l1_handler_tx_from_log(log: Log, chain_id: ChainId) -> Result<L1HandlerTx, Error> {
-    let log = LogMessageToL2::decode_log(log.as_ref())
-        .map_err(|e| Error::MalformedMessage(format!("decode LogMessageToL2 log: {e}")))?;
+fn l1_handler_tx_from_log(
+    log: Log,
+    chain_id: ChainId,
+) -> Result<L1HandlerTx, EthereumCollectorError> {
+    let log = LogMessageToL2::decode_log(log.as_ref()).map_err(|e| {
+        EthereumCollectorError::MalformedMessage(format!("decode LogMessageToL2 log: {e}"))
+    })?;
 
     let from_address = log.from_address;
     let contract_address = ContractAddress::from(log.to_address);
     let entry_point_selector = felt_from_u256(log.selector);
     let nonce = felt_from_u256(log.nonce);
     let paid_fee_on_l1: u128 = log.fee.try_into().map_err(|_| {
-        Error::MalformedMessage(format!("L1->L2 fee {} does not fit into u128", log.fee))
+        EthereumCollectorError::MalformedMessage(format!(
+            "L1->L2 fee {} does not fit into u128",
+            log.fee
+        ))
     })?;
     let payload = log.payload.clone().into_iter().map(felt_from_u256).collect::<Vec<_>>();
 

--- a/crates/messaging/src/stream/collector/mod.rs
+++ b/crates/messaging/src/stream/collector/mod.rs
@@ -15,8 +15,6 @@ use katana_primitives::transaction::L1HandlerTx;
 pub mod ethereum;
 pub mod starknet;
 
-use crate::Error;
-
 /// A message gathered from the settlement chain together with the position
 /// that identifies it uniquely.
 ///
@@ -64,8 +62,11 @@ pub struct GatherResult {
 /// details of log/event fetching and conversion to L1HandlerTx.
 #[auto_impl::auto_impl(Arc)]
 pub trait MessageCollector: Send + Sync + 'static {
+    /// The error type returned by collector operations.
+    type Error: std::error::Error + Send + Sync + 'static;
+
     /// Get the latest block number on the settlement chain.
-    fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + '_>>;
+    fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Self::Error>> + Send + '_>>;
 
     /// Gather messages from the given block range.
     ///
@@ -81,5 +82,5 @@ pub trait MessageCollector: Send + Sync + 'static {
         from_tx_index: u64,
         to_block: BlockNumber,
         chain_id: ChainId,
-    ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Error>> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Self::Error>> + Send + '_>>;
 }

--- a/crates/messaging/src/stream/collector/starknet.rs
+++ b/crates/messaging/src/stream/collector/starknet.rs
@@ -11,12 +11,26 @@ use katana_primitives::{hash, ContractAddress, Felt};
 use starknet::core::types::{BlockId, EmittedEvent, EventFilter};
 use starknet::macros::selector;
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{AnyProvider, JsonRpcClient, Provider};
+use starknet::providers::{
+    AnyProvider, JsonRpcClient, Provider, ProviderError as StarknetProviderError,
+};
 use tracing::{debug, trace};
 use url::Url;
 
 use crate::stream::collector::{GatherResult, MessageCollector, OrderedMessage};
-use crate::{Error, LOG_TARGET};
+use crate::LOG_TARGET;
+
+/// Errors produced by [`StarknetCollector`].
+#[derive(Debug, thiserror::Error)]
+pub enum StarknetCollectorError {
+    #[error("starknet provider error: {0}")]
+    Provider(#[from] StarknetProviderError),
+
+    /// A Starknet event was found whose shape didn't match the expected
+    /// `MessageSent` schema.
+    #[error("malformed settlement chain message: {0}")]
+    MalformedMessage(String),
+}
 
 /// TODO: This may come from the configuration.
 pub const MESSAGE_SENT_EVENT_KEY: Felt = selector!("MessageSent");
@@ -47,7 +61,7 @@ impl StarknetCollector {
         contract_address: ContractAddress,
         from_block: BlockId,
         to_block: BlockId,
-    ) -> Result<Vec<EmittedEvent>> {
+    ) -> Result<Vec<EmittedEvent>, StarknetProviderError> {
         trace!(target: LOG_TARGET, from_block = ?from_block, to_block = ?to_block, "Fetching starknet events.");
 
         let mut events = vec![];
@@ -84,8 +98,10 @@ impl StarknetCollector {
 }
 
 impl MessageCollector for StarknetCollector {
-    fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + '_>> {
-        Box::pin(async { self.provider.block_number().await.map_err(|_| Error::GatherError) })
+    type Error = StarknetCollectorError;
+
+    fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Self::Error>> + Send + '_>> {
+        Box::pin(async { Ok(self.provider.block_number().await?) })
     }
 
     fn gather(
@@ -94,9 +110,9 @@ impl MessageCollector for StarknetCollector {
         from_tx_index: u64,
         to_block: u64,
         chain_id: ChainId,
-    ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Error>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Self::Error>> + Send + '_>> {
         Box::pin(async move {
-            let mut messages: Vec<OrderedMessage> = vec![];
+            let mut messages: Vec<OrderedMessage> = Vec::new();
 
             let events = Self::fetch_events(
                 &self.provider,
@@ -104,8 +120,7 @@ impl MessageCollector for StarknetCollector {
                 BlockId::Number(from_block),
                 BlockId::Number(to_block),
             )
-            .await
-            .map_err(|_| Error::GatherError)?;
+            .await?;
 
             // Starknet events don't carry a native tx index, so we assign one by
             // counting `MessageSent` events scoped to each block.
@@ -141,32 +156,32 @@ impl MessageCollector for StarknetCollector {
 
 // --- Conversion functions ---
 
-fn l1_handler_tx_from_event(event: &EmittedEvent, chain_id: ChainId) -> Result<L1HandlerTx> {
+fn l1_handler_tx_from_event(
+    event: &EmittedEvent,
+    chain_id: ChainId,
+) -> Result<L1HandlerTx, StarknetCollectorError> {
     // Validate event shape before any indexing — the `MessageSent` schema requires
     // exactly 4 keys (event_key, random_hash, from_address, to_address) and at least
     // 3 data entries (selector, nonce, payload_length, ...payload).
     if event.keys.len() != 4 {
-        return Err(Error::MalformedMessage(format!(
+        return Err(StarknetCollectorError::MalformedMessage(format!(
             "MessageSent event expected 4 keys, got {}",
             event.keys.len()
-        ))
-        .into());
+        )));
     }
     if event.data.len() < 3 {
-        return Err(Error::MalformedMessage(format!(
+        return Err(StarknetCollectorError::MalformedMessage(format!(
             "MessageSent event expected at least 3 data entries (selector, nonce, \
              payload_length), got {}",
             event.data.len()
-        ))
-        .into());
+        )));
     }
 
     if event.keys[0] != MESSAGE_SENT_EVENT_KEY {
-        return Err(Error::MalformedMessage(format!(
+        return Err(StarknetCollectorError::MalformedMessage(format!(
             "MessageSent event key mismatch: expected {MESSAGE_SENT_EVENT_KEY:#x}, got {:#x}",
             event.keys[0]
-        ))
-        .into());
+        )));
     }
 
     let from_address = event.keys[2];

--- a/crates/messaging/src/stream/collector/starknet.rs
+++ b/crates/messaging/src/stream/collector/starknet.rs
@@ -1,19 +1,16 @@
 use std::pin::Pin;
-use std::sync::Arc;
 
 use alloy_primitives::B256;
 use anyhow::Result;
 use futures::Future;
+use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::chain::ChainId;
 use katana_primitives::hash::StarkHash;
 use katana_primitives::transaction::L1HandlerTx;
 use katana_primitives::{hash, ContractAddress, Felt};
-use starknet::core::types::{BlockId, EmittedEvent, EventFilter};
+use katana_rpc_types::event::{EmittedEvent, EventFilter};
+use katana_starknet::rpc::{StarknetRpcClient, StarknetRpcClientError};
 use starknet::macros::selector;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{
-    AnyProvider, JsonRpcClient, Provider, ProviderError as StarknetProviderError,
-};
 use tracing::{debug, trace};
 use url::Url;
 
@@ -24,7 +21,7 @@ use crate::LOG_TARGET;
 #[derive(Debug, thiserror::Error)]
 pub enum StarknetCollectorError {
     #[error("starknet provider error: {0}")]
-    Provider(#[from] StarknetProviderError),
+    Provider(#[from] StarknetRpcClientError),
 
     /// A Starknet event was found whose shape didn't match the expected
     /// `MessageSent` schema.
@@ -36,32 +33,24 @@ pub enum StarknetCollectorError {
 pub const MESSAGE_SENT_EVENT_KEY: Felt = selector!("MessageSent");
 
 /// Starknet settlement chain message collector.
+#[derive(Debug)]
 pub struct StarknetCollector {
-    provider: Arc<AnyProvider>,
+    provider: StarknetRpcClient,
     messaging_contract_address: ContractAddress,
-}
-
-impl std::fmt::Debug for StarknetCollector {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StarknetCollector")
-            .field("messaging_contract_address", &self.messaging_contract_address)
-            .finish_non_exhaustive()
-    }
 }
 
 impl StarknetCollector {
     pub fn new(rpc_url: Url, messaging_contract_address: ContractAddress) -> Result<Self> {
-        let provider =
-            Arc::new(AnyProvider::JsonRpcHttp(JsonRpcClient::new(HttpTransport::new(rpc_url))));
+        let provider = StarknetRpcClient::new(rpc_url);
         Ok(Self { provider, messaging_contract_address })
     }
 
     async fn fetch_events(
-        provider: &AnyProvider,
+        provider: &StarknetRpcClient,
         contract_address: ContractAddress,
-        from_block: BlockId,
-        to_block: BlockId,
-    ) -> Result<Vec<EmittedEvent>, StarknetProviderError> {
+        from_block: BlockIdOrTag,
+        to_block: BlockIdOrTag,
+    ) -> Result<Vec<EmittedEvent>, StarknetRpcClientError> {
         trace!(target: LOG_TARGET, from_block = ?from_block, to_block = ?to_block, "Fetching starknet events.");
 
         let mut events = vec![];
@@ -69,7 +58,7 @@ impl StarknetCollector {
         let filter = EventFilter {
             from_block: Some(from_block),
             to_block: Some(to_block),
-            address: Some(*contract_address),
+            address: Some(contract_address),
             keys: Some(vec![vec![MESSAGE_SENT_EVENT_KEY]]),
         };
 
@@ -101,7 +90,7 @@ impl MessageCollector for StarknetCollector {
     type Error = StarknetCollectorError;
 
     fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Self::Error>> + Send + '_>> {
-        Box::pin(async { Ok(self.provider.block_number().await?) })
+        Box::pin(async { Ok(self.provider.block_number().await?.block_number) })
     }
 
     fn gather(
@@ -117,8 +106,8 @@ impl MessageCollector for StarknetCollector {
             let events = Self::fetch_events(
                 &self.provider,
                 self.messaging_contract_address,
-                BlockId::Number(from_block),
-                BlockId::Number(to_block),
+                BlockIdOrTag::Number(from_block),
+                BlockIdOrTag::Number(to_block),
             )
             .await?;
 
@@ -259,12 +248,15 @@ mod tests {
         let event = EmittedEvent {
             from_address: felt!(
                 "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-            ),
+            )
+            .into(),
             keys: vec![MESSAGE_SENT_EVENT_KEY, selector!("random_hash"), from_address, to_address],
             data: vec![selector, nonce, Felt::from(calldata.len() as u128), Felt::THREE],
             block_hash: Some(selector!("block_hash")),
             block_number: Some(0),
             transaction_hash,
+            transaction_index: 0,
+            event_index: 0,
         };
 
         let message_hash = compute_starknet_to_appchain_message_hash(
@@ -303,7 +295,8 @@ mod tests {
         let event = EmittedEvent {
             from_address: felt!(
                 "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-            ),
+            )
+            .into(),
             keys: vec![
                 selector!("AnOtherUnexpectedEvent"),
                 selector!("random_hash"),
@@ -314,6 +307,8 @@ mod tests {
             block_hash: Some(selector!("block_hash")),
             block_number: Some(0),
             transaction_hash,
+            transaction_index: 0,
+            event_index: 0,
         };
 
         let err = l1_handler_tx_from_event(&event, ChainId::default()).unwrap_err();
@@ -329,12 +324,15 @@ mod tests {
         let event = EmittedEvent {
             from_address: felt!(
                 "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-            ),
+            )
+            .into(),
             keys: vec![selector!("AnOtherUnexpectedEvent"), selector!("random_hash"), from_address],
             data: vec![],
             block_hash: Some(selector!("block_hash")),
             block_number: Some(0),
             transaction_hash,
+            transaction_index: 0,
+            event_index: 0,
         };
 
         let err = l1_handler_tx_from_event(&event, ChainId::default()).unwrap_err();

--- a/crates/messaging/src/stream/mod.rs
+++ b/crates/messaging/src/stream/mod.rs
@@ -15,7 +15,7 @@ pub mod trigger;
 use collector::{GatherResult, MessageCollector};
 use trigger::MessageTrigger;
 
-use crate::{Error, MessagingOutcome, LOG_TARGET};
+use crate::{MessagingOutcome, LOG_TARGET};
 
 /// Maximum number of blocks to fetch in a single gather call.
 const MAX_BLOCKS_PER_GATHER: u64 = 200;
@@ -23,13 +23,13 @@ const MAX_BLOCKS_PER_GATHER: u64 = 200;
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 
 /// The phase of the stream's state machine.
-enum MessageStreamPhase {
+enum MessageStreamPhase<E> {
     /// Waiting for the trigger to fire.
     Idle,
     /// Fetching the latest block number from the settlement chain.
-    CheckingBlock(BoxFuture<Result<BlockNumber, Error>>),
+    CheckingBlock(BoxFuture<Result<BlockNumber, E>>),
     /// Fetching messages from a known block range.
-    Gathering(BoxFuture<Result<GatherResult, Error>>),
+    Gathering(BoxFuture<Result<GatherResult, E>>),
 }
 
 /// A message stream that composes a collector ("how") and a trigger ("when").
@@ -44,7 +44,7 @@ enum MessageStreamPhase {
 /// cursor is passed to the collector on every gather so messages at or before the
 /// cursor in `from_block` are filtered out (supports same-block resume after a crash).
 #[allow(missing_debug_implementations)]
-pub struct MessageStream<C, T> {
+pub struct MessageStream<C: MessageCollector, T> {
     collector: Arc<C>,
     trigger: T,
     chain_id: ChainId,
@@ -54,7 +54,7 @@ pub struct MessageStream<C, T> {
     /// gather from. The "safe head" is `latest_block - confirmation_depth`; gathers
     /// never cross past it. `0` disables the protection.
     confirmation_depth: u64,
-    phase: MessageStreamPhase,
+    phase: MessageStreamPhase<C::Error>,
 }
 
 impl<C, T> MessageStream<C, T>
@@ -247,9 +247,13 @@ mod tests {
     use super::collector::OrderedMessage;
     use super::*;
     use crate::stream::collector::{GatherResult, MessageCollector};
-    use crate::Error;
 
     const SHORT: Duration = Duration::from_millis(50);
+
+    /// A dummy error type returned by [`MockCollector`] when a response queue is empty.
+    #[derive(Debug, thiserror::Error)]
+    #[error("mock collector error")]
+    pub struct MockCollectorError;
 
     /// One recorded call to [`MockCollector::gather`].
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -264,15 +268,15 @@ mod tests {
     ///
     /// Each test pushes responses in expected order via [`push_latest_block`] and
     /// [`push_gather`]. The collector pops them on each call. If a queue is empty,
-    /// the method returns [`Error::GatherError`] so tests fail loudly when they
+    /// the method returns [`MockCollectorError`] so tests fail loudly when they
     /// haven't enqueued enough responses.
     ///
     /// All calls are recorded for assertions via [`latest_block_calls`] and
     /// [`gather_calls`].
     #[derive(Default)]
     pub struct MockCollector {
-        latest_block_responses: Mutex<VecDeque<Result<u64, Error>>>,
-        gather_responses: Mutex<VecDeque<Result<GatherResult, Error>>>,
+        latest_block_responses: Mutex<VecDeque<Result<u64, MockCollectorError>>>,
+        gather_responses: Mutex<VecDeque<Result<GatherResult, MockCollectorError>>>,
         latest_block_call_count: AtomicU64,
         gather_calls: Mutex<Vec<GatherCall>>,
     }
@@ -283,12 +287,12 @@ mod tests {
         }
 
         /// Push a `latest_block` response onto the queue. Called in FIFO order.
-        pub fn push_latest_block(&self, response: Result<u64, Error>) {
+        pub fn push_latest_block(&self, response: Result<u64, MockCollectorError>) {
             self.latest_block_responses.lock().push_back(response);
         }
 
         /// Push a `gather` response onto the queue. Called in FIFO order.
-        pub fn push_gather(&self, response: Result<GatherResult, Error>) {
+        pub fn push_gather(&self, response: Result<GatherResult, MockCollectorError>) {
             self.gather_responses.lock().push_back(response);
         }
 
@@ -304,10 +308,14 @@ mod tests {
     }
 
     impl MessageCollector for MockCollector {
-        fn latest_block(&self) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + '_>> {
+        type Error = MockCollectorError;
+
+        fn latest_block(
+            &self,
+        ) -> Pin<Box<dyn Future<Output = Result<u64, Self::Error>> + Send + '_>> {
             self.latest_block_call_count.fetch_add(1, Ordering::SeqCst);
             let response =
-                self.latest_block_responses.lock().pop_front().unwrap_or(Err(Error::GatherError));
+                self.latest_block_responses.lock().pop_front().unwrap_or(Err(MockCollectorError));
             Box::pin(async move { response })
         }
 
@@ -317,7 +325,7 @@ mod tests {
             from_tx_index: u64,
             to_block: u64,
             chain_id: ChainId,
-        ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Error>> + Send + '_>> {
+        ) -> Pin<Box<dyn Future<Output = Result<GatherResult, Self::Error>> + Send + '_>> {
             self.gather_calls.lock().push(GatherCall {
                 from_block,
                 from_tx_index,
@@ -325,7 +333,7 @@ mod tests {
                 chain_id,
             });
             let response =
-                self.gather_responses.lock().pop_front().unwrap_or(Err(Error::GatherError));
+                self.gather_responses.lock().pop_front().unwrap_or(Err(MockCollectorError));
             Box::pin(async move { response })
         }
     }
@@ -563,7 +571,7 @@ mod tests {
         let (mut stream, collector, trigger) = build(5, 0, 0);
 
         // Tick 1: latest_block errors. No gather. No yield. Cursor unchanged.
-        collector.push_latest_block(Err(Error::GatherError));
+        collector.push_latest_block(Err(MockCollectorError));
         trigger.fire();
         assert_no_yield(&mut stream).await;
         assert!(collector.gather_calls().is_empty());
@@ -588,7 +596,7 @@ mod tests {
 
         // Tick 1: gather errors. No yield. Cursor unchanged.
         collector.push_latest_block(Ok(8));
-        collector.push_gather(Err(Error::GatherError));
+        collector.push_gather(Err(MockCollectorError));
         trigger.fire();
         assert_no_yield(&mut stream).await;
 


### PR DESCRIPTION
Decouples the messaging collectors from the shared `messaging::Error` enum and from the starknet-rs provider. The `MessageCollector` trait gains an associated `Error` type so each implementation can surface its own variants; `EthereumCollector` and `StarknetCollector` now carry purpose-built error enums that preserve the underlying provider error rather than collapsing every failure into a single `GatherError`. `MessageStream` propagates `C::Error` through its phase futures, and the unused `messaging::Error` and `messaging::ProviderError` enums are removed.

The Starknet collector also switches off `starknet-rs`'s `Arc<AnyProvider>` and onto `katana_starknet::rpc::StarknetRpcClient`, with block/event types coming from `katana_primitives` and `katana_rpc_types`.