### PR TITLE
chore(cross-chain-game): repoint permalinks to the squash-merge commit

### DIFF
--- a/examples/cross-chain-game/app/src/source.ts
+++ b/examples/cross-chain-game/app/src/source.ts
@@ -7,7 +7,7 @@
 // re-check the line numbers below.
 
 // The demo's own contracts, pinned to a katana commit (see note above).
-export const SOURCE_REF = "ae0e4ee74dc915b5db3b810eefc9c9b1452ca379";
+export const SOURCE_REF = "2e36ba5ae08b2f7c07e6e6a458464995e1d59a25";
 const DEMO_BASE = `https://github.com/dojoengine/katana/blob/${SOURCE_REF}/examples/cross-chain-game`;
 
 // The piltover core is an external contract (cartridge-gg/piltover), pulled in

--- a/examples/cross-chain-game/docs/architecture.md
+++ b/examples/cross-chain-game/docs/architecture.md
@@ -34,7 +34,7 @@ gameplay functions, and `GameMinted` / `GamePlayed` events:
 #[dojo::model]
 pub struct Stats { #[key] pub id: u8, pub total_minted: u64, pub available: u64, /* … */ }
 ```
-[`cairo/game/src/lib.cairo:35`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L35)
+[`cairo/game/src/lib.cairo:35`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L35)
 
 ## The two-chain split: play on L2, anchor on L1
 

--- a/examples/cross-chain-game/docs/client.md
+++ b/examples/cross-chain-game/docs/client.md
@@ -30,22 +30,22 @@ async function toriiSql(base, sql) {
   return res.json();                       // array of row objects
 }
 ```
-[`app/src/chain.ts:81`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L81)
+[`app/src/chain.ts:81`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L81)
 
 Two parsing details every client needs:
 
 - **Columns come back as hex strings** (`"0x…41"`). Collapse to numbers:
-  `const num = (v) => Number(BigInt(v));` [`app/src/chain.ts:46`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L46)
+  `const num = (v) => Number(BigInt(v));` [`app/src/chain.ts:46`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L46)
 - **Each event row has `internal_event_id`** = `block:txHash:world:idx`. Split it
   to recover the block height and the tx hash (for explorer links / settlement
-  gating): [`app/src/chain.ts:89`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L89)
+  gating): [`app/src/chain.ts:89`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L89)
 
 Reading current state is then a one-liner against the model table:
 
 ```ts
 const rows = await toriiSql(TORII_GAME, 'SELECT total_minted, available … FROM "game-Stats" WHERE id = 0');
 ```
-[`app/src/chain.ts:117`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L117)
+[`app/src/chain.ts:117`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L117)
 
 ## Joining across two Toriis
 
@@ -62,7 +62,7 @@ const [played, claimed] = await Promise.all([
 ]);
 // → each play row gets a claimTxHash if a matching claim exists
 ```
-[`app/src/chain.ts:220`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L220)
+[`app/src/chain.ts:220`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L220)
 
 This "read both indexers, join on a shared field" pattern is how any multi-chain
 appchain app presents one coherent timeline.
@@ -72,10 +72,10 @@ appchain app presents one coherent timeline.
 A few things aren't world state, so they bypass Torii and hit the chain directly:
 
 - **Block heights** (appchain tip) and **piltover `get_state`** (settled height) —
-  the "settled N / tip M" gauge. [`app/src/chain.ts:281`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L281)
+  the "settled N / tip M" gauge. [`app/src/chain.ts:281`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L281)
 - **The L1 purchase log** (piltover `MessageSent`) via `getEvents`, so a purchase
   shows as *pending* before the appchain relays it — that L1-side event isn't in
-  either world. [`app/src/chain.ts:189`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L189)
+  either world. [`app/src/chain.ts:189`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L189)
 
 Rule of thumb: world models/events → Torii; raw chain facts (block numbers,
 non-world contract events, settled state) → RPC.
@@ -84,9 +84,9 @@ non-world contract events, settled state) → RPC.
 
 Writes are ordinary signed transactions; nothing Torii-specific:
 
-- **L1→L2 (buy):** `storeSystem.buy_game(game_id)` — the L1 store runs its rules, then messages the appchain — [`app/src/chain.ts:145`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L145)
-- **L2 (play):** `gameSystem.play_game()` — [`app/src/chain.ts:253`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L253)
-- **L2→L1 (bank):** `scoreSystem.claim_score(game_system, player, score)` — [`app/src/chain.ts:292`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L292)
+- **L1→L2 (buy):** `storeSystem.buy_game(game_id)` — the L1 store runs its rules, then messages the appchain — [`app/src/chain.ts:145`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L145)
+- **L2 (play):** `gameSystem.play_game()` — [`app/src/chain.ts:253`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L253)
+- **L2→L1 (bank):** `scoreSystem.claim_score(game_system, player, score)` — [`app/src/chain.ts:292`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L292)
 
 Two practical notes from the demo:
 
@@ -96,7 +96,7 @@ Two practical notes from the demo:
 - **A write returns before the read updates.** `playGame()` sends the tx, waits
   for the receipt, then **polls Torii** until the play is indexed before returning
   the score — bridging the write path to the eventually-consistent read path.
-  [`app/src/chain.ts:253`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L253)
+  [`app/src/chain.ts:253`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L253)
 
 ## Wallets (optional Controller)
 
@@ -150,7 +150,7 @@ refetches only when there's new data:
 const cleanup = await subscribeToriiUpdates(ping); // ping = debounced tick()
 const slow = setInterval(tick, 4000);              // safety net + RPC-only reads
 ```
-[`app/src/App.tsx:135`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/App.tsx#L135)
+[`app/src/App.tsx:135`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/App.tsx#L135)
 
 `subscribeToriiUpdates` opens a gRPC subscription (`@dojoengine/torii-wasm`'s
 `ToriiClient`) on **both** worlds — `onEntityUpdated` for models (`game-Stats`,
@@ -163,7 +163,7 @@ an interval later:
 subs.push(await client.onEntityUpdated(null, null, () => onUpdate()));
 subs.push(await client.onEventMessageUpdated(null, null, () => onUpdate()));
 ```
-[`app/src/chain.ts:107`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/chain.ts#L107)
+[`app/src/chain.ts:107`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/chain.ts#L107)
 
 The slow interval stays as a safety net and to refresh the few facts Torii can't
 push: the saya-settled block and the appchain tip are read straight from RPC, and
@@ -175,7 +175,7 @@ banked runs are just a filter over the joined play list:
 const unbanked = plays.filter((p) => !p.claimTxHash);   // still on L2
 const banked   = plays.filter((p) =>  p.claimTxHash);    // settled to L1
 ```
-[`app/src/App.tsx:170`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/app/src/App.tsx#L170)
+[`app/src/App.tsx:170`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/app/src/App.tsx#L170)
 
 ## Current known blockers (appchain Controller)
 

--- a/examples/cross-chain-game/docs/contracts.md
+++ b/examples/cross-chain-game/docs/contracts.md
@@ -17,7 +17,7 @@ global state, or a real key (a player address) for per-entity rows.
 #[dojo::model]
 pub struct Stats { #[key] pub id: u8, pub total_minted: u64, pub available: u64, /* … */ }
 ```
-[`cairo/game/src/lib.cairo:35`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L35)
+[`cairo/game/src/lib.cairo:35`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L35)
 
 **A system** is a `#[dojo::contract]`. It reaches the world via `self.world(@"ns")`
 and reads/writes models:
@@ -28,7 +28,7 @@ let mut stats: Stats = world.read_model(SINGLETON);
 stats.available -= 1;
 world.write_model(@stats);
 ```
-[`cairo/game/src/lib.cairo:114`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L114)
+[`cairo/game/src/lib.cairo:114`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L114)
 
 **Config goes in `dojo_init`** — it runs once at migration. Pass addresses you
 only learn at deploy time (e.g. the contract on the *other* chain) here rather
@@ -40,7 +40,7 @@ fn dojo_init(self: @ContractState, registry: ContractAddress) {
     world.write_model(@GameConfig { id: SINGLETON, registry });
 }
 ```
-[`cairo/game/src/lib.cairo:80`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L80)
+[`cairo/game/src/lib.cairo:80`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L80)
 
 **Permissions:** a system may only write models in namespaces it's a *writer* of;
 that grant is declared at migration (see [deployment.md](./deployment.md)).
@@ -66,7 +66,7 @@ fn mint_game(ref self: ContractState, from_address: felt252, game_id: felt252) {
     world.emit_event(@GameMinted { mint_no: stats.total_minted, buyer: from_address, /* … */ });
 }
 ```
-[`cairo/game/src/lib.cairo:93`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L93)
+[`cairo/game/src/lib.cairo:93`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L93)
 
 In the demo the client doesn't call piltover directly — the player calls
 `buy_game` on the L1 `store` contract, which runs the store's rules and then makes
@@ -86,7 +86,7 @@ contract that will consume it; the payload is yours to define:
 send_message_to_l1_syscall(config.registry.into(), array![player, score.into()].span())
     .unwrap_syscall();
 ```
-[`cairo/game/src/lib.cairo:131`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L131)
+[`cairo/game/src/lib.cairo:131`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L131)
 
 **2. Consume on a settlement system.** It calls the piltover core; this reverts
 until saya has settled the block containing the message (that's the whole point —
@@ -96,7 +96,7 @@ until saya has settled the block containing the message (that's the whole point 
 let piltover = IPiltoverMessagingDispatcher { contract_address: config.piltover };
 piltover.consume_message_from_appchain(from_address, array![player, score].span());
 ```
-[`cairo/score/src/lib.cairo:99`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/score/src/lib.cairo#L99)
+[`cairo/score/src/lib.cairo:99`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/score/src/lib.cairo#L99)
 
 **The payload contract is sacred.** The `(from_address, payload)` the consumer
 passes must reconstruct exactly what the sender emitted, or the hash won't match
@@ -131,7 +131,7 @@ monotonic sequence**:
 #[dojo::event]
 pub struct GamePlayed { #[key] pub game_no: u64, pub player: felt252, pub score: u64 }
 ```
-[`cairo/game/src/lib.cairo:71`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/cairo/game/src/lib.cairo#L71)
+[`cairo/game/src/lib.cairo:71`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/cairo/game/src/lib.cairo#L71)
 
 The demo keys `GameMinted`/`GamePlayed`/`ScoreClaimed` by `mint_no`/`game_no`/
 `claim_no` so Torii keeps one row per mint/play/bank — which is exactly what the

--- a/examples/cross-chain-game/docs/deployment.md
+++ b/examples/cross-chain-game/docs/deployment.md
@@ -59,7 +59,7 @@ const manifest = loadJson<Manifest>(resolve(cwd, "manifest_dev.json"));
 const world = manifest.world.address;
 const system = manifest.contracts.find((c) => c.tag === s.systemTag).address;
 ```
-[`scripts/lib.ts:106`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/scripts/lib.ts#L106)
+[`scripts/lib.ts:106`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/scripts/lib.ts#L106)
 
 ## Migration order (wiring across chains)
 
@@ -81,7 +81,7 @@ const store = migrateWorld({ pkg: "store", seed: "ccg_store", namespace: "store"
   systemTag: "store-store", rpcUrl: d.settlement.rpcUrl, account: d.settlement.account,
   initArgs: [d.settlement.piltover, game.system] }); // ← needs the game system
 ```
-[`scripts/deploy.ts:20`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/scripts/deploy.ts#L20)
+[`scripts/deploy.ts:20`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/scripts/deploy.ts#L20)
 
 `migrateWorld` (`scripts/lib.ts`) generates that world's `dojo_dev.toml` from these
 values, runs `sozo build` then `sozo migrate`, and returns the parsed addresses,
@@ -100,16 +100,16 @@ depends on the previous. For your own app, this is the template:
 
 1. **Preflight** — install the Dojo toolchain (`asdf install`) + JS deps and
    verify the heavy prerequisites (katana binary, patched saya, dojo checkout).
-2. **Settlement Katana** (`:5050`, `SN_SEPOLIA`). [`up.sh:91`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L91)
-3. **Mock TEE registry** via `saya-ops` — the attestation verifier saya needs. [`up.sh:98`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L98)
+2. **Settlement Katana** (`:5050`, `SN_SEPOLIA`). [`up.sh:91`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L91)
+3. **Mock TEE registry** via `saya-ops` — the attestation verifier saya needs. [`up.sh:98`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L98)
 4. **piltover core + rollup config** via `katana init rollup --tee` — deploys the
-   mailbox on L1 and writes the appchain's chain config. [`up.sh:109`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L109)
-5. **Base `deployments.json`** — rpc urls, accounts, piltover, Torii urls. [`up.sh:125`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L125)
-6. **Appchain Katana** (`:5051`, rollup, `--tee mock --messaging.enabled`). [`up.sh:147`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L147)
-7. **saya-tee** sidecar — starts proving/settling appchain blocks. [`up.sh:159`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L159)
+   mailbox on L1 and writes the appchain's chain config. [`up.sh:109`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L109)
+5. **Base `deployments.json`** — rpc urls, accounts, piltover, Torii urls. [`up.sh:125`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L125)
+6. **Appchain Katana** (`:5051`, rollup, `--tee mock --messaging.enabled`). [`up.sh:147`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L147)
+7. **saya-tee** sidecar — starts proving/settling appchain blocks. [`up.sh:159`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L159)
 8. **Migrate the three worlds** (`scripts/deploy.ts`: score → game → store) and record addresses.
 9. **Two Torii instances** — settlement world `:8081`, appchain world `:8082`,
-   distinct relay ports. [`up.sh:185`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L185)
+   distinct relay ports. [`up.sh:185`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L185)
 10. **Client** (Vite, `:3001`).
 
 ```bash

--- a/examples/cross-chain-game/docs/services.md
+++ b/examples/cross-chain-game/docs/services.md
@@ -30,7 +30,7 @@ chain your app runs *on* — and each is a Katana instance:
   mainnet/Sepolia in production). It hosts the **piltover core** and your
   settlement world. In the demo it runs with `--chain-id SN_SEPOLIA` so saya's
   tooling and `katana init rollup` agree on the chain id.
-  [`up.sh:91`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L91)
+  [`up.sh:91`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L91)
 - **Appchain Katana ("L2").** Your app's chain, started as a **rollup** that
   settles to the piltover core. Key flags:
   - `--tee mock` — run as a TEE-settled rollup (mock attestation locally).
@@ -45,7 +45,7 @@ chain your app runs *on* — and each is a Katana instance:
   katana --chain "$CHAIN_DIR" --tee mock --dev --dev.no-fee --block-time 5000 \
          --http.port 5051 --explorer --messaging.enabled
   ```
-  [`up.sh:147`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L147)
+  [`up.sh:147`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L147)
 
 **How they connect.** The appchain is created by `katana init rollup`, which
 deploys the piltover core on the settlement chain and writes a chain config the
@@ -63,7 +63,7 @@ messages that have been *settled*, so L1 contracts can consume them safely. That
 contract is piltover.
 
 **Where / how.** Deployed by `katana init rollup --tee` on the settlement chain
-([`up.sh:109`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L109)). Its interface, as used in this guide:
+([`up.sh:109`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L109)). Its interface, as used in this guide:
 
 - `send_message_to_appchain(to, selector, payload)` — **L1 → L2**. Emits
   `MessageSent`; the appchain relays it. (In the demo, called by the L1 `store`
@@ -90,7 +90,7 @@ The message becomes consumable on L1 **only after** its block is settled:
 This is why the demo's *bank* step can't be instant: the client has to wait for
 saya to settle the block the play landed in before claiming.
 
-**Where / how.** A sidecar process next to the two Katanas ([`up.sh:159`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L159)):
+**Where / how.** A sidecar process next to the two Katanas ([`up.sh:159`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L159)):
 
 ```bash
 saya-tee tee start --mock-prove \
@@ -100,7 +100,7 @@ saya-tee tee start --mock-prove \
 
 - `--mock-prove` — exercises the settlement *plumbing* without a real SP1/TEE
   prover. It proves the messaging path works, not proof soundness.
-- The **mock TEE registry** (deployed by `saya-ops`, [`up.sh:98`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L98)) is the on-L1
+- The **mock TEE registry** (deployed by `saya-ops`, [`up.sh:98`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L98)) is the on-L1
   attestation verifier; the mock accepts saya's attestation so `update_state` is
   allowed. In production this is a real attestation registry.
 
@@ -130,7 +130,7 @@ world isn't indexed; its purchases are read from the piltover log over RPC):
 torii --rpc http://localhost:5050 --world "$SCORE_WORLD" --http.port 8081 …  # settlement
 torii --rpc http://localhost:5051 --world "$GAME_WORLD"  --http.port 8082 …  # appchain
 ```
-[`up.sh:185`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L185), [`up.sh:194`](https://github.com/dojoengine/katana/blob/ae0e4ee74dc915b5db3b810eefc9c9b1452ca379/examples/cross-chain-game/up.sh#L194)
+[`up.sh:185`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L185), [`up.sh:194`](https://github.com/dojoengine/katana/blob/2e36ba5ae08b2f7c07e6e6a458464995e1d59a25/examples/cross-chain-game/up.sh#L194)
 
 **How the client uses it.** Current state from model tables (`game-Stats`), feeds
 from per-event tables (`game-GamePlayed`), via `GET /sql?query=…`. The client even


### PR DESCRIPTION
Repoints the cross-chain-game docs + `source.ts` (`SOURCE_REF`) permalinks from the PR-branch commit `ae0e4ee7` to the #580 squash-merge commit `2e36ba5a` on main (39 occurrences). `PILTOVER_REF` is left unchanged. Examples-only — the required Rust checks are path-excluded.