### PR TITLE
feat(init): point AMD TEE registry prefill at the canonical program

### DIFF
--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -92,15 +92,25 @@ mod slot;
 const MOCK_TEE_REGISTRY_SEPOLIA: Felt =
     felt!("0x037189b1807f1358074b70b3dc8ab79167bbf72cff1296286052f6dfe31c8f15");
 
-/// The canonical AMD TEE registry (`AMDTEERegistry`) deployed on Starknet Sepolia by the
-/// `cartridge-gg/katana-tee` project. It performs real SEV-SNP / SP1 Groth16 attestation
-/// verification, so it pairs with the real prover (`saya-tee`, non-mock). Used to prefill the TEE
-/// registry address when a rollup is initialized with the AMD SEV-SNP + SP1 Groth16 proof on
-/// Sepolia.
+/// The canonical AMD TEE registry (`AMDTEERegistry`) on Starknet Sepolia — the **settling**
+/// registry that pins the production TEE-VM image's SP1 program
+/// `0x0019e70e8ab3f5d697cf5a3194cbb4bcd3e77d1075f1ac53a7db7d90e088363b`. It performs real
+/// SEV-SNP / SP1 Groth16 verification, so it pairs with the real prover (`saya-tee`, non-mock).
+/// Used to prefill the TEE registry address when a rollup is initialized with the AMD SEV-SNP +
+/// SP1 Groth16 proof on Sepolia.
 ///
-/// Source: <https://github.com/cartridge-gg/katana-tee/blob/5b1316cfa4db36954e92241845aaa01d1956fc3b/deployments/sepolia.json#L10>
+/// Source: <https://github.com/cartridge-gg/katana-tee/blob/99b4096cf8f6945d978f6ea95338aa4ffd71c4aa/README.md#sepolia>
 const AMD_TEE_REGISTRY_SEPOLIA: Felt =
-    felt!("0x06ef2e9da38576240174cd4740d9e323f855dc1ce8094362f122ed7278bf32b");
+    felt!("0x06616163a5221890df1772a504f94d02122a12ed5b4c35ef7480b19b04c73761");
+
+/// The canonical AMD TEE registry (`AMDTEERegistry`) on Starknet mainnet — pins the same
+/// production SP1 program `0x0019e70e…` as the Sepolia settling registry above. Used to prefill
+/// the TEE registry address when a rollup is initialized with the AMD SEV-SNP + SP1 Groth16 proof
+/// on mainnet.
+///
+/// Source: <https://github.com/cartridge-gg/katana-tee/blob/99b4096cf8f6945d978f6ea95338aa4ffd71c4aa/deployments/mainnet.json#L11>
+const AMD_TEE_REGISTRY_MAINNET: Felt =
+    felt!("0x04ec71aee9b92315ec2a7368eace15fd82fd816dd74ce9d0afcfc7077cf9fe2d");
 
 #[derive(Debug, Args)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/bin/katana/src/cli/init/prompt.rs
+++ b/bin/katana/src/cli/init/prompt.rs
@@ -16,8 +16,8 @@ use starknet::signers::{LocalWallet, SigningKey};
 use tokio::runtime::Handle;
 
 use super::{
-    deployment, PersistentOutcome, ProofImpl, SovereignOutcome, AMD_TEE_REGISTRY_SEPOLIA,
-    MOCK_TEE_REGISTRY_SEPOLIA,
+    deployment, PersistentOutcome, ProofImpl, SovereignOutcome, AMD_TEE_REGISTRY_MAINNET,
+    AMD_TEE_REGISTRY_SEPOLIA, MOCK_TEE_REGISTRY_SEPOLIA,
 };
 use crate::cli::init::deployment::DeploymentOutcome;
 use crate::cli::init::slot::{self, PaymasterAccountArgs};
@@ -111,19 +111,22 @@ pub async fn prompt_rollup() -> Result<PersistentOutcome> {
         let mut prompt = CustomType::<ContractAddress>::new("TEE registry address")
             .with_help_message("Address of the IAMDTeeRegistry contract on the settlement chain.");
 
-        // The canonical TEE registries are already deployed on Sepolia, so prefill the matching
-        // address as the default. It stays editable in case the operator points at their own
-        // deployment. The mock registry pairs with the mock prover; the AMD registry performs real
-        // SEV-SNP / SP1 Groth16 verification.
-        if matches!(network_type, SettlementChainOpt::Sepolia) {
-            let sepolia_default = match proof_impl {
-                ProofImpl::MockTee => Some(MOCK_TEE_REGISTRY_SEPOLIA),
-                ProofImpl::AmdSevSnpSp1Groth16 => Some(AMD_TEE_REGISTRY_SEPOLIA),
-                ProofImpl::Stark => None,
-            };
-            if let Some(addr) = sepolia_default {
-                prompt = prompt.with_default(ContractAddress::from(addr));
+        // The canonical TEE registries are already deployed, so prefill the matching address as
+        // the default. It stays editable in case the operator points at their own deployment. The
+        // mock registry pairs with the mock prover; the AMD registries perform real SEV-SNP / SP1
+        // Groth16 verification and pin the production TEE-VM image's SP1 program.
+        let registry_default = match (&network_type, proof_impl) {
+            (SettlementChainOpt::Sepolia, ProofImpl::MockTee) => Some(MOCK_TEE_REGISTRY_SEPOLIA),
+            (SettlementChainOpt::Sepolia, ProofImpl::AmdSevSnpSp1Groth16) => {
+                Some(AMD_TEE_REGISTRY_SEPOLIA)
             }
+            (SettlementChainOpt::Mainnet, ProofImpl::AmdSevSnpSp1Groth16) => {
+                Some(AMD_TEE_REGISTRY_MAINNET)
+            }
+            _ => None,
+        };
+        if let Some(addr) = registry_default {
+            prompt = prompt.with_default(ContractAddress::from(addr));
         }
 
         Some(prompt.prompt()?)


### PR DESCRIPTION
## Summary

`katana init rollup` prefills the **TEE registry address** when you pick a TEE proof mode. The Sepolia AMD registry constant pointed at `0x06ef2e9d…`, which pins a **superseded** SP1 program (`0x00ed032f…`). A rollup initialized through that prefill would settle against a registry that rejects the current proofs ("Wrong program").

This updates the prefill to the **canonical settling registry** and adds a mainnet default.

## Changes
- **`AMD_TEE_REGISTRY_SEPOLIA`** `0x06ef2e9d…` → **`0x06616163a5221890df1772a504f94d02122a12ed5b4c35ef7480b19b04c73761`** — the Sepolia *settling* registry that pins the production TEE-VM image's SP1 program `0x0019e70e…` (what `saya-tee` proves). Refreshed the doc comment + `Source` link (the old `deployments/sepolia.json` link was dead — that file was removed in katana-tee).
- **Add `AMD_TEE_REGISTRY_MAINNET`** = `0x04ec71aee9b92315ec2a7368eace15fd82fd816dd74ce9d0afcfc7077cf9fe2d` — the mainnet registry pinning the same `0x0019e70e…` program.
- `prompt.rs`: prefill the AMD registry for **Mainnet + Sepolia** (previously Sepolia only).

## Context
`cartridge-gg/katana-tee` made the SP1 **v6.1.0 alloy14** build canonical (program `0x0019e70e…`), matching the production TEE-VM image. The registries that pin it are `0x06616163` (Sepolia) and `0x04ec71ae` (mainnet). Sources: [katana-tee README / mainnet.json @ `99b4096`](https://github.com/cartridge-gg/katana-tee/blob/99b4096cf8f6945d978f6ea95338aa4ffd71c4aa/README.md#deployments).

## Testing
`cargo test -p katana cli::init::tests` — 26 passed. Prefill remains editable; the `--tee` CLI-flag path (explicit `--tee-registry-address`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)