### PR TITLE
feat(rpc): intercept `starknet_simulateTransactions` in cartridge middleware

### DIFF
--- a/crates/rpc/rpc-server/src/middleware/cartridge/controller_deployment.rs
+++ b/crates/rpc/rpc-server/src/middleware/cartridge/controller_deployment.rs
@@ -19,7 +19,8 @@ use katana_provider::{ProviderFactory, ProviderRO};
 use katana_rpc_api::error::cartridge::CartridgeApiError;
 use katana_rpc_api::error::starknet::StarknetApiError;
 use katana_rpc_types::broadcasted::{BroadcastedTx, BroadcastedTxWithChainId};
-use katana_rpc_types::{BroadcastedInvokeTx, FeeEstimate};
+use katana_rpc_types::trace::SimulatedTransactionsResponse;
+use katana_rpc_types::{BroadcastedInvokeTx, FeeEstimate, SimulationFlag};
 use starknet::core::types::SimulationFlagForEstimateFee;
 use starknet::macros::selector;
 use starknet::signers::local_wallet::SignError;
@@ -29,8 +30,9 @@ use tracing::{debug, trace};
 
 use super::utils::{
     parse_params, AddExecuteOutsideParams, AddExecuteOutsideRequestParams, EstimateFeeParams,
-    EstimateFeeRequestParams, CARTRIDGE_ADD_EXECUTE_FROM_OUTSIDE,
-    CARTRIDGE_ADD_EXECUTE_FROM_OUTSIDE_TX, STARKNET_ESTIMATE_FEE,
+    EstimateFeeRequestParams, SimulateTransactionsParams, SimulateTransactionsRequestParams,
+    CARTRIDGE_ADD_EXECUTE_FROM_OUTSIDE, CARTRIDGE_ADD_EXECUTE_FROM_OUTSIDE_TX,
+    STARKNET_ESTIMATE_FEE, STARKNET_SIMULATE_TRANSACTIONS,
 };
 use crate::cartridge::encode_calls;
 use crate::starknet::{PendingBlockProvider, StarknetApi};
@@ -177,6 +179,23 @@ where
         Ok(new_request)
     }
 
+    fn build_simulate_transactions_request<'a>(
+        request: &Request<'a>,
+        block_id: BlockIdOrTag,
+        transactions: Vec<BroadcastedTx>,
+        simulation_flags: Vec<SimulationFlag>,
+    ) -> Result<Request<'a>, CartridgeApiError> {
+        let params = rpc_params!(block_id, transactions, simulation_flags);
+        let params = params
+            .to_rpc_params()
+            .map_err(|err| CartridgeApiError::ControllerDeployment { error: Box::new(err) })?;
+
+        let mut new_request = request.clone();
+        new_request.params = params.map(Cow::Owned);
+
+        Ok(new_request)
+    }
+
     async fn starknet_estimate_fee<'a>(
         &self,
         params: EstimateFeeParams,
@@ -184,6 +203,18 @@ where
     ) -> S::MethodResponse {
         let request_id = request.id().clone();
         match self.starknet_estimate_fee_inner(params, request).await {
+            Ok(response) => response,
+            Err(err) => MethodResponse::error(request_id, ErrorObjectOwned::from(err)),
+        }
+    }
+
+    async fn starknet_simulate_transactions<'a>(
+        &self,
+        params: SimulateTransactionsParams,
+        request: Request<'a>,
+    ) -> S::MethodResponse {
+        let request_id = request.id().clone();
+        match self.starknet_simulate_transactions_inner(params, request).await {
             Ok(response) => response,
             Err(err) => MethodResponse::error(request_id, ErrorObjectOwned::from(err)),
         }
@@ -273,6 +304,90 @@ where
 
                 let og_estimates = estimates[deploy_txs_len..].to_vec();
                 let payload = ResponsePayload::success(og_estimates);
+
+                Ok(MethodResponse::response(request.id().clone(), payload.into(), usize::MAX))
+            }
+
+            ResponsePayload::Error(..) => Ok(response),
+        }
+    }
+
+    async fn starknet_simulate_transactions_inner<'a>(
+        &self,
+        params: SimulateTransactionsParams,
+        request: Request<'a>,
+    ) -> Result<S::MethodResponse, CartridgeApiError> {
+        let SimulateTransactionsParams { block_id, simulation_flags, transactions } = params;
+        let candidate_addresses =
+            self.estimate_fee_candidate_addresses(block_id, &transactions).await?;
+
+        let deployer_nonce = self
+            .context
+            .starknet
+            .nonce_at(block_id, self.context.deployer_address)
+            .await
+            .map_err(|err| CartridgeApiError::ControllerDeployment { error: Box::new(err) })?;
+
+        let deploy_controller_txs = self
+            .get_controller_deployment_txs(candidate_addresses, deployer_nonce)
+            .await
+            .map_err(|err| CartridgeApiError::ControllerDeployment { error: Box::new(err) })?;
+
+        // No Controller to deploy, simply forward the request.
+        if deploy_controller_txs.is_empty() {
+            trace!(target: "middleware::cartridge", "No controller to deploy - forwarding request.");
+            return Ok(self.service.call(request).await);
+        }
+
+        let og_txs_len = transactions.len();
+        let deploy_txs_len = deploy_controller_txs.len();
+        trace!(target: "middleware::cartridge", deployment_count = deploy_txs_len, "Prepending controller deployment transactions to simulate transactions.");
+
+        // Build a new simulateTransactions request with the deploy controller transactions
+        // prepended.
+        let new_simulate_txs = [deploy_controller_txs, transactions].concat();
+        let updated_request = Self::build_simulate_transactions_request(
+            &request,
+            block_id,
+            new_simulate_txs,
+            simulation_flags,
+        )?;
+
+        // Call the inner service with the updated request.
+        let response = self.service.call(updated_request).await;
+
+        // IMPORTANT:
+        //
+        // Beyond this point, we assume the response is a valid starknet_simulateTransactions
+        // response. It's up to the devs to make sure this middleware is wrapped around valid
+        // Starknet JSON-RPC service and no other middlewares are installed that modify the
+        // response body.
+
+        // Extract the response body to remove the simulation results for the deploy controller
+        // transactions before returning the response to the caller.
+        //
+        // This is done to respect the semantics of the starknet_simulateTransactions response,
+        // which specifies that the results are only for transactions that are included in the
+        // original request.
+        let response_body = response.as_json().get();
+        let res =
+            serde_json::from_str::<Response<'_, SimulatedTransactionsResponse>>(response_body)
+                .map_err(|err| CartridgeApiError::ControllerDeployment { error: Box::new(err) })?;
+
+        match res.payload {
+            ResponsePayload::Success(simulated) => {
+                let results_len = simulated.transactions.len();
+                let new_txs_len = deploy_txs_len + og_txs_len;
+                assert_eq!(
+                    results_len, new_txs_len,
+                    "unexpected simulateTransactions response length: expected {new_txs_len}, got \
+                     {results_len}"
+                );
+
+                let og_results = simulated.transactions[deploy_txs_len..].to_vec();
+                let payload = ResponsePayload::success(SimulatedTransactionsResponse {
+                    transactions: og_results,
+                });
 
                 Ok(MethodResponse::response(request.id().clone(), payload.into(), usize::MAX))
             }
@@ -440,6 +555,15 @@ where
                         .inspect_err(|error| debug!(target: "middleware::cartridge", %method, %error, "Failed to parse params."))
                     {
                         return this.starknet_estimate_fee(params.into(), request).await;
+                    }
+                }
+
+                STARKNET_SIMULATE_TRANSACTIONS => {
+                    trace!(target: "middleware::cartridge::controller", %method, "Intercepting JSON-RPC method.");
+                    if let Ok(params) = parse_params::<SimulateTransactionsRequestParams>(&request)
+                        .inspect_err(|error| debug!(target: "middleware::cartridge", %method, %error, "Failed to parse params."))
+                    {
+                        return this.starknet_simulate_transactions(params.into(), request).await;
                     }
                 }
 

--- a/crates/rpc/rpc-server/src/middleware/cartridge/utils.rs
+++ b/crates/rpc/rpc-server/src/middleware/cartridge/utils.rs
@@ -2,12 +2,13 @@ use jsonrpsee::types::{ErrorObjectOwned, Request};
 use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::{ContractAddress, Felt};
 use katana_rpc_types::broadcasted::BroadcastedTx;
-use katana_rpc_types::{FeeSource, OutsideExecution};
+use katana_rpc_types::{FeeSource, OutsideExecution, SimulationFlag};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use starknet::core::types::SimulationFlagForEstimateFee;
 
 pub(super) const STARKNET_ESTIMATE_FEE: &str = "starknet_estimateFee";
+pub(super) const STARKNET_SIMULATE_TRANSACTIONS: &str = "starknet_simulateTransactions";
 pub(super) const CARTRIDGE_ADD_EXECUTE_FROM_OUTSIDE: &str = "cartridge_addExecuteFromOutside";
 pub(super) const CARTRIDGE_ADD_EXECUTE_FROM_OUTSIDE_TX: &str =
     "cartridge_addExecuteOutsideTransaction";
@@ -86,6 +87,40 @@ impl From<EstimateFeeRequestParams> for EstimateFeeParams {
             EstimateFeeRequestParams::Named(params) => params,
             EstimateFeeRequestParams::Positional(params) => {
                 Self { transactions: params.0, simulation_flags: params.1, block_id: params.2 }
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub(super) struct SimulateTransactionsParams {
+    #[serde(alias = "blockId")]
+    pub block_id: BlockIdOrTag,
+    pub transactions: Vec<BroadcastedTx>,
+    #[serde(alias = "simulationFlags")]
+    pub simulation_flags: Vec<SimulationFlag>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct SimulateTransactionsPositionalParams(
+    BlockIdOrTag,
+    Vec<BroadcastedTx>,
+    Vec<SimulationFlag>,
+);
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(super) enum SimulateTransactionsRequestParams {
+    Named(SimulateTransactionsParams),
+    Positional(SimulateTransactionsPositionalParams),
+}
+
+impl From<SimulateTransactionsRequestParams> for SimulateTransactionsParams {
+    fn from(value: SimulateTransactionsRequestParams) -> Self {
+        match value {
+            SimulateTransactionsRequestParams::Named(params) => params,
+            SimulateTransactionsRequestParams::Positional(params) => {
+                Self { block_id: params.0, transactions: params.1, simulation_flags: params.2 }
             }
         }
     }

--- a/crates/rpc/rpc-server/src/middleware/tests/controller_deployment.rs
+++ b/crates/rpc/rpc-server/src/middleware/tests/controller_deployment.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use jsonrpsee::MethodResponse;
 use katana_pool::api::TransactionPool;
 use katana_primitives::felt;
-use katana_rpc_types::FeeEstimate;
+use katana_rpc_types::{FeeEstimate, SimulatedTransactionsResponse};
 use katana_utils::arbitrary;
 use serde::de::DeserializeOwned;
 use serde_json::json;
@@ -347,6 +347,181 @@ async fn passthrough_malformed_estimate_fee() {
     assert_eq!(calls_count, 0);
 }
 
+/// ## Case:
+///
+/// The sender address 0x1 is already deployed and requires no extra deployment.
+///
+/// ## Expected:
+///
+/// The request is forwarded unchanged and the response is passed through.
+#[tokio::test(flavor = "multi_thread")]
+async fn simulate_transactions_forwards_when_deployed_account() {
+    let expected = SimulatedTransactionsResponse {
+        transactions: vec![make_simulated_tx(arbitrary!(FeeEstimate))],
+    };
+
+    let rpc_responses = HashMap::from_iter([("starknet_simulateTransactions", expected.clone())]);
+    let test = setup_simulate_test(HashMap::new(), rpc_responses).await;
+
+    let tx = make_invoke_tx(DEPLOYER_ADDRESS);
+    let response = test.call("starknet_simulateTransactions", &json!(["latest", [tx], []])).await;
+
+    // If it is deployed, a getAccountCalldata request should not be made.
+    assert!(!test.mock_api_state.has_get_account_calldata_request(DEPLOYER_ADDRESS));
+
+    let calls = test.rpc.simulate_transactions_calls();
+    assert_eq!(calls.len(), 1, "expected only one call to simulateTransactions");
+    assert_eq!(calls[0].tx_count, 1, "rpc service should get 1 tx (no deploy)");
+
+    let actual: SimulatedTransactionsResponse = get_result(response);
+    assert_eq!(actual, expected, "response is passed through as is");
+}
+
+/// ## Case:
+///
+/// Address 0xDEAD is not yet deployed and belongs to a Controller account.
+///
+/// ## Expected:
+///
+/// The middleware prepends a deploy transaction to the simulate request and returns the
+/// simulation results for the original transactions only.
+#[tokio::test(flavor = "multi_thread")]
+async fn simulate_transactions_prepends_deploy_tx_for_controller() {
+    let cartridge_responses = HashMap::from_iter([(
+        CONTROLLER_ADDRESS,
+        controller_calldata_response(CONTROLLER_ADDRESS),
+    )]);
+
+    // The rpc service will receive 2 txs (1 deploy + 1 original).
+    let expected = SimulatedTransactionsResponse {
+        transactions: vec![
+            make_simulated_tx(arbitrary!(FeeEstimate)), // prepended controller deploy tx
+            make_simulated_tx(arbitrary!(FeeEstimate)),
+        ],
+    };
+    let rpc_responses = HashMap::from_iter([("starknet_simulateTransactions", expected.clone())]);
+
+    let test = setup_simulate_test(cartridge_responses, rpc_responses).await;
+
+    let tx = make_invoke_tx(CONTROLLER_ADDRESS);
+    let response = test.call("starknet_simulateTransactions", &json!(["latest", [tx], []])).await;
+
+    // If it is undeployed, a getAccountCalldata request should be made.
+    assert!(test.mock_api_state.has_get_account_calldata_request(CONTROLLER_ADDRESS));
+
+    let calls = test.rpc.simulate_transactions_calls();
+    assert_eq!(calls.len(), 1, "expected only one call to simulateTransactions");
+    assert_eq!(calls[0].tx_count, 2, "rpc service should receive 2 txs (deploy + original)");
+
+    // The middleware should remove the deploy tx result and return only the original tx result
+    // before sending it back to the caller.
+    let actual: SimulatedTransactionsResponse = get_result(response);
+
+    assert_eq!(actual.transactions.len(), 1, "response should have 1 result for the original tx");
+    assert_eq!(actual.transactions[..], expected.transactions[1..]);
+}
+
+/// ## Case:
+///
+/// Address 0xBEEF is not deployed and the Cartridge API does not recognize it as a Controller.
+///
+/// ## Expected:
+///
+/// Even though the address is undeployed, no deploy transaction is created and the original
+/// request is forwarded unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn simulate_transactions_forwards_for_undeployed_non_controller() {
+    let expected = SimulatedTransactionsResponse {
+        transactions: vec![make_simulated_tx(arbitrary!(FeeEstimate))],
+    };
+    let rpc_responses = HashMap::from_iter([("starknet_simulateTransactions", expected.clone())]);
+
+    let test = setup_simulate_test(HashMap::new(), rpc_responses).await;
+
+    let tx = make_invoke_tx(NON_CONTROLLER_ADDRESS);
+    let response = test.call("starknet_simulateTransactions", &json!(["latest", [tx], []])).await;
+
+    // If it is undeployed, a getAccountCalldata request should be made regardless if it's a
+    // Controller or not.
+    assert!(test.mock_api_state.has_get_account_calldata_request(NON_CONTROLLER_ADDRESS));
+
+    let calls = test.rpc.simulate_transactions_calls();
+    assert_eq!(calls.len(), 1, "expected only one call to simulateTransactions");
+    assert_eq!(calls[0].tx_count, 1, "rpc service should get 1 tx (no deploy)");
+
+    let actual: SimulatedTransactionsResponse = get_result(response);
+    assert_eq!(actual, expected, "response is passed through as is");
+}
+
+/// ## Case:
+///
+/// Three invoke transactions all from undeployed Controller address 0xDEAD.
+///
+/// ## Expected:
+///
+/// The middleware deduplicates by sender address, creating only one deploy transaction despite
+/// three transactions from the same sender.
+///
+/// Inner service receives 4 txs (1 deploy + 3 original); middleware returns 3 results.
+#[tokio::test(flavor = "multi_thread")]
+async fn simulate_transactions_deduplicates_same_controller() {
+    let expected = SimulatedTransactionsResponse {
+        transactions: vec![
+            make_simulated_tx(arbitrary!(FeeEstimate)), // prepended controller deploy tx
+            make_simulated_tx(arbitrary!(FeeEstimate)),
+            make_simulated_tx(arbitrary!(FeeEstimate)),
+            make_simulated_tx(arbitrary!(FeeEstimate)),
+        ],
+    };
+
+    let cartridge_responses = HashMap::from_iter([(
+        CONTROLLER_ADDRESS,
+        controller_calldata_response(CONTROLLER_ADDRESS),
+    )]);
+
+    // rpc service receives 4 txs (1 deploy + 3 original).
+    let rpc_responses = HashMap::from_iter([("starknet_simulateTransactions", expected.clone())]);
+
+    let setup = setup_simulate_test(cartridge_responses, rpc_responses).await;
+
+    let tx1 = make_invoke_tx(CONTROLLER_ADDRESS);
+    let tx2 = make_invoke_tx(CONTROLLER_ADDRESS);
+    let tx3 = make_invoke_tx(CONTROLLER_ADDRESS);
+    let res =
+        setup.call("starknet_simulateTransactions", &json!(["latest", [tx1, tx2, tx3], []])).await;
+
+    // If it is undeployed, a getAccountCalldata request should be made.
+    assert!(setup.mock_api_state.has_get_account_calldata_request(CONTROLLER_ADDRESS));
+
+    let calls = setup.rpc.simulate_transactions_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].tx_count, 4, "rpc service should get 4 txs (1 deploy + 3 og)");
+
+    let actual: SimulatedTransactionsResponse = get_result(res);
+    assert_eq!(actual.transactions.len(), 3, "response should not include the deploy tx result");
+    assert_eq!(actual.transactions[..], expected.transactions[1..]);
+}
+
+/// ## Case:
+///
+/// When starknet_simulateTransactions is called with malformed params, the middleware should
+/// gracefully fall through to the inner service rather than erroring.
+///
+/// ## Expected:
+///
+/// Inner service receives request unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn passthrough_malformed_simulate_transactions() {
+    let setup = setup_simulate_test(HashMap::new(), HashMap::new()).await;
+
+    // Malformed params — not a valid [block_id, transactions, flags] sequence.
+    setup.call("starknet_simulateTransactions", &json!(["not_valid"])).await;
+
+    // The inner service should have received the request (fallthrough).
+    let calls = setup.rpc.simulate_transactions_calls();
+    assert_eq!(calls.len(), 1);
+}
+
 mod setup {
     use std::collections::HashMap;
     use std::future::Future;
@@ -440,6 +615,23 @@ mod setup {
         cartridge_api_responses: HashMap<ContractAddress, GetAccountCalldataResponse>,
         inner_rpc_responses: HashMap<&'static str, Vec<FeeEstimate>>,
     ) -> TestSetup {
+        let mock_rpc = MockRpcService::new(inner_rpc_responses);
+        setup_test_with_mock(cartridge_api_responses, mock_rpc).await
+    }
+
+    pub async fn setup_simulate_test(
+        cartridge_api_responses: HashMap<ContractAddress, GetAccountCalldataResponse>,
+        inner_simulate_responses: HashMap<&'static str, SimulatedTransactionsResponse>,
+    ) -> TestSetup {
+        let mock_rpc =
+            MockRpcService::new(HashMap::new()).with_simulate_responses(inner_simulate_responses);
+        setup_test_with_mock(cartridge_api_responses, mock_rpc).await
+    }
+
+    async fn setup_test_with_mock(
+        cartridge_api_responses: HashMap<ContractAddress, GetAccountCalldataResponse>,
+        mock_rpc: MockRpcService,
+    ) -> TestSetup {
         let (mock_url, mock_api_state) = start_mock_cartridge_api(cartridge_api_responses).await;
 
         let chain_spec = Arc::new(ChainSpec::dev());
@@ -483,7 +675,6 @@ mod setup {
             deployer_private_key,
         );
 
-        let mock_rpc = MockRpcService::new(inner_rpc_responses);
         let service = layer.layer(mock_rpc.clone());
 
         TestSetup { controller_deployment_service: service, rpc: mock_rpc, mock_api_state, pool }
@@ -525,6 +716,24 @@ mod setup {
             fee_data_availability_mode: DataAvailabilityMode::L1,
             is_query: false,
         })
+    }
+
+    /// Creates a simulated transaction result with the given fee estimate. The trace is a
+    /// minimal reverted invoke trace — the middleware only cares about the number of results, not
+    /// their contents.
+    pub fn make_simulated_tx(fee_estimation: FeeEstimate) -> SimulatedTransactions {
+        SimulatedTransactions {
+            transaction_trace: TxTrace::Invoke(InvokeTxTrace {
+                execute_invocation: ExecuteInvocation::Reverted(RevertedInvocation {
+                    revert_reason: String::new(),
+                }),
+                validate_invocation: None,
+                fee_transfer_invocation: None,
+                state_diff: None,
+                execution_resources: ExecutionResources { l1_gas: 0, l2_gas: 0, l1_data_gas: 0 },
+            }),
+            fee_estimation,
+        }
     }
 
     pub fn make_execute_outside() -> OutsideExecution {
@@ -684,6 +893,11 @@ mod setup {
         pub tx_count: usize,
     }
 
+    #[derive(Clone, Debug, Default)]
+    pub struct SimulateTransactionsRecordedCall {
+        pub tx_count: usize,
+    }
+
     #[derive(Clone, Debug)]
     pub struct OutsideExecuteRecordedCall {
         pub outside_execution: OutsideExecution,
@@ -696,11 +910,14 @@ mod setup {
 
     #[derive(Clone, Default)]
     pub struct MockRpcService {
-        /// Pre-configured response JSON per method name.
+        /// Pre-configured `starknet_estimateFee` response per method name.
         responses: Arc<HashMap<&'static str, Vec<FeeEstimate>>>,
+        /// Pre-configured `starknet_simulateTransactions` response per method name.
+        simulate_responses: Arc<HashMap<&'static str, SimulatedTransactionsResponse>>,
 
         any_calls: Arc<Mutex<HashMap<String, Vec<AnyRecordedCall>>>>,
         estimate_fee_calls: Arc<Mutex<Vec<EstimateFeeRecordedCall>>>,
+        simulate_transactions_calls: Arc<Mutex<Vec<SimulateTransactionsRecordedCall>>>,
         outside_execute_calls: Arc<Mutex<Vec<(ContractAddress, OutsideExecuteRecordedCall)>>>,
     }
 
@@ -709,8 +926,20 @@ mod setup {
             Self { responses: Arc::new(responses), ..Default::default() }
         }
 
+        pub fn with_simulate_responses(
+            mut self,
+            responses: HashMap<&'static str, SimulatedTransactionsResponse>,
+        ) -> Self {
+            self.simulate_responses = Arc::new(responses);
+            self
+        }
+
         pub fn estimate_fee_calls(&self) -> Vec<EstimateFeeRecordedCall> {
             self.estimate_fee_calls.lock().clone()
+        }
+
+        pub fn simulate_transactions_calls(&self) -> Vec<SimulateTransactionsRecordedCall> {
+            self.simulate_transactions_calls.lock().clone()
         }
 
         pub fn outside_execute_calls_count(&self) -> usize {
@@ -758,6 +987,21 @@ mod setup {
                     self.estimate_fee_calls.lock().push(EstimateFeeRecordedCall { tx_count });
                 }
 
+                "starknet_simulateTransactions" => {
+                    // Params are positional: [block_id, transactions, simulation_flags]. The txs
+                    // are the second element, so skip the block_id first.
+                    let params = request.params();
+                    let mut seq = params.sequence();
+
+                    let _block_id: Result<serde_json::Value, _> = seq.next();
+                    let txs: Result<Vec<serde_json::Value>, _> = seq.next();
+                    let tx_count = txs.ok().map(|v| v.len()).unwrap_or(0);
+
+                    self.simulate_transactions_calls
+                        .lock()
+                        .push(SimulateTransactionsRecordedCall { tx_count });
+                }
+
                 "cartridge_addExecuteFromOutside" | "cartridge_addExecuteOutsideTransaction" => {
                     #[derive(Deserialize)]
                     struct NamedAddExecuteOutsideParams {
@@ -768,10 +1012,7 @@ mod setup {
                     }
 
                     fn parse_params<T: DeserializeOwned>(request: &Request<'_>) -> Option<T> {
-                        match request.params().parse() {
-                            Ok(params) => Some(params),
-                            Err(..) => None,
-                        }
+                        request.params().parse().ok()
                     }
 
                     let NamedAddExecuteOutsideParams {
@@ -796,7 +1037,13 @@ mod setup {
                 }
             }
 
-            let response = if let Some(resp) = self.responses.get(method.as_str()) {
+            let response = if let Some(resp) = self.simulate_responses.get(method.as_str()) {
+                MethodResponse::response(
+                    request.id().clone(),
+                    jsonrpsee::ResponsePayload::success(resp.clone()),
+                    usize::MAX,
+                )
+            } else if let Some(resp) = self.responses.get(method.as_str()) {
                 MethodResponse::response(
                     request.id().clone(),
                     jsonrpsee::ResponsePayload::success(resp.clone()),


### PR DESCRIPTION
The cartridge controller-deployment middleware already intercepts `starknet_estimateFee` to transparently deploy Controller accounts that haven't been deployed yet, so that fee estimation succeeds for transactions sent from those senders. This applies the same treatment to `starknet_simulateTransactions`.

When a simulate request includes transactions from an undeployed Controller sender, the middleware prepends the corresponding Controller deployment transactions, forwards the augmented request, then strips the synthetic deployment results from the response so the caller only sees results for the transactions it actually submitted. Note that `simulateTransactions` uses a different positional parameter order (`block_id, transactions, simulation_flags`) and a distinct simulation-flag type from `estimateFee`, both of which are handled in the new param plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)