### PR TITLE
feat(settlement): persist block → proof-request mapping in the DB + RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-prover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-verifier"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6492,7 +6492,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -10984,7 +10984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11004,12 +11004,12 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.6.5",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -14003,7 +14003,7 @@ dependencies = [
 [[package]]
 name = "sp1-methods"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
 dependencies = [
  "lazy_static",
  "sp1-build",
@@ -17362,7 +17362,7 @@ dependencies = [
 [[package]]
 name = "x509-verifier-rust-crypto"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=6d5d610ff458c358bcbbc0a751a53e9f3472500c#6d5d610ff458c358bcbbc0a751a53e9f3472500c"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,9 +278,9 @@ paymaster-service = { git = "https://github.com/cartridge-gg/paymaster", rev = "
 
 
 # AMD SEV-SNP SDKs
-amd-sev-snp-attestation-prover = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "6d5d610ff458c358bcbbc0a751a53e9f3472500c", default-features = false }
-amd-sev-snp-attestation-verifier = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "6d5d610ff458c358bcbbc0a751a53e9f3472500c" }
-x509-verifier-rust-crypto = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "6d5d610ff458c358bcbbc0a751a53e9f3472500c" }
+amd-sev-snp-attestation-prover = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "4ce5017721f03a199e922d989476ed3f2d071a90", default-features = false }
+amd-sev-snp-attestation-verifier = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "4ce5017721f03a199e922d989476ed3f2d071a90" }
+x509-verifier-rust-crypto = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "4ce5017721f03a199e922d989476ed3f2d071a90" }
 
 garaga_rs = { git = "https://github.com/cartridge-gg/garaga.git", rev = "061394abce25b1e6e993a7e65ee8eade4f718f96" }
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -63,12 +63,16 @@ pub fn prompt_db_migration(path: &PathBuf) -> Result<bool> {
 }
 
 /// Default per-target log levels used when `RUST_LOG` is unset.
+///
+/// The `sp1_sdk::network::prover=info` entry keeps the Succinct prover-network submit log
+/// — `Created request <request_id> in transaction <tx_hash>` — captured for every SP1
+/// settlement proof, independent of the trailing global default.
 pub const DEFAULT_LOG_FILTER: &str =
     "katana_db::mdbx=trace,cairo_native::compiler=off,pipeline=debug,stage=debug,tasks=debug,\
      executor=trace,forking::backend=trace,blockifier=off,jsonrpsee_server=off,hyper=off,\
      node=error,explorer=info,rpc=trace,pool=trace,katana_stage::downloader=trace,\
      katana_paymaster=trace,middleware::cartridge=trace,middleware::cartridge::vrf=trace,\
-     rpc::cartridge=debug,info";
+     rpc::cartridge=debug,sp1_sdk::network::prover=info,info";
 
 /// Builds the [`EnvFilter`] used by the node binaries: honors `RUST_LOG` when set,
 /// otherwise falls back to [`DEFAULT_LOG_FILTER`].
@@ -414,6 +418,12 @@ mod tests {
     fn parse_genesis_file() {
         let path = "./test-data/genesis.json";
         parse_genesis(path).unwrap();
+    }
+
+    #[test]
+    fn default_log_filter_parses() {
+        // A malformed directive would otherwise only surface at node startup.
+        EnvFilter::try_new(DEFAULT_LOG_FILTER).unwrap();
     }
 
     #[test]

--- a/crates/node/sequencer/src/lib.rs
+++ b/crates/node/sequencer/src/lib.rs
@@ -38,7 +38,10 @@ use katana_primitives::Felt;
 use katana_provider::api::messaging::{
     MessagingCheckpointProvider, MessagingL1ToL2IndexProvider, MessagingL1ToL2IndexWriter,
 };
-use katana_provider::api::settlement::{SettlementCheckpointProvider, SettlementCheckpointWriter};
+use katana_provider::api::settlement::{
+    SettlementCheckpointProvider, SettlementCheckpointWriter, SettlementProofProvider,
+    SettlementProofWriter,
+};
 use katana_provider::{
     DbProviderFactory, ForkProviderFactory, MutableProvider, ProviderFactory, ProviderRO,
     ProviderRW,
@@ -124,12 +127,15 @@ where
 impl<P> Node<P>
 where
     P: ProviderFactory + Clone + Send + Sync + 'static,
-    <P as ProviderFactory>::Provider:
-        ProviderRO + MessagingL1ToL2IndexProvider + SettlementCheckpointProvider,
+    <P as ProviderFactory>::Provider: ProviderRO
+        + MessagingL1ToL2IndexProvider
+        + SettlementCheckpointProvider
+        + SettlementProofProvider,
     <P as ProviderFactory>::ProviderMut: ProviderRW
         + MessagingCheckpointProvider
         + MessagingL1ToL2IndexWriter
         + SettlementCheckpointWriter
+        + SettlementProofWriter
         + MutableProvider,
 {
     /// Build the node components from the given [`Config`].
@@ -798,6 +804,7 @@ where
         + MessagingCheckpointProvider
         + MessagingL1ToL2IndexWriter
         + SettlementCheckpointWriter
+        + SettlementProofWriter
         + MutableProvider,
 {
     /// Start the node.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -13,6 +13,7 @@ pub mod execution;
 pub mod fee;
 pub mod message;
 pub mod receipt;
+pub mod settlement;
 pub mod transaction;
 pub mod version;
 

--- a/crates/primitives/src/settlement.rs
+++ b/crates/primitives/src/settlement.rs
@@ -1,0 +1,21 @@
+use alloy_primitives::Bytes;
+use serde::{Deserialize, Serialize};
+
+/// An opaque identifier of a settlement proof, whose meaning is defined by the proving backend that
+/// produced it.
+///
+/// The producing prover is a node-level constant (the settlement backend from the node config), so
+/// it is not stored alongside the id — it can be inferred from config. For the SP1 backend this is
+/// the 32-byte Succinct prover-network request ID, the value the Succinct explorer indexes at
+/// `/request/<id>`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
+#[serde(transparent)]
+pub struct ProofId(pub Bytes);
+
+impl ProofId {
+    /// Builds a proof id from its opaque bytes.
+    pub fn new(id: impl Into<Bytes>) -> Self {
+        Self(id.into())
+    }
+}

--- a/crates/rpc/rpc-api/src/katana.rs
+++ b/crates/rpc/rpc-api/src/katana.rs
@@ -1,10 +1,11 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use katana_primitives::block::BlockNumber;
 use katana_rpc_types::broadcasted::{
     BroadcastedDeclareTx, BroadcastedDeployAccountTx, BroadcastedInvokeTx,
 };
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
-use katana_rpc_types::settlement::SettlementStatus;
+use katana_rpc_types::settlement::{BlockProof, SettlementStatus};
 
 /// Katana-specific JSON-RPC methods.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "katana"))]
@@ -57,4 +58,9 @@ pub trait KatanaSettlementApi {
     /// Always succeeds: on a node that does not settle, both are `0`.
     #[method(name = "settlementStatus")]
     async fn settlement_status(&self) -> RpcResult<SettlementStatus>;
+
+    /// Returns the SP1 proof that settled the given block, identified by its Succinct
+    /// prover-network request ID, or `null` if the block has not been settled with a network proof.
+    #[method(name = "getBlockProof")]
+    async fn get_block_proof(&self, block: BlockNumber) -> RpcResult<Option<BlockProof>>;
 }

--- a/crates/rpc/rpc-server/src/settlement.rs
+++ b/crates/rpc/rpc-server/src/settlement.rs
@@ -3,11 +3,12 @@
 use jsonrpsee::core::{async_trait, RpcResult};
 use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
 use jsonrpsee::types::ErrorObjectOwned;
+use katana_primitives::block::BlockNumber;
 use katana_provider::api::block::BlockNumberProvider;
-use katana_provider::api::settlement::SettlementCheckpointProvider;
+use katana_provider::api::settlement::{SettlementCheckpointProvider, SettlementProofProvider};
 use katana_provider::ProviderFactory;
 use katana_rpc_api::katana::KatanaSettlementApiServer;
-use katana_rpc_types::settlement::SettlementStatus;
+use katana_rpc_types::settlement::{BlockProof, SettlementStatus};
 
 /// Serves `katana_settlementStatus` straight from storage: the durable settled-block checkpoint
 /// (written by the embedded settlement service) alongside the live local chain head.
@@ -29,7 +30,7 @@ impl<PF> SettlementApi<PF> {
 impl<PF> KatanaSettlementApiServer for SettlementApi<PF>
 where
     PF: ProviderFactory,
-    PF::Provider: BlockNumberProvider + SettlementCheckpointProvider,
+    PF::Provider: BlockNumberProvider + SettlementCheckpointProvider + SettlementProofProvider,
 {
     async fn settlement_status(&self) -> RpcResult<SettlementStatus> {
         let provider = self.provider.provider();
@@ -42,5 +43,16 @@ where
         let settled_block = provider.settled_block().map_err(internal)?.unwrap_or(0);
 
         Ok(SettlementStatus { settled_block, head })
+    }
+
+    async fn get_block_proof(&self, block: BlockNumber) -> RpcResult<Option<BlockProof>> {
+        let provider = self.provider.provider();
+
+        let internal = |e: katana_provider::ProviderError| {
+            ErrorObjectOwned::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>)
+        };
+
+        let proof_id = provider.block_proof(block).map_err(internal)?;
+        Ok(proof_id.map(|proof_id| BlockProof { block, proof_id }))
     }
 }

--- a/crates/rpc/rpc-types/src/settlement.rs
+++ b/crates/rpc/rpc-types/src/settlement.rs
@@ -1,4 +1,5 @@
 use katana_primitives::block::BlockNumber;
+use katana_primitives::settlement::ProofId;
 use serde::{Deserialize, Serialize};
 
 /// Status of the node's embedded settlement service, returned by `katana_settlementStatus`.
@@ -9,4 +10,18 @@ pub struct SettlementStatus {
     pub head: BlockNumber,
     /// The most recent block settled to the settlement chain.
     pub settled_block: BlockNumber,
+}
+
+/// The proof that settled a given block, returned by `katana_getBlockProof`.
+///
+/// The proving backend is a node-level constant (inferable from config), so only the opaque proof
+/// id is returned. For the `sp1` backend `proofId` is the `0x`-hex Succinct prover-network request
+/// ID, the value the Succinct explorer indexes at `/request/<id>`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockProof {
+    /// The block this proof settled.
+    pub block: BlockNumber,
+    /// The opaque identifier of the proof, rendered as `0x`-hex.
+    pub proof_id: ProofId,
 }

--- a/crates/settlement/src/backend/mod.rs
+++ b/crates/settlement/src/backend/mod.rs
@@ -15,6 +15,7 @@ pub mod tee;
 
 use async_trait::async_trait;
 use katana_primitives::block::BlockNumber;
+use katana_primitives::settlement::ProofId;
 use piltover::PiltoverInput;
 
 use crate::error::SettlementError;
@@ -34,7 +35,8 @@ pub trait ProvingBackend: Send + Sync {
     fn proof_type(&self) -> &'static str;
 
     /// Builds the `update_state` payload settling the state transition
-    /// `(prev_block, block]`.
+    /// `(prev_block, block]`, along with an optional [`ProofId`] to the
+    /// generated proof (`None` for backends/modes without one, e.g. mock).
     ///
     /// `prev_block = None` is the genesis case: nothing has been settled yet
     /// and the range starts at block 0.
@@ -42,5 +44,5 @@ pub trait ProvingBackend: Send + Sync {
         &self,
         prev_block: Option<BlockNumber>,
         block: BlockNumber,
-    ) -> Result<PiltoverInput, SettlementError>;
+    ) -> Result<(PiltoverInput, Option<ProofId>), SettlementError>;
 }

--- a/crates/settlement/src/backend/tee/mod.rs
+++ b/crates/settlement/src/backend/tee/mod.rs
@@ -17,6 +17,7 @@ use cainome::cairo_serde::ContractAddress as CainomeContractAddress;
 use katana_chain_spec::tee::compute_katana_tee_config_hash;
 use katana_chain_spec::ChainSpec;
 use katana_primitives::block::BlockNumber;
+use katana_primitives::settlement::ProofId;
 use katana_primitives::utils::transaction::compute_starknet_to_appchain_message_hash;
 use katana_primitives::Felt;
 use katana_provider::api::block::{BlockHashProvider, HeaderProvider};
@@ -81,7 +82,7 @@ where
         &self,
         prev_block: Option<BlockNumber>,
         block: BlockNumber,
-    ) -> Result<PiltoverInput, SettlementError> {
+    ) -> Result<(PiltoverInput, Option<ProofId>), SettlementError> {
         let attestation = {
             let provider = self.provider.provider();
             build_block_attestation(
@@ -94,9 +95,13 @@ where
             )?
         };
 
-        let sp1_proof = self.prover.prove(&attestation).await?;
+        let (sp1_proof, request_id) = self.prover.prove(&attestation).await?;
 
-        Ok(build_tee_input(&attestation, sp1_proof))
+        // The settlement service persists this opaque id without knowing any SP1 specifics; the
+        // prover type is a node-level constant, inferable from config.
+        let proof = request_id.map(|id| ProofId::new(id.as_slice().to_vec()));
+
+        Ok((build_tee_input(&attestation, sp1_proof), proof))
     }
 }
 

--- a/crates/settlement/src/backend/tee/prover.rs
+++ b/crates/settlement/src/backend/tee/prover.rs
@@ -15,7 +15,7 @@ use amd_sev_snp_attestation_prover::{
 };
 use amd_sev_snp_attestation_verifier::stub::ProcessorType;
 use amd_sev_snp_attestation_verifier::AttestationReport;
-use katana_primitives::{ContractAddress, Felt};
+use katana_primitives::{ContractAddress, Felt, B256};
 use katana_rpc_types::tee::BlockAttestation;
 use katana_tee::amd::report::AttestationReportBytes;
 use katana_tee::amd::{prepare_verifier_input_with_storage, OnchainProof, StarknetRegistryClient};
@@ -69,8 +69,12 @@ pub enum TeeProver {
 }
 
 impl TeeProver {
-    /// Produces the felts for `TEEInput.sp1_proof` from the given attestation.
-    pub async fn prove(&self, attestation: &BlockAttestation) -> Result<Vec<Felt>, TeeProverError> {
+    /// Produces the felts for `TEEInput.sp1_proof` from the given attestation, along with the
+    /// Succinct prover-network request ID of the proof (`None` for mock / off-network proving).
+    pub async fn prove(
+        &self,
+        attestation: &BlockAttestation,
+    ) -> Result<(Vec<Felt>, Option<B256>), TeeProverError> {
         match self {
             Self::Mock => {
                 // The mock journal carries the exact v1 commitment Piltover recomputes from the
@@ -88,7 +92,10 @@ impl TeeProver {
 
                 debug!(%commitment, "Synthesized mock proof journal.");
 
-                Ok(mock::serialize_mock_journal(commitment, attestation.katana_tee_config_hash))
+                Ok((
+                    mock::serialize_mock_journal(commitment, attestation.katana_tee_config_hash),
+                    None,
+                ))
             }
 
             Self::Sp1 { settlement_rpc, tee_registry, prover_key } => {
@@ -100,7 +107,9 @@ impl TeeProver {
                 .map_err(|_| TeeProverError::Timeout(PROOF_GENERATION_TIMEOUT))??;
 
                 record_proof_cost(&proof, attestation);
-                onchain_proof_to_calldata(&proof)
+                let request_id = proof.raw_proof.request_id;
+                let calldata = onchain_proof_to_calldata(&proof)?;
+                Ok((calldata, request_id))
             }
         }
     }

--- a/crates/settlement/src/service.rs
+++ b/crates/settlement/src/service.rs
@@ -9,9 +9,10 @@
 use std::sync::Arc;
 
 use katana_primitives::block::BlockNumber;
+use katana_primitives::settlement::ProofId;
 use katana_primitives::transaction::TxHash;
 use katana_provider::api::block::BlockNumberProvider;
-use katana_provider::api::settlement::SettlementCheckpointWriter;
+use katana_provider::api::settlement::{SettlementCheckpointWriter, SettlementProofWriter};
 use katana_provider::{MutableProvider, ProviderFactory};
 use tokio::sync::{broadcast, oneshot};
 use tokio::task::JoinHandle;
@@ -58,7 +59,8 @@ impl<P, N> SettlementService<P, N>
 where
     P: ProviderFactory + Clone + Send + Sync + 'static,
     <P as ProviderFactory>::Provider: BlockNumberProvider,
-    <P as ProviderFactory>::ProviderMut: SettlementCheckpointWriter + MutableProvider,
+    <P as ProviderFactory>::ProviderMut:
+        SettlementCheckpointWriter + SettlementProofWriter + MutableProvider,
     N: Clone + Send + 'static,
 {
     /// Start the settlement service.
@@ -174,6 +176,26 @@ where
     }
 }
 
+/// Persists the block -> proof mapping for the settled range `[first, last]` to the durable
+/// [`tables::SettlementProofs`] index, read back by the `katana_getBlockProof` RPC. Every block in
+/// the batch was settled by the same proof, so they all map to `proof`. Best-effort, matching
+/// [`persist_settled_block`]: a failed write is logged but never stalls settlement.
+///
+/// [`tables::SettlementProofs`]: katana_db::tables::SettlementProofs
+fn persist_block_proofs<P>(provider: &P, first: BlockNumber, last: BlockNumber, proof: ProofId)
+where
+    P: ProviderFactory,
+    <P as ProviderFactory>::ProviderMut: SettlementProofWriter + MutableProvider,
+{
+    let db = provider.provider_mut();
+    let result = (first..=last)
+        .try_for_each(|block| db.set_block_proof(block, proof.clone()))
+        .and_then(|()| db.commit());
+    if let Err(error) = result {
+        warn!(%error, first, last, "Failed to persist block -> proof mapping.");
+    }
+}
+
 /// What the settle loop should do next, given the current durable state.
 #[derive(Debug, PartialEq, Eq)]
 enum Action {
@@ -212,7 +234,8 @@ impl<P> Worker<P>
 where
     P: ProviderFactory,
     <P as ProviderFactory>::Provider: BlockNumberProvider,
-    <P as ProviderFactory>::ProviderMut: SettlementCheckpointWriter + MutableProvider,
+    <P as ProviderFactory>::ProviderMut:
+        SettlementCheckpointWriter + SettlementProofWriter + MutableProvider,
 {
     async fn run<N: Clone>(
         mut self,
@@ -241,7 +264,7 @@ where
                 Action::Settle { first, last } => {
                     let batch_start = Instant::now();
                     match self.settle_batch(first, last).await {
-                        Ok(tx_hash) => {
+                        Ok((tx_hash, proof)) => {
                             let blocks = last - first + 1;
                             self.proof_metrics
                                 .settle_batch_seconds
@@ -255,10 +278,17 @@ where
                                 first,
                                 last,
                                 tx_hash = %format!("{tx_hash:#x}"),
+                                proof = ?proof,
                                 "Settled block range."
                             );
                             self.cursor = Some(last);
                             persist_settled_block(&self.provider, last);
+                            // Record which proof settled each block in the batch. Backends without
+                            // a proof reference (e.g. mock proving)
+                            // report `None`.
+                            if let Some(proof) = proof {
+                                persist_block_proofs(&self.provider, first, last, proof);
+                            }
                             idle_deadline = Instant::now() + self.idle_flush_interval;
                             backoff = RETRY_BACKOFF_MIN;
                             consecutive_failures = 0;
@@ -367,28 +397,51 @@ where
     }
 
     /// Prove and settle the inclusive block range `[first, last]`.
+    ///
+    /// Returns the settlement-chain transaction hash and a reference to the proof that settled the
+    /// batch (`None` for mock / off-network proving).
     async fn settle_batch(
         &self,
         first: BlockNumber,
         last: BlockNumber,
-    ) -> Result<TxHash, SettlementError> {
+    ) -> Result<(TxHash, Option<ProofId>), SettlementError> {
         let prev_block = if first == 0 { None } else { Some(first - 1) };
 
         let proof_start = Instant::now();
-        let update = self.backend.prove(prev_block, last).await?;
+        let (update, proof) = self.backend.prove(prev_block, last).await?;
         self.proof_metrics.proof_generation_seconds.record(proof_start.elapsed().as_secs_f64());
 
         let update_start = Instant::now();
         let tx_hash = self.piltover.update_state(update).await?;
         self.metrics.state_update_seconds.record(update_start.elapsed().as_secs_f64());
 
-        Ok(tx_hash)
+        Ok((tx_hash, proof))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{next_action, Action};
+    use super::{next_action, persist_block_proofs, Action};
+
+    #[test]
+    fn persist_block_proofs_maps_every_block_in_range() {
+        use katana_primitives::settlement::ProofId;
+        use katana_provider::api::settlement::SettlementProofProvider;
+        use katana_provider::{DbProviderFactory, ProviderFactory};
+
+        let factory = DbProviderFactory::new_in_memory();
+        let proof = ProofId::new(vec![0x11; 32]);
+
+        // A batch settling blocks 5..=8 maps every block to the same proof.
+        persist_block_proofs(&factory, 5, 8, proof.clone());
+
+        for block in 5..=8 {
+            assert_eq!(factory.provider().block_proof(block).unwrap(), Some(proof.clone()));
+        }
+        // Blocks outside the settled range stay unmapped.
+        assert_eq!(factory.provider().block_proof(4).unwrap(), None);
+        assert_eq!(factory.provider().block_proof(9).unwrap(), None);
+    }
 
     #[test]
     fn nothing_settled() {

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,6 +1,7 @@
 use katana_primitives::contract::GenericContractInfo;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
+use katana_primitives::settlement::ProofId;
 use katana_primitives::state::StateUpdates;
 use katana_primitives::Felt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -108,6 +109,7 @@ impl_compress_and_decompress_for_table_values!(
     MigrationCheckpoint,
     PruningCheckpoint,
     SettlementCheckpoint,
+    ProofId,
     HistoricalStateRetention,
     GenericContractInfo,
     StoredBlockBodyIndices,
@@ -144,6 +146,17 @@ mod tests {
             <Receipt as Decompress>::decompress(compressed).expect("failed to decompress receipt");
 
         assert_eq!(decompressed, receipt);
+    }
+
+    #[test]
+    fn proof_id_roundtrip() {
+        use katana_primitives::settlement::ProofId;
+
+        let proof = ProofId::new(vec![0xab; 32]);
+        let compressed = proof.clone().compress().expect("failed to compress proof id");
+        let decompressed =
+            <ProofId as Decompress>::decompress(compressed).expect("failed to decompress proof id");
+        assert_eq!(decompressed, proof);
     }
 
     #[test]

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -2,6 +2,7 @@ use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
 use katana_primitives::execution::TypedTransactionExecutionInfo;
+use katana_primitives::settlement::ProofId;
 use katana_primitives::transaction::{TxHash, TxNumber};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
@@ -59,7 +60,7 @@ pub enum TableType {
     DupSort,
 }
 
-pub const NUM_TABLES: usize = 40;
+pub const NUM_TABLES: usize = 41;
 
 /// Macro to declare `libmdbx` tables.
 #[macro_export]
@@ -199,7 +200,8 @@ define_tables_enum! {[
     (MigrationCheckpoints, TableType::Table),
     (MessagingCheckpoints, TableType::Table),
     (MessagingL1ToL2, TableType::DupSort),
-    (SettlementCheckpoints, TableType::Table)
+    (SettlementCheckpoints, TableType::Table),
+    (SettlementProofs, TableType::Table)
 ]}
 
 tables! {
@@ -300,7 +302,11 @@ tables! {
 
     /// Embedded settlement service progress: the most recent block settled to the settlement
     /// chain. A singleton, keyed by a constant (see `SETTLEMENT_CHECKPOINT_KEY`).
-    SettlementCheckpoints: (u64) => SettlementCheckpoint
+    SettlementCheckpoints: (u64) => SettlementCheckpoint,
+
+    /// Maps each settled block to a prover-agnostic reference to the proof that settled it. Every
+    /// block in a settled batch maps to that batch's single proof.
+    SettlementProofs: (u64) => ProofId
 }
 
 impl Trie for ClassesTrie {
@@ -366,6 +372,7 @@ mod tests {
         assert_eq!(Tables::ALL[37].name(), MessagingCheckpoints::NAME);
         assert_eq!(Tables::ALL[38].name(), MessagingL1ToL2::NAME);
         assert_eq!(Tables::ALL[39].name(), SettlementCheckpoints::NAME);
+        assert_eq!(Tables::ALL[40].name(), SettlementProofs::NAME);
 
         assert_eq!(Tables::Headers.table_type(), TableType::Table);
         assert_eq!(Tables::BlockStateUpdates.table_type(), TableType::Table);
@@ -407,6 +414,7 @@ mod tests {
         assert_eq!(Tables::MessagingCheckpoints.table_type(), TableType::Table);
         assert_eq!(Tables::MessagingL1ToL2.table_type(), TableType::DupSort);
         assert_eq!(Tables::SettlementCheckpoints.table_type(), TableType::Table);
+        assert_eq!(Tables::SettlementProofs.table_type(), TableType::Table);
     }
 
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};

--- a/crates/storage/provider/provider-api/src/settlement.rs
+++ b/crates/storage/provider/provider-api/src/settlement.rs
@@ -1,4 +1,5 @@
 use katana_primitives::block::BlockNumber;
+use katana_primitives::settlement::ProofId;
 
 use crate::ProviderResult;
 
@@ -15,4 +16,19 @@ pub trait SettlementCheckpointProvider: Send + Sync {
 pub trait SettlementCheckpointWriter: Send + Sync {
     /// Records the most recent block settled to the settlement chain.
     fn set_settled_block(&self, block: BlockNumber) -> ProviderResult<()>;
+}
+
+/// Read access to the block -> proof mapping recorded by the settlement service.
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait SettlementProofProvider: Send + Sync {
+    /// Returns a reference to the proof that settled `block`, or `None` if the block has not been
+    /// settled (or was settled without a proof reference, e.g. mock mode).
+    fn block_proof(&self, block: BlockNumber) -> ProviderResult<Option<ProofId>>;
+}
+
+/// Write access to the block -> proof mapping recorded by the settlement service.
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait SettlementProofWriter: Send + Sync {
+    /// Records the proof that settled `block`.
+    fn set_block_proof(&self, block: BlockNumber, proof: ProofId) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -29,6 +29,7 @@ use katana_primitives::contract::{ContractAddress, GenericContractInfo};
 use katana_primitives::env::BlockEnv;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
+use katana_primitives::settlement::ProofId;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use katana_provider_api::block::{
@@ -39,7 +40,10 @@ use katana_provider_api::env::BlockEnvProvider;
 use katana_provider_api::messaging::{
     self, MessagingCheckpointProvider, MessagingL1ToL2IndexProvider, MessagingL1ToL2IndexWriter,
 };
-use katana_provider_api::settlement::{SettlementCheckpointProvider, SettlementCheckpointWriter};
+use katana_provider_api::settlement::{
+    SettlementCheckpointProvider, SettlementCheckpointWriter, SettlementProofProvider,
+    SettlementProofWriter,
+};
 use katana_provider_api::stage::StageCheckpointProvider;
 use katana_provider_api::state::HistoricalStateRetentionProvider;
 use katana_provider_api::state_update::StateUpdateProvider;
@@ -993,6 +997,19 @@ impl<Tx: DbTxMut> SettlementCheckpointWriter for DbProvider<Tx> {
     }
 }
 
+impl<Tx: DbTx> SettlementProofProvider for DbProvider<Tx> {
+    fn block_proof(&self, block: BlockNumber) -> ProviderResult<Option<ProofId>> {
+        Ok(self.0.get::<tables::SettlementProofs>(block)?)
+    }
+}
+
+impl<Tx: DbTxMut> SettlementProofWriter for DbProvider<Tx> {
+    fn set_block_proof(&self, block: BlockNumber, proof: ProofId) -> ProviderResult<()> {
+        self.0.put::<tables::SettlementProofs>(block, proof)?;
+        Ok(())
+    }
+}
+
 pub const STATE_HISTORY_RETENTION_KEY: u64 = 0;
 pub const STATE_TRIE_HISTORY_RETENTION_KEY: u64 = 1;
 
@@ -1046,6 +1063,7 @@ mod tests {
     use katana_primitives::execution::TypedTransactionExecutionInfo;
     use katana_primitives::fee::FeeInfo;
     use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
+    use katana_primitives::settlement::ProofId;
     use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
     use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxWithHash};
     use katana_primitives::{address, felt};
@@ -1053,7 +1071,8 @@ mod tests {
         BlockHashProvider, BlockNumberProvider, BlockProvider, BlockStatusProvider, BlockWriter,
     };
     use katana_provider_api::settlement::{
-        SettlementCheckpointProvider, SettlementCheckpointWriter,
+        SettlementCheckpointProvider, SettlementCheckpointWriter, SettlementProofProvider,
+        SettlementProofWriter,
     };
     use katana_provider_api::state::StateFactoryProvider;
     use katana_provider_api::transaction::TransactionProvider;
@@ -1143,6 +1162,28 @@ mod tests {
         writer.set_settled_block(42).unwrap();
         writer.commit().unwrap();
         assert_eq!(factory.provider().settled_block().unwrap(), Some(42));
+    }
+
+    #[test]
+    fn settlement_proof_roundtrip() {
+        let factory = create_db_provider();
+
+        // Absent until the settlement service writes.
+        assert_eq!(factory.provider().block_proof(5).unwrap(), None);
+
+        // A batch settling blocks 5..=7 writes the same proof reference for every block.
+        let proof = ProofId::new(vec![0xcd; 32]);
+        let writer = factory.provider_mut();
+        for block in 5..=7 {
+            writer.set_block_proof(block, proof.clone()).unwrap();
+        }
+        writer.commit().unwrap();
+
+        for block in 5..=7 {
+            assert_eq!(factory.provider().block_proof(block).unwrap(), Some(proof.clone()));
+        }
+        // Unsettled blocks stay absent.
+        assert_eq!(factory.provider().block_proof(8).unwrap(), None);
     }
 
     #[test]

--- a/crates/storage/provider/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/provider/src/providers/fork/mod.rs
@@ -15,6 +15,7 @@ use katana_primitives::contract::ContractAddress;
 use katana_primitives::env::BlockEnv;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
+use katana_primitives::settlement::ProofId;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use katana_provider_api::block::{
@@ -26,7 +27,10 @@ use katana_provider_api::messaging::{
     MessagingCheckpoint, MessagingCheckpointProvider, MessagingL1ToL2IndexProvider,
     MessagingL1ToL2IndexWriter,
 };
-use katana_provider_api::settlement::{SettlementCheckpointProvider, SettlementCheckpointWriter};
+use katana_provider_api::settlement::{
+    SettlementCheckpointProvider, SettlementCheckpointWriter, SettlementProofProvider,
+    SettlementProofWriter,
+};
 use katana_provider_api::stage::StageCheckpointProvider;
 use katana_provider_api::state::HistoricalStateRetentionProvider;
 use katana_provider_api::state_update::StateUpdateProvider;
@@ -723,6 +727,18 @@ impl<Tx1: DbTx> SettlementCheckpointProvider for ForkedProvider<Tx1> {
 impl<Tx1: DbTxMut> SettlementCheckpointWriter for ForkedProvider<Tx1> {
     fn set_settled_block(&self, block: BlockNumber) -> ProviderResult<()> {
         self.local_db.set_settled_block(block)
+    }
+}
+
+impl<Tx1: DbTx> SettlementProofProvider for ForkedProvider<Tx1> {
+    fn block_proof(&self, block: BlockNumber) -> ProviderResult<Option<ProofId>> {
+        self.local_db.block_proof(block)
+    }
+}
+
+impl<Tx1: DbTxMut> SettlementProofWriter for ForkedProvider<Tx1> {
+    fn set_block_proof(&self, block: BlockNumber, proof: ProofId) -> ProviderResult<()> {
+        self.local_db.set_block_proof(block, proof)
     }
 }
 


### PR DESCRIPTION
## Summary

Records which proof settled each block, so a settled block can be traced back to its proof (e.g. on the Succinct explorer), and exposes it over JSON-RPC. Builds on the settlement observability work (proof-cost metrics, request/tx-hash logging).

Settlement proves a whole block range per batch (one proof per batch), so **every block in a settled batch maps to that batch's single proof** (per-block keying → O(1) lookup by any block number).

## Prover-agnostic by design

The stored value is a **`ProofId`** (`katana-primitives`): an opaque, prover-defined identifier. The TEE/SP1 backend fills it with the Succinct prover-network request ID, but the storage / provider / RPC layers stay agnostic. The **prover type is a node-level config constant, so it is not stored per block** — it can be inferred from config. A future proving backend supplies its own opaque id with zero changes below the backend.

## Changes

- **SDK** (`amd-sev-snp-attestation-sdk`, merged as [PR #2](https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk/pull/2), rev `4ce5017`): `RawProof` retains the network `request_id` instead of discarding it after the cost lookup.
- Threaded up as `Option<ProofId>` through `ProvingBackend::prove` → `settle_batch` (mock / off-network → `None`).
- New per-block `SettlementProofs` table (`block → ProofId`); best-effort write beside the settled-block checkpoint, so a DB failure never stalls settlement.
- `SettlementProof{Provider,Writer}` provider traits + impls over the db and forked providers.
- `katana_getBlockProof(block)` → `{ block, proofId }` (`proofId` as `0x`-hex), or `null` if the block was not settled with a proof.
- Separate commit: pin `sp1_sdk::network::prover=info` in the default log filter so the prover-network submit log is captured for every SP1 proof.

## Testing

- Unit tests: `ProofId` codec round-trip, table registration, provider write/read round-trip, and `persist_block_proofs`. All green.
- Full `katana` binary compiles; clippy clean on the changed crates.
- End-to-end (real Succinct prover) not run locally — covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)