### PR TITLE
feat(cli): display settlement layer config in startup banner

### DIFF
--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{anyhow, Context, Result};
 use console::Style;
 use katana_chain_spec::rollup::ChainConfigDir;
-use katana_chain_spec::ChainSpec;
+use katana_chain_spec::{ChainSpec, SettlementLayer, SettlementProofKind};
 use katana_db::Db;
 use katana_genesis::allocation::GenesisAccountAlloc;
 use katana_genesis::constant::{
@@ -103,6 +103,7 @@ pub fn print_intro(args: &SequencerNodeArgs, chain: &ChainSpec) {
             serde_json::json!({
                 "accounts": accounts.map(|a| serde_json::json!(a)).collect::<Vec<_>>(),
                 "seed": format!("{}", seed),
+                "settlement": chain.settlement(),
             })
         )
     } else {
@@ -124,6 +125,10 @@ pub fn print_intro(args: &SequencerNodeArgs, chain: &ChainSpec) {
 
         print_genesis_contracts(chain, account_class_hash);
         print_genesis_accounts(accounts);
+
+        if let Some(settlement) = chain.settlement() {
+            print_settlement(settlement);
+        }
 
         println!(
             r"
@@ -187,6 +192,58 @@ PREDEPLOYED CONTRACTS
 | Contract        | Account Contract
 | Class Hash      | {hash:#064x}"
         )
+    }
+}
+
+fn print_settlement(settlement: &SettlementLayer) {
+    match settlement {
+        SettlementLayer::Ethereum { id, rpc_url, account, core_contract, block } => {
+            println!(
+                r"
+
+SETTLEMENT
+==================
+
+| Settlement      | Ethereum
+| Chain ID        | {id}
+| RPC URL         | {rpc_url}
+| Account         | {account}
+| Core Contract   | {core_contract}
+| Deployed Block  | {block}"
+            );
+        }
+
+        SettlementLayer::Starknet { id, rpc_url, core_contract, block, proof_kind } => {
+            let proof_kind = match proof_kind {
+                SettlementProofKind::ValidityProof => "Validity Proof",
+                SettlementProofKind::Tee => "TEE",
+            };
+
+            println!(
+                r"
+
+SETTLEMENT
+==================
+
+| Settlement      | Starknet
+| Chain ID        | {id}
+| RPC URL         | {rpc_url}
+| Core Contract   | {core_contract}
+| Deployed Block  | {block}
+| Proof System    | {proof_kind}"
+            );
+        }
+
+        SettlementLayer::Sovereign { .. } => {
+            println!(
+                r"
+
+SETTLEMENT
+==================
+
+| Settlement      | Sovereign"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Displays the configured settlement layer in the node startup banner. A new `SETTLEMENT` section is printed (in the same `| Label | Value` style as the existing predeployed-contracts block) showing the settlement kind and its fields:

- **Ethereum** — chain ID, RPC URL, account, core contract, deployed block
- **Starknet** — chain ID, RPC URL, core contract, deployed block, proof system (`Validity Proof` / `TEE`)
- **Sovereign** — kind only

It only prints when a settlement layer is configured (`chain.settlement()` is `Some`), so plain dev nodes are unchanged. The same data is also added to the JSON-format startup log.

## Note

The RPC URL is printed in full, which may include provider API keys for real rollups. This was an explicit choice; flagging it for reviewer awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
