### PR TITLE
amdsev: stop strip_reserved_args from glob-expanding operator args

### DIFF
--- a/.github/workflows/amdsev-lint.yml
+++ b/.github/workflows/amdsev-lint.yml
@@ -52,6 +52,14 @@ jobs:
           fi
           shellcheck -s sh -S warning /tmp/guest-init.sh
 
+      - name: Unit test strip_reserved_args
+        # Fast, no-QEMU regression test for the guest init's arg sanitizer:
+        # extracts strip_reserved_args from build-initrd.sh and asserts it
+        # filters reserved flags while leaving glob values (e.g. the `*` in
+        # `--http.cors-origins *`) literal. The boot smoke test covers the
+        # same path end to end but only in the slow amdsev-initrd-test job.
+        run: ./scripts/test-strip-reserved-args.sh
+
       - name: actionlint (amdsev workflows only)
         working-directory: .
         run: |

--- a/misc/AMDSEV/scripts/build-initrd.sh
+++ b/misc/AMDSEV/scripts/build-initrd.sh
@@ -1136,7 +1136,9 @@ load_fw_cfg_args() {
 
     if [ -f "$FW_CFG_ARGS_RAW" ]; then
         RAW_FWCFG_ARGS="$(tr '\n\r\t' '   ' < "$FW_CFG_ARGS_RAW")"
-        KATANA_FWCFG_ARGS="$(strip_reserved_args $RAW_FWCFG_ARGS)"
+        # Quote the raw string so the glob is NOT expanded here at the call
+        # site; strip_reserved_args word-splits it internally under `set -f`.
+        KATANA_FWCFG_ARGS="$(strip_reserved_args "$RAW_FWCFG_ARGS")"
         log "fw_cfg katana args: ${KATANA_FWCFG_ARGS:-<empty>}"
     else
         log "No fw_cfg args entry (opt/org.katana/args)"
@@ -1397,8 +1399,14 @@ handle_control_command() {
             # tries to re-open FD 3 after the host disconnects it fails with
             # EBUSY — and a failed `exec` redirect under POSIX `set -e`
             # terminates init, panicking the kernel.
+            # Disable pathname expansion around the unquoted arg split: the
+            # fw_cfg args must word-split into argv, but a glob in an operator
+            # value (e.g. `--http.cors-origins *`) must reach Katana literally,
+            # not expand against the rootfs.
+            set -f
             # shellcheck disable=SC2086
             /bin/katana --db-dir="$KATANA_DB_DIR" $CHAIN_ARGS $KATANA_FWCFG_ARGS 3<&- 3>&- &
+            set +f
             KATANA_PID=$!
             KATANA_EXIT_CODE="running"
             respond_control "ok started pid=$KATANA_PID"

--- a/misc/AMDSEV/scripts/build-initrd.sh
+++ b/misc/AMDSEV/scripts/build-initrd.sh
@@ -1079,7 +1079,13 @@ strip_reserved_args() {
     SKIP_NEXT=0
     OUT=""
     # Word-splitting the unquoted $* is the point: callers pass a flat
-    # whitespace-separated arg string, not pre-split words.
+    # whitespace-separated arg string, not pre-split words. Disable pathname
+    # expansion around the loop so glob characters in operator-supplied values
+    # (most commonly the `*` in `--http.cors-origins *`) stay literal — without
+    # `set -f` the shell would expand `*` to the contents of CWD, which inside
+    # the initrd's busybox / rootfs is `bin dev etc init lib …` and ends up
+    # being passed to Katana as a noisy list of fake origins.
+    set -f
     # shellcheck disable=SC2048
     for tok in $*; do
         if [ "$SKIP_NEXT" -eq 1 ]; then
@@ -1100,6 +1106,7 @@ strip_reserved_args() {
         esac
         OUT="${OUT}${OUT:+ }${tok}"
     done
+    set +f
     echo "$OUT"
 }
 

--- a/misc/AMDSEV/scripts/test-initrd.sh
+++ b/misc/AMDSEV/scripts/test-initrd.sh
@@ -391,9 +391,18 @@ run_boot_smoke_test() {
     # same default invocation as start-vm.sh, including --tee sev-snp).
     # Requires a TEE-capable katana (v1.8.0-rc.1+); the CI workflow pins
     # KATANA_TEST_VERSION accordingly.
+    #
+    # `--http.cors-origins *` is included as a regression test for the
+    # strip_reserved_args glob-expansion bug in build-initrd.sh: without
+    # `set -f` around the unquoted `for tok in $*` loop, the guest sh would
+    # pathname-expand the `*` to the rootfs's top-level dirs (bin dev etc
+    # init lib lib64 …) before reaching katana — katana would then see
+    # `--http.cors-origins bin dev etc init …`, reject `dev` as an unknown
+    # flag, exit, and the RPC liveness check below would time out.
     printf '%s\n' \
         "--http.addr" "0.0.0.0" \
         "--http.port" "${VM_RPC_PORT}" \
+        "--http.cors-origins" "*" \
         "--tee" "sev-snp" \
         > "$KATANA_ARGS_FILE"
 

--- a/misc/AMDSEV/scripts/test-strip-reserved-args.sh
+++ b/misc/AMDSEV/scripts/test-strip-reserved-args.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# ==============================================================================
+# TEST-STRIP-RESERVED-ARGS.SH - Unit tests for the guest init's
+# strip_reserved_args sanitizer.
+# ==============================================================================
+#
+# strip_reserved_args lives in the init heredoc inside build-initrd.sh and
+# runs in the guest under busybox sh. It word-splits host-supplied Katana CLI
+# args (intentional) while filtering the flags init owns (--db-* / --data-dir
+# / --chain). The word-split loop must NOT also pathname-expand glob
+# characters in operator values — most importantly the `*` in
+# `--http.cors-origins *`, which would otherwise expand against the initrd
+# rootfs CWD into `bin dev etc init lib …` and reach Katana as a list of
+# fake origins.
+#
+# This extracts the function from build-initrd.sh and exercises it directly —
+# fast, no QEMU. It is the precise regression test for that glob bug; the
+# boot smoke test (test-initrd.sh) covers the same path end to end but slowly
+# and only indirectly (via an RPC-liveness timeout).
+#
+# Run from anywhere; exits non-zero on any failed assertion.
+# ==============================================================================
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_INITRD="${SCRIPT_DIR}/build-initrd.sh"
+[ -f "$BUILD_INITRD" ] || { echo "build-initrd.sh not found at $BUILD_INITRD" >&2; exit 1; }
+
+FN="$(mktemp)"
+GLOBDIR="$(mktemp -d)"
+trap 'rm -f "$FN"; rm -rf "$GLOBDIR"' EXIT
+
+# Extract just the strip_reserved_args function definition (from its header
+# to the first line that is a lone closing brace).
+awk '/^strip_reserved_args\(\)/{f=1} f{print} f && /^}$/{exit}' "$BUILD_INITRD" > "$FN"
+grep -q '^strip_reserved_args()' "$FN" || { echo "failed to extract strip_reserved_args from $BUILD_INITRD" >&2; exit 1; }
+
+# The function logs to stderr via log(); the real one targets the console.
+log() { :; }
+# shellcheck disable=SC1090  # sourcing the extracted function by path
+. "$FN"
+
+# Populate a directory so a leaked unquoted glob would expand to filenames,
+# reproducing the rootfs-CWD expansion the bug caused.
+touch "$GLOBDIR/bin" "$GLOBDIR/dev" "$GLOBDIR/etc"
+
+FAILS=0
+check() {
+    # $1 description, $2 expected, $3 actual
+    if [ "$3" = "$2" ]; then
+        echo "ok   - $1"
+    else
+        echo "FAIL - $1"
+        echo "         want: [$2]"
+        echo "         got:  [$3]"
+        FAILS=$((FAILS + 1))
+    fi
+}
+
+# Invoke the sanitizer from inside the populated directory.
+run() { ( cd "$GLOBDIR" && strip_reserved_args "$@" ); }
+
+# Regression: a glob in an operator value must survive literally.
+check "glob '*' stays literal" \
+    "--http.cors-origins *" "$(run "--http.cors-origins *")"
+
+# Reserved flags are still stripped (two-token form).
+check "--db-dir and its value are stripped" \
+    "--http.port 5050" "$(run "--db-dir /mnt/evil --http.port 5050")"
+
+check "--chain and its value are stripped" \
+    "--tee sev-snp" "$(run "--chain /mnt/evil --tee sev-snp")"
+
+# Single-token --flag=value form is stripped.
+check "--data-dir=VALUE is stripped" \
+    "--http.port 5050" "$(run "--data-dir=/mnt/evil --http.port 5050")"
+
+# Combined: a reserved flag is stripped while a glob value is preserved.
+check "reserved stripped and glob preserved together" \
+    "--http.cors-origins *" "$(run "--db-dir /mnt/evil --http.cors-origins *")"
+
+if [ "$FAILS" -ne 0 ]; then
+    echo "strip_reserved_args: ${FAILS} assertion(s) failed" >&2
+    exit 1
+fi
+echo "strip_reserved_args: all assertions passed"


### PR DESCRIPTION
## Problem

The guest init's `strip_reserved_args` (in `misc/AMDSEV/scripts/build-initrd.sh`) sanitizes host-supplied Katana CLI args with an intentional unquoted `for tok in $*` loop. That loop also does **pathname expansion**, so a glob in an operator-supplied value gets expanded against the initrd rootfs before reaching Katana.

The common trigger is `--http.cors-origins *`: the `*` expands to the rootfs top-level dirs (`bin dev etc init lib lib64 …`), Katana receives `--http.cors-origins bin dev etc init …`, rejects `dev` as an unknown argument, and exits. The VM boots but never serves RPC.

## Fix

Wrap the loop in `set -f` / `set +f` so glob characters stay literal while the intended word-splitting still happens. The init runs under `set -eu` (never `-f`), so unconditionally clearing it at the end is correct in this context.

## Regression test

`misc/AMDSEV/scripts/test-initrd.sh` now includes `--http.cors-origins *` in the smoke-test args. Before the fix the guest would forward the expanded directory list to Katana and the RPC liveness check would time out; with the fix it boots and serves RPC. This runs in `amdsev-initrd-test` on every PR touching `misc/AMDSEV`.

Ported from a fix developed in the (now-archived) standalone `katana-tee-vm` repo. shellcheck clean (outer scripts + guest init as POSIX sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)