### PR TITLE
Enable tee-snp and tee-mock TEE features in release builds

### DIFF
--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -69,6 +69,7 @@ default = [
 	"jemalloc",
 	"katana-cli/explorer",
 	"katana-cli/tee-snp",
+	"tee-mock",
 ]
 
 client = [ "dep:colored_json", "dep:serde_json" ]

--- a/scripts/build-gnu.sh
+++ b/scripts/build-gnu.sh
@@ -129,13 +129,17 @@ echo "  OFFLINE_FLAG: ${OFFLINE_FLAG:-<none>}"
 # `--tee sev-snp` (used by katana-tee-vm to run Katana inside an AMD SEV-SNP
 # confidential VM). Without it the binary fails at startup with:
 #   "SEV-SNP TEE provider requires the 'tee-snp' feature to be enabled"
+#
+# `tee-mock` enables `--tee mock`, letting operators and tests exercise the
+# TEE RPC surface without SNP hardware. Without it the binary fails with:
+#   "Mock TEE provider requires the 'tee-mock' feature"
 cargo build \
     $OFFLINE_FLAG \
     --locked \
     --target x86_64-unknown-linux-gnu \
     --profile performance \
     --no-default-features \
-    --features "client,init-slot,jemalloc,tee-snp" \
+    --features "client,init-slot,jemalloc,tee-snp,tee-mock" \
     --bin katana
 
 BINARY_PATH="$PROJECT_ROOT/target/x86_64-unknown-linux-gnu/performance/katana"

--- a/scripts/build-gnu.sh
+++ b/scripts/build-gnu.sh
@@ -125,13 +125,17 @@ echo "  SOURCE_DATE_EPOCH: $SOURCE_DATE_EPOCH"
 echo "  RUSTFLAGS: $RUSTFLAGS"
 echo "  OFFLINE_FLAG: ${OFFLINE_FLAG:-<none>}"
 
+# `tee-snp` is required so the released linux_amd64 binary supports
+# `--tee sev-snp` (used by katana-tee-vm to run Katana inside an AMD SEV-SNP
+# confidential VM). Without it the binary fails at startup with:
+#   "SEV-SNP TEE provider requires the 'tee-snp' feature to be enabled"
 cargo build \
     $OFFLINE_FLAG \
     --locked \
     --target x86_64-unknown-linux-gnu \
     --profile performance \
     --no-default-features \
-    --features "client,init-slot,jemalloc" \
+    --features "client,init-slot,jemalloc,tee-snp" \
     --bin katana
 
 BINARY_PATH="$PROJECT_ROOT/target/x86_64-unknown-linux-gnu/performance/katana"


### PR DESCRIPTION
## Problem

The published portable linux_amd64 release binary (`katana_v1.8.0-rc.1_linux_amd64.tar.gz`) rejects `--tee sev-snp` at startup:

```
error: failed to build node
    SEV-SNP TEE provider requires the 'tee-snp' feature to be enabled
```

This was caught by katana-tee-vm's CI boot test, which embeds the katana release binary in an AMD SEV-SNP confidential VM: see dojoengine/katana-tee-vm#9 and specifically [this comment](https://github.com/dojoengine/katana-tee-vm/pull/9#issuecomment-4676804486).

The same build also drops the mock TEE provider: `--tee mock` fails with `Mock TEE provider requires the 'tee-mock' feature`.

## Root cause

The portable `katana_<version>_linux_amd64.tar.gz` asset is produced by the **reproducible build** pipeline, not the regular release matrix:

`release.yml` (`release-reproducible-linux-amd64` job) → `scripts/build-reproducible-katana.sh` → `reproducible.Dockerfile` → `scripts/build-gnu.sh`

`build-gnu.sh` builds with `--no-default-features --features "client,init-slot,jemalloc"`, which drops `tee-snp` even though it is in the `katana` crate's default features (`katana-cli/tee-snp` → `katana-sequencer-node/tee-snp` + `katana-tee/snp` → `sev` / `sev-snp` attestation SDK). The runtime bail above is the `#[cfg(not(feature = "tee-snp"))]` branch in `crates/node/sequencer/src/lib.rs`.

`tee-mock` (`katana/tee-mock` → `katana-cli/tee-mock` → `katana-sequencer-node/tee-mock` + `katana-tee/mock`) is not in default features at all, so it is absent from every release leg unless listed explicitly.

Verified empirically on the v1.8.0-rc.1 assets: the portable binary contains the cfg-gated "requires the 'tee-snp' feature" bail string (i.e. compiled **without** the feature), while the `_native` binary instead contains the `SevSnpProvider` init path (compiled **with** it).

## Fix

Add `tee-snp` and `tee-mock` to the explicit feature list in `scripts/build-gnu.sh`:

- **`tee-snp`** — required so the released binary supports `--tee sev-snp` (used by katana-tee-vm to run Katana inside an AMD SEV-SNP confidential VM). This was the only build leg missing it.
- **`tee-mock`** — enables `--tee mock`, letting operators and integration tests exercise the TEE RPC surface (attestation quote endpoints, fork-block binding, etc.) on machines without SNP hardware. The mock provider has no extra native dependencies (`katana-tee`'s `mock` feature is an empty feature list, purely a cfg gate).

| Release leg | tee-snp before | After |
|---|---|---|
| linux_amd64 (portable, reproducible build) | ❌ | ✅ (this PR, + tee-mock) |
| linux_amd64_native | ✅ (default features) | unchanged |
| linux_arm64 / linux_arm64_native | ✅ (default features) | unchanged |
| darwin_arm64 (both) | ✅ (default features) | unchanged |
| win32_amd64 | ❌ (intentionally dropped — openssl-src perl issue, and SEV-SNP is Linux-only AMD tech) | unchanged |

No arch concerns: the v1.8.0-rc.1 linux_arm64 binaries already built successfully with `tee-snp` via default features, and `crates/tee` has no `target_arch` gates — so nothing needed changing for arm64.

## tee-mock is now a default feature of the `katana` bin crate

The change to `build-gnu.sh` only covers the portable reproducible linux_amd64 asset. The other release matrix legs (`linux_amd64_native`, `linux_arm64`/`_native`, `darwin_arm64`/`_native`) build with the bin crate's **default** features, so they would still ship without the mock provider. This PR therefore also adds `tee-mock` to `default` in `bin/katana/Cargo.toml`:

```toml
default = [
	"client",
	"init-custom-settlement-chain",
	"init-slot",
	"jemalloc",
	"katana-cli/explorer",
	"katana-cli/tee-snp",
	"tee-mock",
]
```

With this, **every** release asset built with default features gets `--tee mock` support for exercising the TEE RPC surface without SNP hardware. This is safe to default everywhere because `tee-mock` is dependency-free end to end: `katana-tee`'s `mock` feature is an empty feature list (a pure `cfg` gate), so it pulls in zero new crates — `Cargo.lock` is unchanged by this commit.

**Windows leg:** unaffected. The `win32` build in `release.yml` uses `--no-default-features` with an explicit feature list (`client,init-custom-settlement-chain,init-slot,jemalloc,katana-cli/explorer`) specifically to drop `tee-snp` (its `sev-snp` → vendored-openssl chain fails on the runner's perl). Since Windows doesn't inherit defaults at all, adding `tee-mock` to defaults can't break that leg; and even if it were added to the explicit Windows list later, it would be harmless since it carries no dependencies.

## Validation

- `cargo tree -p katana --no-default-features --features "client,init-slot,jemalloc,tee-snp,tee-mock" --target x86_64-unknown-linux-gnu -e features` confirms the full chains resolve: `katana-tee feature "snp"` (with `sev-snp v0.3.0`) and `katana-tee feature "mock"` via `katana-sequencer-node feature "tee-mock"` both enter the graph.
- `cargo tree --locked -p katana -e features -i katana-tee` (default features) now shows `katana-tee feature "mock"` activated; before the Cargo.toml change it was absent. `cargo metadata --locked` passes and `Cargo.lock` is untouched.
- Full build is validated by CI / the release workflow (the change is to a release build script; cross-compiling the C deps locally on macOS isn't practical). Note the reproducible pipeline's two-pass byte-for-byte comparison will also verify that the added `sev-snp` → vendored-openssl dependency chain stays deterministic. `tee-mock` adds no new dependencies.

## Follow-up

After merging, a new release (v1.8.0-rc.2 or a re-release) is needed so the published portable linux_amd64 asset includes the features and katana-tee-vm can re-tag against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

