### PR TITLE
feat(blockifier): bump l1 handler max l1 gas limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_config",
  "serde",
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra_utils"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "indexmap 2.10.0",
  "metrics",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "apollo_proc_macros"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -11480,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.16.0-rc.0"
-source = "git+https://github.com/dojoengine/sequencer?rev=d2591bb#d2591bb07b5da4bf0feebf18953c291becd45910"
+source = "git+https://github.com/dojoengine/sequencer?rev=2a241ef0f#2a241ef0fffb06696035fe2d69b14b11d71b115a"
 dependencies = [
  "apollo_infra_utils",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,8 +252,8 @@ starknet-types-core = { version = "=0.2.3", features = [ "arbitrary", "hash" ] }
 cairo-vm = { version = "2.5.0", features = [ "test_utils" ] }
 
 # branch: blockifier/v0.16.0-rc.0
-blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb", default-features = false }
-starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "d2591bb" }
+blockifier = { git = "https://github.com/dojoengine/sequencer", rev = "2a241ef0f", default-features = false }
+starknet_api = { git = "https://github.com/dojoengine/sequencer", rev = "2a241ef0f" }
 
 cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1", features = [ "abigen-rs" ] }
 cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1" }

--- a/crates/messaging/src/stream/collector/starknet.rs
+++ b/crates/messaging/src/stream/collector/starknet.rs
@@ -196,7 +196,7 @@ fn l1_handler_tx_from_event(
         calldata,
         chain_id,
         message_hash,
-        paid_fee_on_l1: 30000_u128,
+        paid_fee_on_l1: 1000000_u128,
         entry_point_selector,
         version: Felt::ZERO,
         contract_address: to_address.into(),

--- a/crates/messaging/src/stream/collector/starknet.rs
+++ b/crates/messaging/src/stream/collector/starknet.rs
@@ -272,7 +272,7 @@ mod tests {
             calldata,
             chain_id,
             message_hash: B256::from_slice(message_hash.to_bytes_be().as_slice()),
-            paid_fee_on_l1: 30000_u128,
+            paid_fee_on_l1: 1000000_u128,
             version: Felt::ZERO,
             entry_point_selector: selector,
             contract_address: to_address.into(),


### PR DESCRIPTION
Increase the maximum L1 gas bound for L1 handler transactions. The maximum L1 gas bound is configured via the `VersionedConstants` type that is dependent on the specific version of the Starknet protocol being used. 

These are the [values](https://github.com/dojoengine/sequencer/tree/blockifier/v0.16.0-rc.0/crates/blockifier/resources) of the `VersionedConstants` of each version.

This is following PR on Blockifier where the bump first appeared: https://github.com/dojoengine/sequencer/commit/2a241ef0fffb06696035fe2d69b14b11d71b115a