### PR TITLE
chore(init): update `AMD_TEE_REGISTRY_SEPOLIA` to the v6.1.0 registry

### DIFF
--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -98,9 +98,9 @@ const MOCK_TEE_REGISTRY_SEPOLIA: Felt =
 /// registry address when a rollup is initialized with the AMD SEV-SNP + SP1 Groth16 proof on
 /// Sepolia.
 ///
-/// Source: <https://github.com/cartridge-gg/katana-tee/blob/39831d1854fac9b39ea56d9378ad8eeed6c6c193/deployments/sepolia.json#L10>
+/// Source: <https://github.com/cartridge-gg/katana-tee/blob/2a51f3d4ea4f3176baa316400b18a3faca41358e/deployments/sepolia.json#L10>
 const AMD_TEE_REGISTRY_SEPOLIA: Felt =
-    felt!("0x01258ed7b2d3435097f9290d100d706d7f9f65db2725609cd7697669cac3bc3a");
+    felt!("0x06ef2e9da38576240174cd4740d9e323f855dc1ce8094362f122ed7278bf32b");
 
 #[derive(Debug, Args)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -98,7 +98,7 @@ const MOCK_TEE_REGISTRY_SEPOLIA: Felt =
 /// registry address when a rollup is initialized with the AMD SEV-SNP + SP1 Groth16 proof on
 /// Sepolia.
 ///
-/// Source: <https://github.com/cartridge-gg/katana-tee/blob/2a51f3d4ea4f3176baa316400b18a3faca41358e/deployments/sepolia.json#L10>
+/// Source: <https://github.com/cartridge-gg/katana-tee/blob/5b1316cfa4db36954e92241845aaa01d1956fc3b/deployments/sepolia.json#L10>
 const AMD_TEE_REGISTRY_SEPOLIA: Felt =
     felt!("0x06ef2e9da38576240174cd4740d9e323f855dc1ce8094362f122ed7278bf32b");
 


### PR DESCRIPTION
Follow-up to #612. 

The Sepolia AMD TEE registry was redeployed on a **self-generated SP1 v6.1.0 Garaga Groth16 verifier** because the Succinct prover network deprecated the SP1 v5.0.0 circuit. This updates the interactive `katana init rollup` prefill (AMD SEV-SNP + SP1 Groth16 on Sepolia) to the new canonical registry.

- `AMD_TEE_REGISTRY_SEPOLIA`: `0x01258ed7…3bc3a` → `0x06ef2e9da38576240174cd4740d9e323f855dc1ce8094362f122ed7278bf32b`
- Source permalink bumped to the v6 `deployments/sepolia.json`.

Verified end-to-end on Sepolia: `registry.verify_sp1_proof` returns `Ok(VerifierJournal)` for a real SP1 v6.1.0 network proof.

The SP1 v6 migration (prover port to the v6 async API, self-generated v6.1.0 Garaga verifier, and Sepolia redeploy) is implemented in **cartridge-gg/katana-tee#2** (merged as commit `5b1316c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)