### PR TITLE
make: drop SNOS artifacts from fixtures (snos tests disabled)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ snos-artifacts: $(SNOS_OUTPUT)
 db-compat-artifacts: $(COMPATIBILITY_DB_DIR)
 	@echo "Database compatibility test artifacts prepared successfully."
 
-fixtures: $(SNOS_DB_DIR) $(SNOS_OUTPUT) $(COMPATIBILITY_DB_DIR) $(SPAWN_AND_MOVE_DB) $(SIMPLE_DB) contracts
+fixtures: $(COMPATIBILITY_DB_DIR) $(SPAWN_AND_MOVE_DB) $(SIMPLE_DB) contracts
 	@echo "All test fixtures prepared successfully."
 
 build-explorer:


### PR DESCRIPTION
## Summary

The SNOS test suite (`tests/snos`) is currently disabled, so building its database and artifacts on every `make` / `make fixtures` is wasted work — it triggers a recursive submodule init plus a Python/Cairo setup that isn't needed for the rest of the workspace.

This drops the SNOS prerequisites (`$(SNOS_DB_DIR)`, `$(SNOS_OUTPUT)`) from the `fixtures` target, which is what `make all` invokes.

The artifacts are still available on demand via `make snos-artifacts` (unchanged), so re-enabling SNOS later is just a one-target build away.

## Changes

- `Makefile`: remove `$(SNOS_DB_DIR) $(SNOS_OUTPUT)` from the `fixtures` target prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)