### PR TITLE
fix(chain-spec): close nonce gap that drops preloaded genesis declares (#586)

### DIFF
--- a/crates/chain-spec/src/rollup/utils.rs
+++ b/crates/chain-spec/src/rollup/utils.rs
@@ -113,15 +113,21 @@ impl<'c> GenesisTransactionsBuilder<'c> {
     }
 
     fn declare(&self, class: ContractClass) -> ClassHash {
-        let nonce = self.master_nonce.replace_with(|&mut n| n + Felt::ONE);
-        let sender_address = *self.master_address.get().expect("must be initialized first");
-
         let class_hash = class.class_hash().unwrap();
 
-        // No need to declare the same class if it was already declared.
-        if self.declared_classes.borrow_mut().contains(&class_hash) {
+        // No need to declare the same class if it was already declared. This check must
+        // come *before* consuming a nonce: a dedup hit that still bumped `master_nonce`
+        // would leave a gap in the master account's nonce sequence, making every
+        // subsequent genesis declare tx fail with `InvalidNonce`. This bites classes
+        // preloaded via `--cartridge.controllers`: their hashes sort after the
+        // already-declared Account/UDC classes, so a dedup-induced gap aborts the
+        // controller declares and they never land at their canonical class hash.
+        if self.declared_classes.borrow().contains(&class_hash) {
             return class_hash;
         }
+
+        let nonce = self.master_nonce.replace_with(|&mut n| n + Felt::ONE);
+        let sender_address = *self.master_address.get().expect("must be initialized first");
 
         let compiled_class_hash = class.clone().compile().unwrap().class_hash().unwrap();
 

--- a/crates/chain-spec/tests/rollup.rs
+++ b/crates/chain-spec/tests/rollup.rs
@@ -83,6 +83,53 @@ fn valid_transactions() {
 }
 
 #[test]
+fn controller_class_queryable_at_canonical_hash_after_genesis() {
+    use katana_contracts::controller::{ControllerLatest, ControllerV108};
+    use katana_genesis::json::GenesisJson;
+
+    const CANONICAL_LATEST: Felt = Felt::from_hex_unchecked(
+        "0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf",
+    );
+    const CANONICAL_V108: Felt = Felt::from_hex_unchecked(
+        "0x511dd75da368f5311134dee2356356ac4da1538d2ad18aa66d57c47e3757d59",
+    );
+
+    let mut chain_spec = chain_spec(1, true);
+    chain_spec
+        .genesis
+        .classes
+        .insert(ControllerLatest::HASH, ControllerLatest::CLASS.clone().into());
+    chain_spec.genesis.classes.insert(ControllerV108::HASH, ControllerV108::CLASS.clone().into());
+
+    // Simulate `katana init rollup` -> genesis.json -> node reload.
+    let json = GenesisJson::try_from(chain_spec.genesis.clone()).unwrap();
+    chain_spec.genesis = Genesis::try_from(json).unwrap();
+
+    let provider = DbProviderFactory::new_in_memory();
+    let provider = provider.provider();
+    let ef = executor(chain_spec.clone());
+
+    let state = PreloadedStateProvider::new(provider.latest().unwrap(), chain_spec.state_updates());
+    let mut executor = ef.executor(Box::new(state), katana_primitives::env::BlockEnv::default());
+    executor.execute_block(chain_spec.block()).expect("failed to execute genesis block");
+
+    let output = executor.take_execution_output().unwrap();
+    for (i, (.., result)) in output.transactions.iter().enumerate() {
+        assert!(result.is_success(), "genesis tx {i} failed: {result:?}");
+    }
+
+    let genesis_state = executor.state();
+    assert!(
+        genesis_state.class(CANONICAL_LATEST).unwrap().is_some(),
+        "controller.latest must be queryable at canonical hash {CANONICAL_LATEST:#x}"
+    );
+    assert!(
+        genesis_state.class(CANONICAL_V108).unwrap().is_some(),
+        "controller.v1.0.8 must be queryable at canonical hash {CANONICAL_V108:#x}"
+    );
+}
+
+#[test]
 fn genesis_states() {
     let chain_spec = chain_spec(1, true);
 


### PR DESCRIPTION
## Summary

Fixes #586. The Cartridge Controller account classes seeded into a `katana init rollup --cartridge.controllers` genesis were never actually declared on-chain, so the keychain's auto-deploy failed with *"Class with hash 0x… is not declared"*.

The root cause is **not** a class-hash round-trip shift (as #586 hypothesized) — katana already computes the canonical controller hash (`0x743c8…`) and the genesis.json round-trip preserves it. The real bug is a **nonce gap** in `GenesisTransactionsBuilder::declare`: it consumed a master-account nonce *before* its dedup early-return, so re-declaring an already-declared class burned a nonce without emitting a tx. Because a rollup genesis already lists the Account and UDC classes, `build_preloaded_classes` hits that dedup path and gaps the nonce; the controller class hashes sort after Account/UDC, so a controller declare lands at the gapped nonce and the genesis block aborts with `InvalidNonce`.

## Fix

Move the dedup check before the nonce bump in `declare`. Once the genesis declares execute cleanly, all bundled controller versions land at their canonical hashes and the boot-time re-declare workaround used by the example apps is no longer needed.

## Test

Adds `controller_class_queryable_at_canonical_hash_after_genesis`, which round-trips a controller-preloaded genesis through its JSON form, executes the genesis block, asserts every tx succeeds, and confirms the classes are queryable at their canonical hashes. It fails with `InvalidNonce` before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
