### PR TITLE
test(saya-tee): settle blocks carrying cross-chain messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,14 @@ on:
             - "release/**"
         paths:
             - "Cargo.toml"
+            - "Cargo.lock"
             - "bin/**/*.rs"
             - "bin/**/Cargo.toml"
             - "crates/**/*.rs"
             - "crates/**/Cargo.toml"
             - "crates/explorer/**"
+            - "tests/**/*.rs"
+            - "tests/**/Cargo.toml"
             - ".gitmodules"
             - "Makefile"
             - ".github/workflows/test.yml"
@@ -21,11 +24,14 @@ on:
         types: [opened, synchronize, ready_for_review]
         paths:
             - "Cargo.toml"
+            - "Cargo.lock"
             - "bin/**/*.rs"
             - "bin/**/Cargo.toml"
             - "crates/**/*.rs"
             - "crates/**/Cargo.toml"
             - "crates/explorer/**"
+            - "tests/**/*.rs"
+            - "tests/**/Cargo.toml"
             - ".gitmodules"
             - "Makefile"
             - ".github/workflows/test.yml"
@@ -59,10 +65,13 @@ jobs:
                   filters: |
                       broader-rust:
                         - 'Cargo.toml'
+                        - 'Cargo.lock'
                         - 'bin/**/*.rs'
                         - 'bin/**/Cargo.toml'
                         - 'crates/**/*.rs'
                         - 'crates/**/Cargo.toml'
+                        - 'tests/**/*.rs'
+                        - 'tests/**/Cargo.toml'
                         - '!crates/explorer/**'
                         - '.github/workflows/test.yml'
 
@@ -648,7 +657,7 @@ jobs:
             - name: Clone Saya repository
               run: |
                   git clone https://github.com/dojoengine/saya /tmp/saya
-                  git -C /tmp/saya checkout 17c0ee0
+                  git -C /tmp/saya checkout v0.4.1
 
             - uses: software-mansion/setup-scarb@v1
               with:

--- a/tests/saya-tee/Cargo.toml
+++ b/tests/saya-tee/Cargo.toml
@@ -16,6 +16,7 @@ katana-genesis.workspace = true
 katana-messaging.workspace = true
 katana-primitives.workspace = true
 katana-rpc-api.workspace = true
+katana-rpc-types.workspace = true
 katana-sequencer-node = { workspace = true, features = ["tee-mock"] }
 katana-tee = { workspace = true, features = ["mock"] }
 katana-utils = { workspace = true, features = ["node"] }

--- a/tests/saya-tee/src/main.rs
+++ b/tests/saya-tee/src/main.rs
@@ -48,6 +48,7 @@ use anyhow::Result;
 
 mod assertions;
 mod bootstrap;
+mod messaging;
 mod nodes;
 mod saya;
 
@@ -109,6 +110,32 @@ async fn main() -> Result<()> {
         )
         .await?;
     }
+
+    // 7. Regression: drive a cross-chain message in each direction through a *settled* block. The
+    //    loop above only settles plain transfer blocks, so it never builds a `messages_commitment`
+    //    over a real message. A block that consumes an L1->L2 message only settles if saya-tee
+    //    hashes L1->L2 messages with the Poseidon formula Katana commits to (not the Ethereum
+    //    keccak formula); otherwise piltover's `update_state` rejects it with 'tee: invalid
+    //    messages' and `wait_for_settlement` below times out.
+    // Deploy the l1-handler contract on the appchain (declare blocks settle as
+    // plain blocks before the message phases).
+    let handler = messaging::deploy_msg_handler(&l3).await?;
+    println!("Deployed appchain l1-handler contract at {}", hex_felt(&handler));
+
+    println!("--- L1 -> L2 message, then settle ---");
+    let tip_before = messaging::current_tip(&l3).await?;
+    messaging::send_l1_to_l2(&l2, bootstrap.piltover_address, handler).await?;
+    println!(
+        "Sent send_message_to_appchain on L2; waiting for the appchain to relay the L1-handler"
+    );
+    messaging::wait_for_relay(&l3, tip_before, Duration::from_secs(30)).await?;
+    assertions::wait_for_settlement(&l2, &l3, bootstrap.piltover_address, Duration::from_secs(180))
+        .await?;
+
+    println!("--- L2 -> L1 message, then settle ---");
+    messaging::send_l2_to_l1(&l3, handler).await?;
+    assertions::wait_for_settlement(&l2, &l3, bootstrap.piltover_address, Duration::from_secs(180))
+        .await?;
 
     println!("=== saya-tee e2e test PASSED ===");
     Ok(())

--- a/tests/saya-tee/src/messaging.rs
+++ b/tests/saya-tee/src/messaging.rs
@@ -1,0 +1,165 @@
+//! Cross-chain message settlement regression coverage.
+//!
+//! The base flow ([`crate::main`]) only settles plain transfer blocks, so it never
+//! builds a `messages_commitment` over a real cross-chain message — the path that
+//! once silently broke. This module deploys an l1-handler contract on the appchain
+//! and drives one message in each direction through a *settled* block:
+//!
+//! - **L1 → L2:** [`send_l1_to_l2`] calls `send_message_to_appchain` on the L2 piltover core. The
+//!   appchain's messaging collector relays it into the `msg_handler_value` l1-handler, which lands
+//!   in an L3 block that must settle.
+//! - **L2 → L1:** [`send_l2_to_l1`] makes the appchain emit `send_message_to_l1`.
+//!
+//! **Regression target:** saya-tee must hash L1→L2 messages with the Poseidon
+//! formula Katana commits to. If it uses the Ethereum `keccak256` formula,
+//! piltover's `update_state` rejects the L1→L2-bearing block with
+//! `'tee: invalid messages'` and settlement stalls — caught by the
+//! [`crate::assertions::wait_for_settlement`] that follows, timing out.
+
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use katana_primitives::class::ContractClass;
+use katana_primitives::utils::get_contract_address;
+use katana_primitives::{ContractAddress, Felt};
+use katana_rpc_types::RpcSierraContractClass;
+use starknet::accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+use starknet::contract::ContractFactory;
+use starknet::core::types::{BlockId, BlockTag, Call, FlattenedSierraClass};
+use starknet::macros::{felt, selector};
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::{JsonRpcClient, Provider};
+use starknet::signers::{LocalWallet, SigningKey};
+
+use crate::nodes::{L2InProcess, L3InProcess};
+
+/// Prebuilt sierra class exposing the `msg_handler_value` `#[l1_handler]` and a
+/// `send_message` entrypoint (which calls `send_message_to_l1`).
+const MSG_HANDLER_SIERRA: &str =
+    "crates/contracts/build/katana_messaging_contract_msg_starknet.contract_class.json";
+
+/// Deterministic deploy salt for the l1-handler contract on the appchain.
+const DEPLOY_SALT: Felt = felt!("0x1337");
+
+/// The value `msg_handler_value` asserts it receives (`assert(value == 888)`).
+const HANDLER_VALUE: Felt = felt!("888");
+
+/// Declares + deploys the `contract_msg_starknet` l1-handler contract on the
+/// appchain and returns its address. Mirrors how the contract would be deployed
+/// in practice (runtime declare+deploy via UDC), since rollup genesis only
+/// deploys account allocations.
+pub async fn deploy_msg_handler(l3: &L3InProcess) -> Result<Felt> {
+    let json = std::fs::read_to_string(MSG_HANDLER_SIERRA)
+        .with_context(|| format!("reading {MSG_HANDLER_SIERRA}"))?;
+    let class =
+        ContractClass::from_str(&json).map_err(|e| anyhow!("parse msg-handler sierra: {e}"))?;
+    let class_hash = class.class_hash().context("compute sierra class hash")?;
+    let casm_hash = class.clone().compile().context("compile sierra->casm")?.class_hash()?;
+
+    let sierra = class.to_sierra().ok_or_else(|| anyhow!("not a sierra class"))?;
+    let flattened = FlattenedSierraClass::try_from(RpcSierraContractClass::from(sierra))
+        .context("flatten sierra class")?;
+
+    let account = l3.account();
+
+    let declare = account
+        .declare_v3(flattened.into(), casm_hash)
+        .send()
+        .await
+        .context("declare msg-handler")?;
+    wait_for_tx(&l3.provider(), declare.transaction_hash).await?;
+
+    // No constructor args; non-unique so the address is salt+class deterministic.
+    // `new` uses the legacy UDC, which Katana's dev genesis predeploys.
+    #[allow(deprecated)]
+    let factory = ContractFactory::new(class_hash, &account);
+    let deploy = factory
+        .deploy_v3(Vec::new(), DEPLOY_SALT, false)
+        .send()
+        .await
+        .context("deploy msg-handler")?;
+    wait_for_tx(&l3.provider(), deploy.transaction_hash).await?;
+
+    Ok(get_contract_address(DEPLOY_SALT, class_hash, &[], ContractAddress::ZERO))
+}
+
+/// Current L3 block height (settlement target baseline).
+pub async fn current_tip(l3: &L3InProcess) -> Result<u64> {
+    l3.provider().block_number().await.context("fetch L3 tip")
+}
+
+/// L1 → L2: send a message from the L2 piltover core to the appchain's
+/// `msg_handler_value` l1-handler. The appchain collector relays it.
+pub async fn send_l1_to_l2(l2: &L2InProcess, piltover: Felt, handler: Felt) -> Result<()> {
+    let account = l2_account(l2).await?;
+    // send_message_to_appchain(to_address, selector, payload: Span<felt252>)
+    // serializes as [to_address, selector, payload_len, ...payload].
+    let call = Call {
+        to: piltover,
+        selector: selector!("send_message_to_appchain"),
+        calldata: vec![handler, selector!("msg_handler_value"), Felt::ONE, HANDLER_VALUE],
+    };
+    let res =
+        account.execute_v3(vec![call]).send().await.context("invoke send_message_to_appchain")?;
+    wait_for_tx(&l2.provider(), res.transaction_hash).await
+}
+
+/// L2 → L1: have the appchain contract emit `send_message_to_l1`.
+pub async fn send_l2_to_l1(l3: &L3InProcess, handler: Felt) -> Result<()> {
+    let account = l3.account();
+    // send_message(to_address, value) -> send_message_to_l1_syscall('MSG', [to, value])
+    let call = Call {
+        to: handler,
+        selector: selector!("send_message"),
+        calldata: vec![felt!("0x1"), HANDLER_VALUE],
+    };
+    let res = account.execute_v3(vec![call]).send().await.context("invoke send_message")?;
+    wait_for_tx(&l3.provider(), res.transaction_hash).await
+}
+
+/// Waits until the appchain mines a block past `prev_tip` — i.e. the relayed
+/// l1-handler tx has been included. Returns the new tip.
+pub async fn wait_for_relay(l3: &L3InProcess, prev_tip: u64, timeout: Duration) -> Result<u64> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let tip = current_tip(l3).await?;
+        if tip > prev_tip {
+            return Ok(tip);
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "appchain did not relay/mine the l1-handler within {timeout:?} (still at block \
+                 {prev_tip})"
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Builds a `SingleOwnerAccount` for the L2 prefunded dev account.
+async fn l2_account(
+    l2: &L2InProcess,
+) -> Result<SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>> {
+    let provider = l2.provider();
+    let chain_id = provider.chain_id().await.context("fetch L2 chain id")?;
+    let (address, private_key) = l2.prefunded_account_keys();
+    let signer = LocalWallet::from_signing_key(SigningKey::from_secret_scalar(private_key));
+    let mut account =
+        SingleOwnerAccount::new(provider, signer, address, chain_id, ExecutionEncoding::New);
+    account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
+    Ok(account)
+}
+
+async fn wait_for_tx(provider: &JsonRpcClient<HttpTransport>, tx_hash: Felt) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match provider.get_transaction_receipt(tx_hash).await {
+            Ok(_) => return Ok(()),
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            Err(e) => return Err(anyhow!("tx {tx_hash:#x} not accepted: {e}")),
+        }
+    }
+}

--- a/tests/saya-tee/src/nodes.rs
+++ b/tests/saya-tee/src/nodes.rs
@@ -94,7 +94,11 @@ impl L3InProcess {
 /// Spawns the L2 settlement Katana as an in-process `TestNode` on the standard dev chain spec
 /// (`ChainId::SEPOLIA`, `fee: false`) — equivalent to `katana --dev --dev.no-fee`.
 pub async fn spawn_l2() -> L2InProcess {
-    let config = katana_utils::node::test_config();
+    let mut config = katana_utils::node::test_config();
+    // The L3 messaging collector fetches `MessageSent` events from this node with
+    // `chunk_size = 200`; `test_config` caps `max_event_page_size` at 100, which
+    // would reject the query. Raise it so the L1->L2 relay can run.
+    config.rpc.max_event_page_size = Some(1024);
     L2InProcess { inner: TestNode::new_with_config(config).await }
 }
 
@@ -136,7 +140,7 @@ pub async fn spawn_l3(l2: &L2InProcess, piltover_address: Felt) -> L3InProcess {
     let settlement = SettlementLayer::Starknet {
         block: 0,
         id: l2_chain_id,
-        rpc_url: l2_url,
+        rpc_url: l2_url.clone(),
         core_contract: piltover_address.into(),
         proof_kind: SettlementProofKind::Tee,
     };
@@ -151,6 +155,18 @@ pub async fn spawn_l3(l2: &L2InProcess, piltover_address: Felt) -> L3InProcess {
     let mut config = katana_utils::node::test_config();
     config.chain = Arc::new(ChainSpec::Rollup(l3_chain));
     config.tee = Some(TeeConfig { provider_type: TeeProviderType::Mock, fork_block_number: None });
+    // Enable the inbound messaging collector so L1->L2 messages sent on L2's
+    // piltover core are relayed into L3 as L1-handler txs — letting the messaging
+    // regression settle a block that actually consumes a cross-chain message.
+    config.messaging = Some(katana_messaging::MessagingConfig {
+        settlement: katana_messaging::SettlementChainConfig::Starknet {
+            rpc_url: l2_url,
+            contract_address: piltover_address.into(),
+        },
+        interval: 1,
+        from_block: 0,
+        confirmation_depth: 0,
+    });
     // Note: rollup chain specs (provable mode) never produce empty blocks
     // even with `block_time` set, per the upstream Saya README. The L3 only
     // advances when transactions are submitted; we drive that explicitly


### PR DESCRIPTION
## What

Adds a regression phase to the persistent-TEE e2e (`tests/saya-tee`) that settles blocks which actually **carry cross-chain messages** — in both directions.

The existing harness only drives plain transfer blocks, so its `messages_commitment` is always over an empty message set. That's why a real bug went uncaught: saya hashed L1→L2 messages with the Ethereum `keccak256` formula instead of the Poseidon hash Katana commits to, so any settled block that consumes an L1→L2 message is rejected by piltover with `'tee: invalid messages'` and settlement stalls.

## How

After the existing plain-block loop, the test:
1. declares + deploys the `contract_msg_starknet` l1-handler on the appchain;
2. **L1→L2:** calls `send_message_to_appchain` on the L2 piltover core, lets the appchain messaging collector relay it into an l1-handler tx, then asserts the block settles;
3. **L2→L1:** emits `send_message_to_l1` from the appchain, then asserts the block settles.

Supporting harness changes: enable the messaging collector on the L3 node (`config.messaging`), and raise the L2 node's `max_event_page_size` (the collector queries with `chunk_size = 200`; `test_config` capped it at 100).

## Verification

- **Green** against a Poseidon-hashing `saya-tee`: both message blocks settle, test passes.
- **Red** against a keccak-hashing `saya-tee`: the L1→L2 message block fails `'tee: invalid messages'`, piltover stalls, the settlement assertion times out.

## Note

This guards the fix in **saya** (dojoengine/saya#77). Until that lands, building `saya-tee` from saya `main` (pre-fix) makes this test correctly fail — so this should merge after the saya fix is available to CI.
