### PR TITLE
feat(settlement): record SP1 proof-generation cost metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-prover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=a4fdff0037b84c52a5b283e460eb7e26462fe593#a4fdff0037b84c52a5b283e460eb7e26462fe593"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-verifier"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=a4fdff0037b84c52a5b283e460eb7e26462fe593#a4fdff0037b84c52a5b283e460eb7e26462fe593"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3979,7 +3979,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5058,7 +5058,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5327,7 +5327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6472,7 +6472,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6877,7 +6877,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9346,7 +9346,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9558,7 +9558,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -11159,7 +11159,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11196,7 +11196,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -12298,7 +12298,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14003,7 +14003,7 @@ dependencies = [
 [[package]]
 name = "sp1-methods"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=a4fdff0037b84c52a5b283e460eb7e26462fe593#a4fdff0037b84c52a5b283e460eb7e26462fe593"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
 dependencies = [
  "lazy_static",
  "sp1-build",
@@ -15258,7 +15258,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15267,7 +15267,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16746,7 +16746,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17294,7 +17294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17362,7 +17362,7 @@ dependencies = [
 [[package]]
 name = "x509-verifier-rust-crypto"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=a4fdff0037b84c52a5b283e460eb7e26462fe593#a4fdff0037b84c52a5b283e460eb7e26462fe593"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,9 +278,9 @@ paymaster-service = { git = "https://github.com/cartridge-gg/paymaster", rev = "
 
 
 # AMD SEV-SNP SDKs
-amd-sev-snp-attestation-prover = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "a4fdff0037b84c52a5b283e460eb7e26462fe593", default-features = false }
-amd-sev-snp-attestation-verifier = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "a4fdff0037b84c52a5b283e460eb7e26462fe593" }
-x509-verifier-rust-crypto = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "a4fdff0037b84c52a5b283e460eb7e26462fe593" }
+amd-sev-snp-attestation-prover = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "6d5d610ff458c358bcbbc0a751a53e9f3472500c", default-features = false }
+amd-sev-snp-attestation-verifier = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "6d5d610ff458c358bcbbc0a751a53e9f3472500c" }
+x509-verifier-rust-crypto = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "6d5d610ff458c358bcbbc0a751a53e9f3472500c" }
 
 garaga_rs = { git = "https://github.com/cartridge-gg/garaga.git", rev = "061394abce25b1e6e993a7e65ee8eade4f718f96" }
 

--- a/crates/settlement/src/backend/tee/prover.rs
+++ b/crates/settlement/src/backend/tee/prover.rs
@@ -99,6 +99,7 @@ impl TeeProver {
                 .await
                 .map_err(|_| TeeProverError::Timeout(PROOF_GENERATION_TIMEOUT))??;
 
+                record_proof_cost(&proof, attestation);
                 onchain_proof_to_calldata(&proof)
             }
         }
@@ -214,6 +215,63 @@ impl TeeProver {
             TeeProverError::ProofGenerationFailed(format!("SP1 proof task panicked: {e}"))
         })?
     }
+}
+
+/// Records the proof-generation cost, when the SP1 prover network reported it (the mock prover and
+/// off-network proving report no cost, so this is a no-op there). Recorded here — the only place
+/// the [`OnchainProof`] and its cost are in scope — rather than in the backend-agnostic settlement
+/// service.
+///
+/// The cost is emitted two ways: as aggregate `katana_settlement_sp1_proof_*` histograms (for
+/// dashboards and alerting), and as a per-proof `info` log carrying the settled block range. The
+/// metrics carry no block label on purpose — a block number is unbounded cardinality — so the log
+/// is how you attribute a specific cost to the batch `(prev_block, block]` that incurred it.
+fn record_proof_cost(proof: &OnchainProof, attestation: &BlockAttestation) {
+    use std::sync::Once;
+
+    use metrics::{describe_histogram, histogram};
+
+    static DESCRIBE: Once = Once::new();
+    DESCRIBE.call_once(|| {
+        describe_histogram!(
+            "settlement.sp1_proof_cycles",
+            "RISC-V cycles executed to generate an SP1 settlement proof."
+        );
+        describe_histogram!(
+            "settlement.sp1_proof_gas_used",
+            "Prover-network gas (PGU) billed for an SP1 settlement proof."
+        );
+        describe_histogram!(
+            "settlement.sp1_proof_gas_price",
+            "Prover-network gas price (PROVE base units per PGU) at settlement time."
+        );
+    });
+
+    let Some(cost) = &proof.raw_proof.cost else { return };
+
+    if let Some(cycles) = cost.cycles {
+        histogram!("settlement.sp1_proof_cycles").record(cycles as f64);
+    }
+    if let Some(gas_used) = cost.gas_used {
+        histogram!("settlement.sp1_proof_gas_used").record(gas_used as f64);
+    }
+    if let Some(gas_price) = cost.gas_price {
+        histogram!("settlement.sp1_proof_gas_price").record(gas_price as f64);
+    }
+
+    // Per-range attribution: `prev_block` is `None` for the genesis batch (its `Felt::MAX`
+    // sentinel does not fit a `u64`).
+    let block = u64::try_from(attestation.block_number).unwrap_or_default();
+    let prev_block = u64::try_from(attestation.prev_block_number).ok();
+    info!(
+        ?prev_block,
+        block,
+        cycles = ?cost.cycles,
+        gas_used = ?cost.gas_used,
+        gas_price = ?cost.gas_price,
+        deduction_amount = ?cost.deduction_amount,
+        "SP1 proof generation cost."
+    );
 }
 
 /// Converts an [`OnchainProof`] into the Garaga Groth16 calldata felts that Piltover's SP1

--- a/monitoring/grafana/dashboards/overview.json
+++ b/monitoring/grafana/dashboards/overview.json
@@ -3692,6 +3692,291 @@
       ],
       "title": "Settled Block",
       "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "RISC-V cycles executed to generate each SP1 settlement proof (prover-network only).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Cycles",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 131
+      },
+      "id": 149,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "katana_settlement_sp1_proof_cycles{instance=~\"$instance\", quantile=~\"0.5|0.9|0.99\"}",
+          "instant": false,
+          "legendFormat": "p{{quantile}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Proof Cycles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Prover-network gas (PGU) billed per SP1 settlement proof (prover-network only).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Gas (PGU)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 131
+      },
+      "id": 150,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "katana_settlement_sp1_proof_gas_used{instance=~\"$instance\", quantile=~\"0.5|0.9|0.99\"}",
+          "instant": false,
+          "legendFormat": "p{{quantile}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Proof Gas Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Estimated fee per proof = gas_used x gas_price, in $PROVE (18 decimals). Derived from the raw billed figures; see settlement metrics notes on fulfiller-vs-requester semantics.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "PROVE",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 139
+      },
+      "id": 151,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(katana_settlement_sp1_proof_gas_used{instance=~\"$instance\", quantile=\"0.5\"} * katana_settlement_sp1_proof_gas_price{instance=~\"$instance\", quantile=\"0.5\"}) / 1e18",
+          "instant": false,
+          "legendFormat": "fee (p50 x p50)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Proof Fee (PROVE)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary

Adds metrics for the **cost of each SP1 proof generation** — the actual figures the prover network bills — surfaced on the existing settlement metrics + Grafana dashboard.

New metrics (recorded per settled batch, prover-network only):
- `katana_settlement_sp1_proof_cycles` — RISC-V cycles executed
- `katana_settlement_sp1_proof_gas_used` — prover-network gas (PGU) billed
- `katana_settlement_sp1_proof_gas_price` — gas price ($PROVE base units per PGU)

Dashboard: a **Proof Cost** group (Proof Cycles, Proof Gas Used, derived Proof Fee) appended to the Settlement row.

## How it works

The cost is computed by the SP1 prover network but was discarded before reaching katana. The companion SDK change (**cartridge-gg/amd-sev-snp-attestation-sdk#1**, now merged) adds an optional `ProofCost` to `RawProof` (rides along on `OnchainProof`), populated by driving `NetworkProver` directly to capture the fulfilled request's billed figures. Here we bump the SDK rev and record the cost in the TEE backend — the only place the `OnchainProof`/cost is in scope — leaving the backend-agnostic settlement service untouched. Off-network/mock proving reports no cost, so recording is a no-op there.

## Caveats
- **Network-mode only**: cost is `None` for cpu/mock provers; can't be exercised by the mock test harness. Validated by compiling against the merged SDK commit; runtime figures require a live prover-network key.
- **Fee semantics**: `deduction_amount` is a fulfiller-balance movement, not a requester invoice, so we record the raw `gas_used`/`gas_price`/`cycles` and derive fee in Grafana rather than trust one ambiguous number.

## Dependency
Pins the SDK to the squash-merge commit of #1 on `feat/sp1-v6-alloy14` (the branch katana already tracks).

## Checks
- `DOCS_RS=1 cargo check -p katana-settlement` (against the merged SDK commit) — clean
- `cargo +nightly-2025-02-20 fmt --all` — clean
- clippy (`-p katana-settlement --all-targets`, repo deny flags) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)