### PR TITLE
fix(pool): exempt L1Handler txns from account-nonce ordering

### DIFF
--- a/crates/pool/pool/Cargo.toml
+++ b/crates/pool/pool/Cargo.toml
@@ -20,5 +20,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 futures-util.workspace = true
+katana-provider = { workspace = true, features = [ "test-utils" ] }
 rand.workspace = true
 starknet.workspace = true

--- a/crates/pool/pool/src/validation/stateful.rs
+++ b/crates/pool/pool/src/validation/stateful.rs
@@ -126,6 +126,16 @@ impl Validator for TxValidator {
             let tx_nonce = tx.nonce();
             let address = tx.sender();
 
+            // L1-handler txns carry the L1->L2 message nonce (assigned by the
+            // settlement core / piltover), NOT a sequential account nonce. They must
+            // bypass account-nonce ordering: a message whose nonce is ahead of the
+            // target contract's account nonce would otherwise be tagged `Dependent`
+            // and dropped from the pool forever, so the handler never executes. This
+            // mirrors the L1Handler exemption in `validate` below.
+            if let ExecutableTx::L1Handler(_) = tx.transaction {
+                return Ok(ValidationOutcome::Valid(tx));
+            }
+
             // For declare transactions, perform a static check if there's already an existing class
             // with the same hash.
             if let ExecutableTx::Declare(ref declare_tx) = tx.transaction {
@@ -343,5 +353,69 @@ fn map_pre_validation_err(
             let tx_nonce = incoming_tx_nonce.0;
             Ok(InvalidTransactionError::InvalidNonce { address, current_nonce, tx_nonce })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use katana_chain_spec::ChainSpec;
+    use katana_executor::blockifier::cache::ClassCache;
+    use katana_executor::ExecutionFlags;
+    use katana_pool_api::validation::{ValidationOutcome, Validator};
+    use katana_primitives::chain::ChainId;
+    use katana_primitives::env::BlockEnv;
+    use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, L1HandlerTx};
+    use katana_primitives::{address, Felt, B256};
+    use katana_provider::api::state::StateFactoryProvider;
+    use katana_provider::test_utils::test_provider;
+    use katana_provider::ProviderFactory;
+    use parking_lot::Mutex;
+    use starknet::macros::selector;
+
+    use super::TxValidator;
+
+    fn validator() -> TxValidator {
+        let provider = test_provider().provider();
+        let state = provider.latest().unwrap();
+        TxValidator::new(
+            state,
+            ExecutionFlags::new(),
+            None,
+            BlockEnv::default(),
+            Arc::new(Mutex::new(())),
+            Arc::new(ChainSpec::dev()),
+            ClassCache::new().unwrap(),
+        )
+    }
+
+    // Regression: an L1-handler tx carries the L1->L2 message nonce assigned by the
+    // settlement core, NOT a sequential account nonce. The pool must not subject it to
+    // account-nonce ordering. Before the fix, a message whose nonce was ahead of the
+    // target contract account nonce (the normal case) was tagged `Dependent` and
+    // dropped from the pool forever, so `mint_run`-style l1_handlers never executed.
+    #[tokio::test]
+    async fn l1_handler_with_nonce_gap_is_valid() {
+        let validator = validator();
+
+        // Message nonce 12, but the target contract account nonce is 0 (empty state).
+        let tx = ExecutableTxWithHash::new(ExecutableTx::L1Handler(L1HandlerTx {
+            nonce: Felt::from(12_u64),
+            chain_id: ChainId::default(),
+            paid_fee_on_l1: 0,
+            version: Felt::ZERO,
+            message_hash: B256::ZERO,
+            calldata: vec![Felt::ZERO, Felt::ONE],
+            contract_address: address!("0x1337"),
+            entry_point_selector: selector!("mint_run"),
+        }));
+
+        let outcome = validator.validate(tx).await.expect("validation should not error");
+        let is_valid = matches!(outcome, ValidationOutcome::Valid(_));
+        assert!(
+            is_valid,
+            "L1Handler must bypass account-nonce ordering (was tagged Dependent before the fix)"
+        );
     }
 }


### PR DESCRIPTION
## Problem

L1-handler transactions carry the **L1→L2 message nonce** assigned by the settlement core (e.g. piltover / `StarknetMessaging`), **not** a sequential account nonce. But `TxValidator`'s trait `validate` method (`crates/pool/pool/src/validation/stateful.rs`) runs a dependent-nonce check on *every* transaction:

```rust
let tx_nonce = tx.nonce();
let address  = tx.sender();
...
let current_nonce = /* sender's account nonce, from pool or state */;
if tx_nonce > current_nonce {
    return Ok(ValidationOutcome::Dependent { current_nonce, tx_nonce, tx });
}
```

For an L1-handler, `tx.sender()` is the target contract and `tx.nonce()` is the message nonce — which is unrelated to that contract's account nonce, and effectively always ahead of it. So the handler is tagged `Dependent`, `Pool::add_transaction` maps that to `InvalidNonce`, and the tx is dropped from the pool **forever** (it "will retry on next gather", but the gap never closes). The handler never executes.

The inner `validate` fn already exempts L1-handlers (`Transaction::L1Handler(_) => Ok(Valid(..))`), but the outer dependent-nonce check returns first, so that exemption is never reached.

## Symptom (how this was found)

An appchain settling to a Starknet core contract never executes its L1→L2 messages. In the `cross-chain-dungeon` example, every `Entry.enter` emits a `mint_run` L1→L2 message that katana ingests and then rejects:

```
INFO  messaging: L1Handler transaction added to the pool. tx_hash=0x25d367… msg_hash=0x06a3efb1…
TRACE pool: Dependent transaction. tx_nonce=12 current_nonce=0
WARN  messaging: Failed to add L1Handler transaction to pool; will retry on next gather.
      error=Invalid transaction nonce of contract at address 0x6d3d2eab…
            Account nonce: 0x0; got: 0xc.
```

The appchain stays frozen (no `mint_run` ever runs), so the run is never created and the client hangs on "entering the dungeon" indefinitely.

## Fix

Move the `L1Handler` exemption ahead of the dependent-nonce check, so L1-handlers bypass account-nonce ordering entirely (consistent with the existing exemption in the inner `validate`). L1-handler replay protection is the L1 message consumption, not a sequential nonce, so dropping the ordering is semantically correct.

## Test

Adds `l1_handler_with_nonce_gap_is_valid`: builds a `TxValidator` over an empty state and validates an `L1HandlerTx` whose message nonce (12) is ahead of the target contract's account nonce (0). It asserts the outcome is `Valid`.

Verified locally:
- **without** the fix → `FAILED` (`L1Handler must bypass account-nonce ordering (was tagged Dependent before the fix)`)
- **with** the fix → `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)