### PR TITLE
docs(tee): pin supported saya version to 0.4.0

### DIFF
--- a/docs/tee-deployment.md
+++ b/docs/tee-deployment.md
@@ -46,10 +46,8 @@ from; `saya-tee` registers itself there at startup.
 Binaries on `PATH`:
 
 - `katana` — this repo (`cargo build --release -p katana`).
-- `saya-tee` and `saya-ops` — from [`cartridge-gg/saya`][saya]. **Supported
-  version: `0.4.0`.** Other versions are not guaranteed to be wire-compatible
-  with this Katana revision; pin to the `v0.4.0` tag when building or
-  installing.
+- `saya-tee` and `saya-ops` — from [`cartridge-gg/saya`][saya]. Supported
+  version: `0.4.0`.
 - `jq` — for parsing JSON from `saya-ops`.
 
 A funded settlement-chain account:

--- a/docs/tee-deployment.md
+++ b/docs/tee-deployment.md
@@ -46,7 +46,10 @@ from; `saya-tee` registers itself there at startup.
 Binaries on `PATH`:
 
 - `katana` — this repo (`cargo build --release -p katana`).
-- `saya-tee` and `saya-ops` — from [`cartridge-gg/saya`][saya].
+- `saya-tee` and `saya-ops` — from [`cartridge-gg/saya`][saya]. **Supported
+  version: `0.4.0`.** Other versions are not guaranteed to be wire-compatible
+  with this Katana revision; pin to the `v0.4.0` tag when building or
+  installing.
 - `jq` — for parsing JSON from `saya-ops`.
 
 A funded settlement-chain account:


### PR DESCRIPTION
## Summary

Follow-up to #578. Calls out the wire-compatible saya release (`0.4.0`) in the TEE deployment guide's prerequisites so operators don't pick up a drifting main and hit subtle protocol mismatches.

## Test plan

- [ ] Skim the rendered prerequisites section on the PR page.