### PR TITLE
feat(init): prefill canonical AMD TEE registry for Sepolia rollup

### DIFF
--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -80,7 +80,7 @@ use starknet::providers::Provider;
 use starknet::signers::SigningKey;
 use url::Url;
 
-mod deployment;
+pub mod deployment;
 mod prompt;
 #[cfg(feature = "init-slot")]
 mod slot;
@@ -91,6 +91,16 @@ mod slot;
 /// rollup is initialized with the Mock TEE proof on Sepolia.
 const MOCK_TEE_REGISTRY_SEPOLIA: Felt =
     felt!("0x037189b1807f1358074b70b3dc8ab79167bbf72cff1296286052f6dfe31c8f15");
+
+/// The canonical AMD TEE registry (`AMDTEERegistry`) deployed on Starknet Sepolia by the
+/// `cartridge-gg/katana-tee` project. It performs real SEV-SNP / SP1 Groth16 attestation
+/// verification, so it pairs with the real prover (`saya-tee`, non-mock). Used to prefill the TEE
+/// registry address when a rollup is initialized with the AMD SEV-SNP + SP1 Groth16 proof on
+/// Sepolia.
+///
+/// Source: <https://github.com/cartridge-gg/katana-tee/blob/39831d1854fac9b39ea56d9378ad8eeed6c6c193/deployments/sepolia.json#L10>
+const AMD_TEE_REGISTRY_SEPOLIA: Felt =
+    felt!("0x01258ed7b2d3435097f9290d100d706d7f9f65db2725609cd7697669cac3bc3a");
 
 #[derive(Debug, Args)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -924,7 +934,6 @@ mod tests {
             )
         );
     }
-
     #[test]
     fn cli_accept_tee_flag_with_registry() {
         #[derive(Parser)]

--- a/bin/katana/src/cli/init/prompt.rs
+++ b/bin/katana/src/cli/init/prompt.rs
@@ -16,7 +16,8 @@ use starknet::signers::{LocalWallet, SigningKey};
 use tokio::runtime::Handle;
 
 use super::{
-    deployment, PersistentOutcome, ProofImpl, SovereignOutcome, MOCK_TEE_REGISTRY_SEPOLIA,
+    deployment, PersistentOutcome, ProofImpl, SovereignOutcome, AMD_TEE_REGISTRY_SEPOLIA,
+    MOCK_TEE_REGISTRY_SEPOLIA,
 };
 use crate::cli::init::deployment::DeploymentOutcome;
 use crate::cli::init::slot::{self, PaymasterAccountArgs};
@@ -110,12 +111,19 @@ pub async fn prompt_rollup() -> Result<PersistentOutcome> {
         let mut prompt = CustomType::<ContractAddress>::new("TEE registry address")
             .with_help_message("Address of the IAMDTeeRegistry contract on the settlement chain.");
 
-        // The mock TEE registry is already deployed on Sepolia, so prefill its address as the
-        // default. It stays editable in case the operator points at their own mock deployment.
-        if matches!(proof_impl, ProofImpl::MockTee)
-            && matches!(network_type, SettlementChainOpt::Sepolia)
-        {
-            prompt = prompt.with_default(ContractAddress::from(MOCK_TEE_REGISTRY_SEPOLIA));
+        // The canonical TEE registries are already deployed on Sepolia, so prefill the matching
+        // address as the default. It stays editable in case the operator points at their own
+        // deployment. The mock registry pairs with the mock prover; the AMD registry performs real
+        // SEV-SNP / SP1 Groth16 verification.
+        if matches!(network_type, SettlementChainOpt::Sepolia) {
+            let sepolia_default = match proof_impl {
+                ProofImpl::MockTee => Some(MOCK_TEE_REGISTRY_SEPOLIA),
+                ProofImpl::AmdSevSnpSp1Groth16 => Some(AMD_TEE_REGISTRY_SEPOLIA),
+                ProofImpl::Stark => None,
+            };
+            if let Some(addr) = sepolia_default {
+                prompt = prompt.with_default(ContractAddress::from(addr));
+            }
         }
 
         Some(prompt.prompt()?)


### PR DESCRIPTION
## Summary

When running `katana init rollup` interactively and selecting **Sepolia** as the settlement chain with the **TEE → AMD SEV-SNP + SP1 Groth16** (non-mock) proof, the "TEE registry address" prompt now prefills the canonical `AMDTEERegistry` deployed on Starknet Sepolia by [`cartridge-gg/katana-tee`](https://github.com/cartridge-gg/katana-tee):

`0x01258ed7b2d3435097f9290d100d706d7f9f65db2725609cd7697669cac3bc3a`

This mirrors the existing prefill for the mock TEE registry (`MOCK_TEE_REGISTRY_SEPOLIA`). The default stays editable, so operators can still point at their own deployment.

## Scope / notes

- Prefill is **interactive-prompt only**, identical to the mock behavior. The CLI-flag path (`--tee`) still requires an explicit `--tee-registry-address` (enforced by clap) and is untouched.
- The address is just a default; it remains fully editable.
