### PR TITLE
rpc(cli): add `starknet messages-status` subcommand

### DIFF
--- a/bin/katana/src/cli/rpc/client.rs
+++ b/bin/katana/src/cli/rpc/client.rs
@@ -7,6 +7,7 @@ use katana_primitives::block::{BlockIdOrTag, BlockNumber, ConfirmedBlockIdOrTag}
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, StorageKey};
 use katana_primitives::transaction::TxHash;
+use katana_primitives::B256;
 use katana_rpc_types::event::EventFilterWithPage;
 use katana_rpc_types::trie::ContractStorageKeys;
 use katana_rpc_types::FunctionCall;
@@ -77,6 +78,7 @@ const GET_BLOCK_WITH_RECEIPTS: &str = "starknet_getBlockWithReceipts";
 const GET_STATE_UPDATE: &str = "starknet_getStateUpdate";
 const GET_STORAGE_AT: &str = "starknet_getStorageAt";
 const GET_TRANSACTION_STATUS: &str = "starknet_getTransactionStatus";
+const GET_MESSAGES_STATUS: &str = "starknet_getMessagesStatus";
 const GET_TRANSACTION_BY_HASH: &str = "starknet_getTransactionByHash";
 const GET_TRANSACTION_BY_BLOCK_ID_AND_INDEX: &str = "starknet_getTransactionByBlockIdAndIndex";
 const GET_TRANSACTION_RECEIPT: &str = "starknet_getTransactionReceipt";
@@ -129,6 +131,10 @@ impl Client {
 
     pub async fn get_transaction_status(&self, transaction_hash: TxHash) -> Result<Value> {
         self.send_request(GET_TRANSACTION_STATUS, rpc_params!(transaction_hash)).await
+    }
+
+    pub async fn get_messages_status(&self, transaction_hash: B256) -> Result<Value> {
+        self.send_request(GET_MESSAGES_STATUS, rpc_params!(transaction_hash)).await
     }
 
     pub async fn get_transaction_by_hash(&self, transaction_hash: TxHash) -> Result<Value> {

--- a/bin/katana/src/cli/rpc/starknet.rs
+++ b/bin/katana/src/cli/rpc/starknet.rs
@@ -7,7 +7,7 @@ use katana_primitives::class::ClassHash;
 use katana_primitives::contract::StorageKey;
 use katana_primitives::execution::{Call, EntryPointSelector};
 use katana_primitives::transaction::TxHash;
-use katana_primitives::{ContractAddress, Felt};
+use katana_primitives::{ContractAddress, Felt, B256};
 use katana_rpc_types::event::{EventFilter, EventFilterWithPage, ResultPageRequest};
 use katana_rpc_types::trie::ContractStorageKeys;
 
@@ -35,6 +35,10 @@ pub enum StarknetCommands {
     /// Get transaction by hash [starknet_getTransactionByHash]
     #[command(name = "tx")]
     GetTransactionByHash(GetTransactionArgs),
+
+    /// Get the status of L2 messages spawned from an L1 transaction [starknet_getMessagesStatus]
+    #[command(name = "messages-status")]
+    GetMessagesStatus(GetMessagesStatusArgs),
 
     /// Get transaction by block ID and index [starknet_getTransactionByBlockIdAndIndex]
     #[command(name = "tx-by-block")]
@@ -158,6 +162,14 @@ pub struct GetStorageAtArgs {
     #[arg(long)]
     #[arg(default_value = "latest")]
     block: BlockIdArg,
+}
+
+#[derive(Debug, Args)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct GetMessagesStatusArgs {
+    /// The L1 (settlement chain) transaction hash that spawned the L2 messages
+    #[arg(value_name = "L1_TX_HASH")]
+    transaction_hash: B256,
 }
 
 #[derive(Debug, Args)]
@@ -351,6 +363,11 @@ impl StarknetCommands {
                     let result = client.get_transaction_by_hash(hash).await?;
                     println!("{}", colored_json::to_colored_json_auto(&result)?);
                 };
+            }
+
+            StarknetCommands::GetMessagesStatus(args) => {
+                let result = client.get_messages_status(args.transaction_hash).await?;
+                println!("{}", colored_json::to_colored_json_auto(&result)?);
             }
 
             StarknetCommands::GetTransactionByBlockIdAndIndex(args) => {


### PR DESCRIPTION
Adds a `messages-status` subcommand to `katana rpc starknet`, wiring the already-implemented `starknet_getMessagesStatus` RPC method into the CLI. It takes the L1 (settlement chain) transaction hash as a positional argument and prints the returned per-message L2 statuses as colored JSON, matching the other read subcommands.

The hash is parsed as a `B256` rather than a `Felt` — Ethereum L1 hashes can exceed `STARK_PRIME`, so modular reduction would corrupt the lookup key.

Usage: `katana rpc starknet messages-status <L1_TX_HASH>`
