### PR TITLE
feat(tee-vm): bundle paymaster-service + vrf-server sidecars into the initrd

### DIFF
--- a/.github/workflows/amdsev-initrd-test.yml
+++ b/.github/workflows/amdsev-initrd-test.yml
@@ -144,12 +144,59 @@ jobs:
           chmod +x .katana-bin/katana
           echo "KATANA_BIN=$PWD/.katana-bin/katana" >> "$GITHUB_ENV"
 
+      - name: Download sidecar binaries (paymaster-service, vrf-server)
+        # The PR ref has no matching katana release, so pull the sidecars
+        # from the latest published katana release — this test exercises the
+        # bundling path (preflight, multi-root dynamic-lib walk incl. the
+        # libssl pin, cpio modes, reproducibility), not sidecar behavior, so
+        # exact sidecar bytes don't matter here.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          KATANA_VER="$(gh release list --repo dojoengine/katana --exclude-drafts --limit 50 \
+            --json tagName --jq '[.[].tagName | select(test("^v[0-9]"))][0]')"
+          [ -n "$KATANA_VER" ] || { echo "could not resolve latest katana release" >&2; exit 1; }
+          echo "Using sidecars from katana release: $KATANA_VER"
+          mkdir -p .sidecar-dl
+          gh release download "$KATANA_VER" \
+            --repo dojoengine/katana \
+            --pattern 'paymaster-service_*_linux_amd64.tar.gz' \
+            --pattern 'vrf-server_*_linux_amd64.tar.gz' \
+            --dir .sidecar-dl/
+          tar -xzf .sidecar-dl/paymaster-service_*_linux_amd64.tar.gz -C .sidecar-dl/
+          tar -xzf .sidecar-dl/vrf-server_*_linux_amd64.tar.gz -C .sidecar-dl/
+          PAYMASTER_BIN="$(find "$PWD/.sidecar-dl" -type f -name paymaster-service | head -n1)"
+          VRF_BIN="$(find "$PWD/.sidecar-dl" -type f -name vrf-server | head -n1)"
+          if [ -z "$PAYMASTER_BIN" ] || [ -z "$VRF_BIN" ]; then
+            echo "sidecar binary missing after extract" >&2
+            exit 1
+          fi
+          chmod +x "$PAYMASTER_BIN" "$VRF_BIN"
+          {
+            echo "PAYMASTER_BIN=$PAYMASTER_BIN"
+            echo "VRF_BIN=$VRF_BIN"
+          } >> "$GITHUB_ENV"
+
       - name: Build kernel + sealed initrd
         # Skips OVMF — the EDK2 build takes far longer than everything else
         # combined and the plain-QEMU boot test doesn't load firmware. The
         # kernel component just downloads the pinned Ubuntu .deb (vmlinuz is
         # needed for direct kernel boot below).
-        run: ./build.sh --katana "$KATANA_BIN" kernel initrd
+        run: |
+          ./build.sh --katana "$KATANA_BIN" \
+            --paymaster-bin "$PAYMASTER_BIN" --vrf-bin "$VRF_BIN" \
+            kernel initrd
+
+      - name: Assert sidecars are bundled in the initrd
+        run: |
+          zcat output/qemu/initrd.img | cpio -t 2>/dev/null > /tmp/initrd-list
+          rc=0
+          for f in bin/paymaster-service bin/vrf-server usr/lib/ssl/cert.pem; do
+            grep -q "^\.\?/\?$f\$" /tmp/initrd-list || { echo "::error::$f missing from initrd"; rc=1; }
+          done
+          grep -q 'libssl\.so\.3' /tmp/initrd-list || { echo "::error::libssl.so.3 missing from initrd"; rc=1; }
+          grep -q 'libcrypto\.so\.3' /tmp/initrd-list || { echo "::error::libcrypto.so.3 missing from initrd"; rc=1; }
+          exit "$rc"
 
       - name: Reproducibility check — rebuild initrd, compare digests
         # Byte-identical initrds are the core promise: the SEV-SNP launch
@@ -162,7 +209,9 @@ jobs:
         # the deb downloads and cpio packaging.
         run: |
           first="$(sha256sum output/qemu/initrd.img | awk '{print $1}')"
-          ./build.sh --katana "$KATANA_BIN" --install output/repro initrd
+          ./build.sh --katana "$KATANA_BIN" \
+            --paymaster-bin "$PAYMASTER_BIN" --vrf-bin "$VRF_BIN" \
+            --install output/repro initrd
           second="$(sha256sum output/repro/initrd.img | awk '{print $1}')"
           echo "first build:  $first"
           echo "second build: $second"

--- a/.github/workflows/amdsev-release.yml
+++ b/.github/workflows/amdsev-release.yml
@@ -179,11 +179,12 @@ jobs:
           # $KATANA_VER is the concrete katana release tag resolved in the ctx
           # step (`latest` is already mapped to a real tag there). katana
           # releases ship several products per tag: katana_*, paymaster-service_*,
-          # vrf-server_* — each with portable (_linux_amd64.tar.gz) and
+          # vrf-server_* — katana with portable (_linux_amd64.tar.gz) and
           # CPU-tuned (_linux_amd64_native.tar.gz) variants. The `katana_`
-          # prefix selects the product; the anchored suffix selects the
-          # portable build over `_native`. A looser `*_linux_amd64.tar.gz`
-          # matches three tarballs and breaks the single-file `tar -xzf`.
+          # prefix selects the product (the sidecars are fetched by the next
+          # step); the anchored suffix selects the portable build over
+          # `_native`. A looser `*_linux_amd64.tar.gz` matches three tarballs
+          # and breaks the single-file `tar -xzf`.
           gh release download "$KATANA_VER" \
             --repo dojoengine/katana \
             --pattern 'katana_*_linux_amd64.tar.gz' \
@@ -195,6 +196,40 @@ jobs:
             exit 1
           fi
           echo "KATANA_BIN=$KATANA_BIN" >> "$GITHUB_ENV"
+
+      - name: Download sidecar binaries (paymaster-service, vrf-server)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KATANA_VER: ${{ steps.ctx.outputs.katana_ver }}
+        run: |
+          mkdir -p .sidecar-dl
+          # The sidecars ship on the same katana release (release.yml's
+          # build-sidecars job). No `_native` variants exist for them, so each
+          # pattern matches exactly one asset. Bundled into the initrd so the
+          # guest supports --paymaster/--vrf without the (non-interactive,
+          # enclave-fatal) auto-install path.
+          gh release download "$KATANA_VER" \
+            --repo dojoengine/katana \
+            --pattern 'paymaster-service_*_linux_amd64.tar.gz' \
+            --pattern 'vrf-server_*_linux_amd64.tar.gz' \
+            --pattern 'checksums.txt' \
+            --dir .sidecar-dl/
+          # checksums.txt (release.yml's generate-checksums job) covers every
+          # release artifact including the sidecar tarballs — verify before use.
+          (cd .sidecar-dl && grep -E ' (paymaster-service|vrf-server)_[^ ]*_linux_amd64\.tar\.gz$' checksums.txt | sha256sum -c -)
+          tar -xzf .sidecar-dl/paymaster-service_*_linux_amd64.tar.gz -C .sidecar-dl/
+          tar -xzf .sidecar-dl/vrf-server_*_linux_amd64.tar.gz -C .sidecar-dl/
+          PAYMASTER_BIN="$(find "$PWD/.sidecar-dl" -type f -name paymaster-service | head -n1)"
+          VRF_BIN="$(find "$PWD/.sidecar-dl" -type f -name vrf-server | head -n1)"
+          if [ -z "$PAYMASTER_BIN" ] || [ -z "$VRF_BIN" ]; then
+            echo "sidecar binary missing after extract" >&2
+            exit 1
+          fi
+          chmod +x "$PAYMASTER_BIN" "$VRF_BIN"
+          {
+            echo "PAYMASTER_BIN=$PAYMASTER_BIN"
+            echo "VRF_BIN=$VRF_BIN"
+          } >> "$GITHUB_ENV"
 
       - name: Reuse OVMF/kernel from previous release when pins are unchanged
         # Only the initrd actually changes between releases when the OVMF
@@ -304,7 +339,9 @@ jobs:
           [ "${REUSE_OVMF:-0}" -eq 1 ] || COMPONENTS="ovmf $COMPONENTS"
           echo "Building components: $COMPONENTS"
           # shellcheck disable=SC2086
-          ./build.sh --katana "$KATANA_BIN" $COMPONENTS
+          ./build.sh --katana "$KATANA_BIN" \
+            --paymaster-bin "$PAYMASTER_BIN" --vrf-bin "$VRF_BIN" \
+            $COMPONENTS
 
           # Record artifact reuse in the build provenance (flows into the
           # release notes via the embedded build-info.txt).
@@ -402,6 +439,15 @@ jobs:
           KERNEL_SHA="$(info_get KERNEL_SHA256)"
           INITRD_SHA="$(info_get INITRD_SHA256)"
           KATANA_SHA="$(info_get KATANA_BINARY_SHA256)"
+          PAYMASTER_SHA="$(info_get PAYMASTER_BINARY_SHA256)"
+          VRF_SHA="$(info_get VRF_BINARY_SHA256)"
+          # Sidecar source pins, from the same file release.yml's
+          # build-sidecars job builds them from.
+          sidecar_rev() {
+            awk -v section="[$1]" '$0 == section {in_s=1; next} /^\[/ {in_s=0} in_s && $1 == "rev" {gsub(/"/, "", $3); print $3; exit}' ../../sidecar-versions.toml
+          }
+          PAYMASTER_REV="$(sidecar_rev paymaster-service)"
+          VRF_REV="$(sidecar_rev vrf-server)"
           LUKS_UUID="$(info_get LUKS_UUID)"
           LAUNCH_MEASUREMENT="$(info_get LAUNCH_MEASUREMENT)"
           OVMF_GIT_URL="$(info_get OVMF_GIT_URL)"
@@ -434,6 +480,8 @@ jobs:
             echo "| \`vmlinuz\` (kernel)              | \`${KERNEL_SHA}\` |"
             echo "| \`initrd.img\`                    | \`${INITRD_SHA}\` |"
             echo "| \`katana\`                        | \`${KATANA_SHA}\` |"
+            echo "| \`paymaster-service\` (embedded in \`initrd.img\`) | \`${PAYMASTER_SHA}\` |"
+            echo "| \`vrf-server\` (embedded in \`initrd.img\`)        | \`${VRF_SHA}\` |"
             echo
             echo "## Pinned upstream sources"
             echo
@@ -442,6 +490,8 @@ jobs:
             echo "| OVMF (guest BIOS) | [\`${OVMF_GIT_URL}\`](${OVMF_GIT_URL%.git}/tree/${OVMF_COMMIT}) (branch \`${OVMF_BRANCH}\`) | \`${OVMF_COMMIT}\` |"
             echo "| Linux kernel      | Ubuntu \`linux-image-unsigned-${KERNEL_VERSION}-generic\` .deb | sha256 \`$(info_get KERNEL_PKG_SHA256)\` |"
             echo "| Katana            | [\`dojoengine/katana\`](https://github.com/dojoengine/katana/releases/tag/${katana_ver}) | \`${katana_ver}\` |"
+            echo "| paymaster-service | [\`cartridge-gg/paymaster\`](https://github.com/cartridge-gg/paymaster) (prebuilt \`${katana_ver}\` release asset) | \`${PAYMASTER_REV}\` |"
+            echo "| vrf-server        | [\`cartridge-gg/vrf\`](https://github.com/cartridge-gg/vrf) (prebuilt \`${katana_ver}\` release asset) | \`${VRF_REV}\` |"
             echo
             echo "## Verify before booting"
             echo

--- a/misc/AMDSEV/build-config
+++ b/misc/AMDSEV/build-config
@@ -17,9 +17,12 @@ KERNEL_PKG_SHA256="36946f21841d1194d3614929104572a4496eb9b62e2931aac854b7ee4145c
 BUSYBOX_PKG_VERSION="1:1.36.1-6ubuntu3.1"
 BUSYBOX_PKG_SHA256="944b2728f53ceb3916cec2c962873c9951e612408099601751db2a0a5d81e0ed"
 
-# glibc runtime packages (Ubuntu packages, for dynamically linked katana)
-GLIBC_RUNTIME_PACKAGES="libc6=2.39-0ubuntu8.7 libgcc-s1=14.2.0-4ubuntu2~24.04.1 libstdc++6=14.2.0-4ubuntu2~24.04.1 zlib1g=1:1.3.dfsg-3.1ubuntu2 liblzma5=5.6.1+really5.4.5-1ubuntu0.3"
-GLIBC_RUNTIME_PACKAGE_SHA256S="libc6=955644e8bc2930a9bf8eea5e4c2237c8a118c1e2ac2845b993b6f7f35eefd293 libgcc-s1=aa7fadbe33b78bcf99885318040601c550c208929565b179891d9a3cc2aa68cd libstdc++6=a51f8de7829211db961a31f02158058ad1a95f92ac6d0a5dff6350e2821c54c0 zlib1g=0b93d16d7498f092fa3070fbbad28cdbc6b3d640f1a7681b96fc37f20d1219f1 liblzma5=d2eabd41ca77d2c2dd9d5d4ef478cccb64ffde6279c47cf4699a857d46785a52"
+# glibc runtime packages (Ubuntu packages, for dynamically linked katana and
+# the bundled sidecar binaries). libssl3t64 is the OpenSSL 3 runtime for the
+# paymaster-service sidecar (katana itself vendors openssl); the installer
+# copies only sonames actually NEEDED, so katana-only builds don't grow.
+GLIBC_RUNTIME_PACKAGES="libc6=2.39-0ubuntu8.7 libgcc-s1=14.2.0-4ubuntu2~24.04.1 libstdc++6=14.2.0-4ubuntu2~24.04.1 zlib1g=1:1.3.dfsg-3.1ubuntu2 liblzma5=5.6.1+really5.4.5-1ubuntu0.3 libssl3t64=3.0.13-0ubuntu3.11"
+GLIBC_RUNTIME_PACKAGE_SHA256S="libc6=955644e8bc2930a9bf8eea5e4c2237c8a118c1e2ac2845b993b6f7f35eefd293 libgcc-s1=aa7fadbe33b78bcf99885318040601c550c208929565b179891d9a3cc2aa68cd libstdc++6=a51f8de7829211db961a31f02158058ad1a95f92ac6d0a5dff6350e2821c54c0 zlib1g=0b93d16d7498f092fa3070fbbad28cdbc6b3d640f1a7681b96fc37f20d1219f1 liblzma5=d2eabd41ca77d2c2dd9d5d4ef478cccb64ffde6279c47cf4699a857d46785a52 libssl3t64=a446cd76c4cb329369a4d3da21246d4e90e93938485b7f820573541a5ee54ead"
 
 # CA certificates (Ubuntu package). Assembled into /usr/local/ssl/cert.pem — katana's
 # vendored openssl OPENSSLDIR — so the in-enclave sequencer can verify TLS for its

--- a/misc/AMDSEV/build.sh
+++ b/misc/AMDSEV/build.sh
@@ -78,6 +78,13 @@ function usage()
 	echo "  --mkfs-ext2 PATH        Path to a static mkfs.ext2 binary (optional; auto-built"
 	echo "                          via build-cryptsetup.sh if not provided). Required for"
 	echo "                          sealed-mode initrd."
+	echo "  --paymaster-bin PATH    Path to a prebuilt paymaster-service binary (optional;"
+	echo "                          katana release asset). Bundled into the initrd so the"
+	echo "                          guest supports --paymaster. Release images always"
+	echo "                          bundle it. Both-or-neither with --vrf-bin."
+	echo "  --vrf-bin PATH          Path to a prebuilt vrf-server binary (optional; katana"
+	echo "                          release asset). Bundled into the initrd so the guest"
+	echo "                          supports --vrf. Both-or-neither with --paymaster-bin."
 	echo "  -h|--help               Usage information"
 	echo ""
 	echo "COMPONENTS (if none specified, builds all):"
@@ -126,6 +133,20 @@ while [ -n "$1" ]; do
 	--mkfs-ext2)
 		[ -z "$2" ] && usage
 		export MKFS_EXT2_BINARY="$2"
+		shift; shift
+		;;
+	--paymaster-bin)
+		[ -z "$2" ] && usage
+		# Same export rationale as --snp-derivekey: build-initrd.sh runs
+		# as a child process and reads PAYMASTER_BINARY from the env. No
+		# auto-build fallback — the sidecars are prebuilt katana release
+		# assets, not vendored source.
+		export PAYMASTER_BINARY="$2"
+		shift; shift
+		;;
+	--vrf-bin)
+		[ -z "$2" ] && usage
+		export VRF_BINARY="$2"
 		shift; shift
 		;;
 	-h|--help)
@@ -314,6 +335,8 @@ INFO_GLIBC_RUNTIME_PACKAGE_SHA256S=""
 INFO_GLIBC_VERSION=""
 INFO_KERNEL_MODULES_EXTRA_PKG_SHA256=""
 INFO_KATANA_BINARY_SHA256=""
+INFO_PAYMASTER_BINARY_SHA256=""
+INFO_VRF_BINARY_SHA256=""
 INFO_OVMF_SHA256=""
 INFO_KERNEL_SHA256=""
 INFO_INITRD_SHA256=""
@@ -336,6 +359,8 @@ if [ -f "$BUILD_INFO" ]; then
 			GLIBC_VERSION) INFO_GLIBC_VERSION="$value" ;;
 			KERNEL_MODULES_EXTRA_PKG_SHA256) INFO_KERNEL_MODULES_EXTRA_PKG_SHA256="$value" ;;
 			KATANA_BINARY_SHA256) INFO_KATANA_BINARY_SHA256="$value" ;;
+			PAYMASTER_BINARY_SHA256) INFO_PAYMASTER_BINARY_SHA256="$value" ;;
+			VRF_BINARY_SHA256) INFO_VRF_BINARY_SHA256="$value" ;;
 			OVMF_SHA256) INFO_OVMF_SHA256="$value" ;;
 			KERNEL_SHA256) INFO_KERNEL_SHA256="$value" ;;
 			INITRD_SHA256) INFO_INITRD_SHA256="$value" ;;
@@ -371,6 +396,8 @@ if [ $BUILD_INITRD -eq 1 ]; then
 	INFO_GLIBC_RUNTIME_PACKAGE_SHA256S="$GLIBC_RUNTIME_PACKAGE_SHA256S"
 	[ -f "$INSTALL_DIR/glibc-version.txt" ] && INFO_GLIBC_VERSION="$(cat "$INSTALL_DIR/glibc-version.txt")"
 	[ -n "$KATANA_BINARY" ] && [ -f "$KATANA_BINARY" ] && INFO_KATANA_BINARY_SHA256="$(sha256sum "$KATANA_BINARY" | awk '{print $1}')"
+	[ -n "${PAYMASTER_BINARY:-}" ] && [ -f "$PAYMASTER_BINARY" ] && INFO_PAYMASTER_BINARY_SHA256="$(sha256sum "$PAYMASTER_BINARY" | awk '{print $1}')"
+	[ -n "${VRF_BINARY:-}" ] && [ -f "$VRF_BINARY" ] && INFO_VRF_BINARY_SHA256="$(sha256sum "$VRF_BINARY" | awk '{print $1}')"
 	[ -f "$INSTALL_DIR/initrd.img" ] && INFO_INITRD_SHA256="$(sha256sum "$INSTALL_DIR/initrd.img" | awk '{print $1}')"
 fi
 
@@ -395,6 +422,8 @@ fi
 	[ -n "$INFO_GLIBC_RUNTIME_PACKAGE_SHA256S" ] && echo "GLIBC_RUNTIME_PACKAGE_SHA256S=$INFO_GLIBC_RUNTIME_PACKAGE_SHA256S"
 	[ -n "$INFO_KERNEL_MODULES_EXTRA_PKG_SHA256" ] && echo "KERNEL_MODULES_EXTRA_PKG_SHA256=$INFO_KERNEL_MODULES_EXTRA_PKG_SHA256"
 	[ -n "$INFO_KATANA_BINARY_SHA256" ] && echo "KATANA_BINARY_SHA256=$INFO_KATANA_BINARY_SHA256"
+	[ -n "$INFO_PAYMASTER_BINARY_SHA256" ] && echo "PAYMASTER_BINARY_SHA256=$INFO_PAYMASTER_BINARY_SHA256"
+	[ -n "$INFO_VRF_BINARY_SHA256" ] && echo "VRF_BINARY_SHA256=$INFO_VRF_BINARY_SHA256"
 	echo ""
 	echo "# Output Checksums (SHA256)"
 	[ -n "$INFO_OVMF_SHA256" ] && echo "OVMF_SHA256=$INFO_OVMF_SHA256"

--- a/misc/AMDSEV/reproduce-release.sh
+++ b/misc/AMDSEV/reproduce-release.sh
@@ -180,11 +180,54 @@ fi
 echo "  katana binary verified: $ACTUAL_KATANA_SHA"
 
 # ------------------------------------------------------------------------------
+# 2b. The exact sidecar binaries the release embedded (if any)
+# ------------------------------------------------------------------------------
+# Releases from tee-vm-v0.2.0 bundle paymaster-service + vrf-server into the
+# initrd and record their input sha256s in build-info. Earlier releases have
+# no sidecar keys and reproduce without them.
+RECORDED_PAYMASTER_SHA="$(info_get PAYMASTER_BINARY_SHA256)"
+RECORDED_VRF_SHA="$(info_get VRF_BINARY_SHA256)"
+SIDECAR_FLAGS=()
+if [[ -n "$RECORDED_PAYMASTER_SHA" && -n "$RECORDED_VRF_SHA" ]]; then
+    for sidecar in paymaster-service vrf-server; do
+        log "Downloading $sidecar $KATANA_VER (linux_amd64 build)"
+        curl -fsSL -o "$WORKDIR/${sidecar}.tar.gz" \
+            "https://github.com/${KATANA_REPO}/releases/download/${KATANA_VER}/${sidecar}_${KATANA_VER}_linux_amd64.tar.gz" \
+            || die "could not download $sidecar $KATANA_VER from $KATANA_REPO"
+        mkdir -p "$WORKDIR/${sidecar}-bin"
+        tar -xzf "$WORKDIR/${sidecar}.tar.gz" -C "$WORKDIR/${sidecar}-bin"
+    done
+    PAYMASTER_BIN="$(find "$WORKDIR/paymaster-service-bin" -type f -name paymaster-service | head -n1)"
+    VRF_BIN="$(find "$WORKDIR/vrf-server-bin" -type f -name vrf-server | head -n1)"
+    [[ -n "$PAYMASTER_BIN" ]] || die "paymaster-service binary not found in downloaded tarball"
+    [[ -n "$VRF_BIN" ]] || die "vrf-server binary not found in downloaded tarball"
+    ACTUAL_PAYMASTER_SHA="$(sha256sum "$PAYMASTER_BIN" | awk '{print $1}')"
+    [[ "$ACTUAL_PAYMASTER_SHA" == "$RECORDED_PAYMASTER_SHA" ]] || die "paymaster-service sha256 mismatch:
+  downloaded: $ACTUAL_PAYMASTER_SHA
+  recorded:   $RECORDED_PAYMASTER_SHA
+The release asset has changed since this release was built — the initrd
+cannot be reproduced from it."
+    ACTUAL_VRF_SHA="$(sha256sum "$VRF_BIN" | awk '{print $1}')"
+    [[ "$ACTUAL_VRF_SHA" == "$RECORDED_VRF_SHA" ]] || die "vrf-server sha256 mismatch:
+  downloaded: $ACTUAL_VRF_SHA
+  recorded:   $RECORDED_VRF_SHA
+The release asset has changed since this release was built — the initrd
+cannot be reproduced from it."
+    chmod +x "$PAYMASTER_BIN" "$VRF_BIN"
+    SIDECAR_FLAGS=(--paymaster-bin "$PAYMASTER_BIN" --vrf-bin "$VRF_BIN")
+    echo "  sidecar binaries verified: $ACTUAL_PAYMASTER_SHA / $ACTUAL_VRF_SHA"
+elif [[ -n "$RECORDED_PAYMASTER_SHA" || -n "$RECORDED_VRF_SHA" ]]; then
+    die "published build-info records only one sidecar sha256 — corrupt provenance"
+else
+    echo "  build-info records no sidecar sha256s — pre-sidecar release, building without them"
+fi
+
+# ------------------------------------------------------------------------------
 # 3. Rebuild everything from source
 # ------------------------------------------------------------------------------
 log "Building OVMF + kernel + initrd (SOURCE_DATE_EPOCH=$RECORDED_EPOCH; expect ~15 minutes)"
 export SOURCE_DATE_EPOCH="$RECORDED_EPOCH"
-"$SCRIPT_DIR/build.sh" --katana "$KATANA_BIN" --install "$OUTPUT_DIR"
+"$SCRIPT_DIR/build.sh" --katana "$KATANA_BIN" ${SIDECAR_FLAGS[@]+"${SIDECAR_FLAGS[@]}"} --install "$OUTPUT_DIR"
 
 # ------------------------------------------------------------------------------
 # 4. Compare against the published release

--- a/misc/AMDSEV/scripts/build-initrd.sh
+++ b/misc/AMDSEV/scripts/build-initrd.sh
@@ -94,6 +94,13 @@ usage() {
     echo "misc/AMDSEV/build-config and run build.sh, not this script directly."
     echo ""
     echo "OPTIONAL ENVIRONMENT VARIABLES:"
+    echo "  PAYMASTER_BINARY                 Path to a prebuilt paymaster-service binary"
+    echo "                                   (katana release asset). Bundled at /bin in"
+    echo "                                   the initrd so the guest supports --paymaster."
+    echo "  VRF_BINARY                       Path to a prebuilt vrf-server binary (katana"
+    echo "                                   release asset). Bundled at /bin so the guest"
+    echo "                                   supports --vrf. Both-or-neither with"
+    echo "                                   PAYMASTER_BINARY."
     echo "  KATANA_UNSEALED_BUILD            Set to 1 to opt OUT of the sealed build."
     echo "                                   Produces an unsealed-only initrd that mounts"
     echo "                                   /dev/sda as plain ext4: no cryptsetup, no"
@@ -193,6 +200,9 @@ echo "Static binaries (sealed-mode only):"
 echo "  cryptsetup binary:     ${CRYPTSETUP_BINARY:-<not set>}"
 echo "  mkfs.ext2 binary:      ${MKFS_EXT2_BINARY:-<not set>}"
 echo "  snp-derivekey binary:  ${SNP_DERIVEKEY_BINARY:-<not set>}"
+echo "Sidecar binaries (optional):"
+echo "  paymaster-service:     ${PAYMASTER_BINARY:-<not set>}"
+echo "  vrf-server:            ${VRF_BINARY:-<not set>}"
 
 if [[ -z "${SOURCE_DATE_EPOCH:-}" ]]; then
     die "SOURCE_DATE_EPOCH must be set for reproducible builds"
@@ -275,6 +285,29 @@ if [[ "$SEALED_STORAGE_BUILD" -eq 1 ]]; then
         || die "SNP_DERIVEKEY_BINARY=$SNP_DERIVEKEY_BINARY does not exist or is not executable"
 fi
 
+# Cartridge sidecar binaries (paymaster-service + vrf-server), prebuilt release
+# assets supplied via PAYMASTER_BINARY / VRF_BINARY (build.sh --paymaster-bin /
+# --vrf-bin). Optional: when unset the image builds WITHOUT sidecars and
+# katana's --paymaster/--vrf flags fail in the guest (the sidecar resolver
+# falls through to an interactive download prompt that dies on the enclave's
+# non-TTY stdin). Release builds always supply both (amdsev-release.yml).
+# Both-or-neither: --vrf uses the paymaster as relayer/forwarder, so a
+# half-bundled image is always a misconfiguration.
+PAYMASTER_BINARY="${PAYMASTER_BINARY:-}"
+VRF_BINARY="${VRF_BINARY:-}"
+if [[ -n "$PAYMASTER_BINARY" || -n "$VRF_BINARY" ]]; then
+    [[ -n "$PAYMASTER_BINARY" && -n "$VRF_BINARY" ]] \
+        || die "PAYMASTER_BINARY and VRF_BINARY must be supplied together (got only one)"
+    PAYMASTER_BINARY="$(to_abs_path "$PAYMASTER_BINARY")"
+    VRF_BINARY="$(to_abs_path "$VRF_BINARY")"
+    [[ -x "$PAYMASTER_BINARY" ]] \
+        || die "PAYMASTER_BINARY=$PAYMASTER_BINARY does not exist or is not executable"
+    [[ -x "$VRF_BINARY" ]] \
+        || die "VRF_BINARY=$VRF_BINARY does not exist or is not executable"
+else
+    log_warn "PAYMASTER_BINARY/VRF_BINARY not set — image will NOT support --paymaster/--vrf in the guest"
+fi
+
 log_ok "Preflight validation complete (sealed-storage build: $([ "$SEALED_STORAGE_BUILD" -eq 1 ] && echo yes || echo no))"
 
 elf_interpreter() {
@@ -288,6 +321,21 @@ if [[ -n "$KATANA_INTERPRETER" ]]; then
 else
     log_warn "Katana has no ELF interpreter; treating it as statically linked"
 fi
+
+# All bundled dynamic ELF executables must share one interpreter — the dynamic
+# runtime installer walks a single pinned-glibc package pool. Static binaries
+# (no interpreter) are fine alongside dynamic ones.
+RUNTIME_INTERPRETER="$KATANA_INTERPRETER"
+for extra_bin in "$PAYMASTER_BINARY" "$VRF_BINARY"; do
+    [[ -n "$extra_bin" ]] || continue
+    extra_interp="$(elf_interpreter "$extra_bin" || true)"
+    [[ -n "$extra_interp" ]] || continue
+    if [[ -z "$RUNTIME_INTERPRETER" ]]; then
+        RUNTIME_INTERPRETER="$extra_interp"
+    elif [[ "$extra_interp" != "$RUNTIME_INTERPRETER" ]]; then
+        die "interpreter mismatch: $extra_bin wants $extra_interp, other binaries use $RUNTIME_INTERPRETER"
+    fi
+done
 
 WORK_DIR="$(mktemp -d)"
 cleanup() {
@@ -356,9 +404,9 @@ pushd "$PACKAGES_DIR" >/dev/null
 
 : "${BUSYBOX_PKG_VERSION:?BUSYBOX_PKG_VERSION not set - required for reproducible builds}"
 : "${KERNEL_MODULES_EXTRA_PKG_VERSION:?KERNEL_MODULES_EXTRA_PKG_VERSION not set - required for reproducible builds}"
-if [[ -n "$KATANA_INTERPRETER" ]]; then
-    : "${GLIBC_RUNTIME_PACKAGES:?GLIBC_RUNTIME_PACKAGES not set - required for reproducible dynamic Katana builds}"
-    : "${GLIBC_RUNTIME_PACKAGE_SHA256S:?GLIBC_RUNTIME_PACKAGE_SHA256S not set - required for reproducible dynamic Katana builds}"
+if [[ -n "$RUNTIME_INTERPRETER" ]]; then
+    : "${GLIBC_RUNTIME_PACKAGES:?GLIBC_RUNTIME_PACKAGES not set - required for reproducible dynamic binary builds}"
+    : "${GLIBC_RUNTIME_PACKAGE_SHA256S:?GLIBC_RUNTIME_PACKAGE_SHA256S not set - required for reproducible dynamic binary builds}"
 fi
 
 log_info "Downloading busybox-static=${BUSYBOX_PKG_VERSION}"
@@ -372,7 +420,7 @@ fi
 log_info "Downloading linux-modules-extra-${KERNEL_VERSION}-generic=${KERNEL_MODULES_EXTRA_PKG_VERSION}"
 apt-get download "linux-modules-extra-${KERNEL_VERSION}-generic=${KERNEL_MODULES_EXTRA_PKG_VERSION}"
 
-if [[ -n "$KATANA_INTERPRETER" ]]; then
+if [[ -n "$RUNTIME_INTERPRETER" ]]; then
     for package_spec in $GLIBC_RUNTIME_PACKAGES; do
         package_name="${package_spec%%=*}"
         [[ "$package_name" != "$package_spec" ]] || die "invalid GLIBC_RUNTIME_PACKAGES entry: $package_spec"
@@ -407,7 +455,7 @@ fi
 log_info "Verifying linux-modules-extra checksum"
 verify_package_sha256 "linux-modules-extra-${KERNEL_VERSION}-generic" "$KERNEL_MODULES_EXTRA_PKG_SHA256"
 
-if [[ -n "$KATANA_INTERPRETER" ]]; then
+if [[ -n "$RUNTIME_INTERPRETER" ]]; then
     for package_spec in $GLIBC_RUNTIME_PACKAGES; do
         package_name="${package_spec%%=*}"
         expected_sha="$(expected_runtime_sha256 "$package_name" || true)"
@@ -439,7 +487,7 @@ fi
 log_info "Extracting linux-modules-extra"
 dpkg-deb -x "$PACKAGES_DIR"/linux-modules-extra-*.deb "$EXTRACTED_DIR"
 
-if [[ -n "$KATANA_INTERPRETER" ]]; then
+if [[ -n "$RUNTIME_INTERPRETER" ]]; then
     for package_spec in $GLIBC_RUNTIME_PACKAGES; do
         package_name="${package_spec%%=*}"
         package_deb="$(find_downloaded_deb "$package_name")"
@@ -526,6 +574,25 @@ if [[ "$SEALED_STORAGE_BUILD" -eq 1 ]]; then
     cp "$SNP_DERIVEKEY_BINARY" bin/snp-derivekey
     chmod +x bin/snp-derivekey
     log_ok "snp-derivekey installed"
+fi
+
+# ------------------------------------------------------------------------------
+# Install Cartridge sidecar binaries (paymaster-service + vrf-server)
+# ------------------------------------------------------------------------------
+# Installed at /bin so katana's sidecar resolution finds them at the $PATH
+# step (the init exports PATH=/bin) — the later resolution steps (katana home
+# dir, interactive GitHub download) never run in the enclave.
+if [[ -n "$PAYMASTER_BINARY" ]]; then
+    log_info "Installing paymaster-service from $PAYMASTER_BINARY"
+    cp "$PAYMASTER_BINARY" bin/paymaster-service
+    chmod +x bin/paymaster-service
+    log_ok "paymaster-service installed"
+fi
+if [[ -n "$VRF_BINARY" ]]; then
+    log_info "Installing vrf-server from $VRF_BINARY"
+    cp "$VRF_BINARY" bin/vrf-server
+    chmod +x bin/vrf-server
+    log_ok "vrf-server installed"
 fi
 
 # ------------------------------------------------------------------------------
@@ -764,7 +831,15 @@ install_dynamic_runtime() {
     local optional_lib=""
 
     declare -A copied_runtime=()
-    local elf_queue=("$INITRD_DIR/bin/katana")
+    # Seed the DT_NEEDED walk with every dynamic executable in the image
+    # (katana + any bundled sidecars) — a lib needed only by a sidecar (e.g.
+    # paymaster-service's libssl.so.3) must be copied too. Static roots are
+    # harmless: elf_needed yields nothing for them.
+    local elf_queue=()
+    local root_rel
+    for root_rel in "${DYNAMIC_ELF_ROOTS[@]}"; do
+        elf_queue+=("$INITRD_DIR/$root_rel")
+    done
 
     install_runtime_elf() {
         runtime_source="$1"
@@ -847,8 +922,12 @@ cp "$KATANA_BINARY" bin/katana
 chmod +x bin/katana
 log_ok "Katana installed"
 
-if [[ -n "$KATANA_INTERPRETER" ]]; then
-    install_dynamic_runtime "$KATANA_INTERPRETER"
+DYNAMIC_ELF_ROOTS=(bin/katana)
+[[ -n "$PAYMASTER_BINARY" ]] && DYNAMIC_ELF_ROOTS+=(bin/paymaster-service)
+[[ -n "$VRF_BINARY" ]] && DYNAMIC_ELF_ROOTS+=(bin/vrf-server)
+
+if [[ -n "$RUNTIME_INTERPRETER" ]]; then
+    install_dynamic_runtime "$RUNTIME_INTERPRETER"
 
     # Record the actual glibc version from the installed libc.so.6. The package
     # version (e.g. 2.39-0ubuntu8.7) sits in GLIBC_RUNTIME_PACKAGES already; this
@@ -882,6 +961,13 @@ cat > init <<'INIT_EOF'
 set -eu
 export PATH=/bin
 export LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/lib:/usr/lib
+# SSL_CERT_FILE: belt-and-braces for OpenSSL-linked sidecars (the CA bundle is
+# also installed at each stack's compiled-in default path). HOME: katana's
+# sidecar resolver eagerly derives ~/.katana even when the $PATH lookup will
+# hit; /etc/passwd already resolves root's home to / via nss_files — this
+# export just removes the passwd-lookup dependency.
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+export HOME=/
 
 # log writes to stderr so command substitution like `$(strip_reserved_args ...)`
 # captures only the function's real output. Both stdout and stderr are
@@ -1667,7 +1753,13 @@ if [[ -n "${CA_CERTIFICATES_PKG_VERSION:-}" ]]; then
     cp usr/local/ssl/cert.pem etc/ssl/certs/ca-certificates.crt   # rustls-native-certs (primary)
     cp usr/local/ssl/cert.pem etc/ssl/cert.pem                    # rustls/alpine fallback
     cp usr/local/ssl/cert.pem etc/pki/tls/certs/ca-bundle.crt     # rustls/RHEL fallback
-    log_ok "CA bundle installed (openssl + rustls paths, $CA_N roots)"
+    # Ubuntu-built libssl3 consumers (the paymaster-service sidecar): the
+    # system OpenSSL's compiled-in OPENSSLDIR is /usr/lib/ssl, so its default
+    # cert file is /usr/lib/ssl/cert.pem. (The /usr/local/ssl path above
+    # serves katana's VENDORED openssl only.)
+    mkdir -p usr/lib/ssl
+    cp usr/local/ssl/cert.pem usr/lib/ssl/cert.pem
+    log_ok "CA bundle installed (vendored openssl + rustls + system openssl paths, $CA_N roots)"
 else
     log_warn "CA_CERTIFICATES_PKG_VERSION not set — enclave will have NO CA bundle (outbound HTTPS will fail)"
 fi
@@ -1688,17 +1780,19 @@ log_info "Normalizing file modes"
 find . -type d -exec chmod 0755 {} +
 find . -type f -exec chmod 0644 {} +
 chmod 0755 bin/busybox bin/katana init
+[[ -n "$PAYMASTER_BINARY" ]] && chmod 0755 bin/paymaster-service
+[[ -n "$VRF_BINARY" ]] && chmod 0755 bin/vrf-server
 if [[ "$SEALED_STORAGE_BUILD" -eq 1 ]]; then
     chmod 0755 bin/cryptsetup bin/mkfs.ext2
     [[ -n "$SNP_DERIVEKEY_BINARY" ]] && chmod 0755 bin/snp-derivekey
 fi
-# The ELF interpreter is execve'd by the kernel when launching katana, so it
-# must keep its execute bit through the 0644 sweep above — a non-executable
-# interpreter makes every dynamic exec fail with EACCES ("Permission
-# denied", exit 126). Shared libraries stay 0644: the loader only opens and
-# mmaps them, which needs read permission, not execute.
-if [[ -n "$KATANA_INTERPRETER" ]]; then
-    chmod 0755 "${KATANA_INTERPRETER#/}"
+# The ELF interpreter is execve'd by the kernel when launching katana (and
+# the sidecars), so it must keep its execute bit through the 0644 sweep above
+# — a non-executable interpreter makes every dynamic exec fail with EACCES
+# ("Permission denied", exit 126). Shared libraries stay 0644: the loader
+# only opens and mmaps them, which needs read permission, not execute.
+if [[ -n "$RUNTIME_INTERPRETER" ]]; then
+    chmod 0755 "${RUNTIME_INTERPRETER#/}"
 fi
 chmod 1777 tmp
 


### PR DESCRIPTION
## Why

The cartridge-appchain SEV-SNP enclave deployments currently run katana **without** `--paymaster --cartridge.paymaster --cartridge.controllers --vrf` (unlike the mock/bare-metal deployment): the generic TEE-VM image doesn't ship the `paymaster-service`/`vrf-server` binaries, so katana's sidecar resolver falls through to its interactive GitHub-download prompt, which hard-fails on the enclave's non-TTY stdin — katana exits(1) before settling.

## What

Bundle both sidecar binaries (already published as assets on every katana release by `release.yml`'s `build-sidecars` job) into the initrd at `/bin`, where the guest init's `PATH=/bin` makes katana's `$PATH` resolution step hit — the auto-install path never runs.

- **`build-initrd.sh`** — optional `PAYMASTER_BINARY`/`VRF_BINARY` env inputs (both-or-neither: `--vrf` uses the paymaster as relayer, a half-bundled image is always a misconfig). Installed at `bin/`, exec bits preserved through the cpio 0644 sweep. The dynamic-runtime `DT_NEEDED` walk is now seeded from **every** bundled executable, so libs needed only by a sidecar are copied too — `paymaster-service` is glibc-dynamic and needs `libssl.so.3`/`libcrypto.so.3`, which katana (vendored openssl) doesn't pull in. It also links Ubuntu's **system** OpenSSL (`OPENSSLDIR=/usr/lib/ssl`), so the CA bundle is additionally installed at `/usr/lib/ssl/cert.pem` (third TLS stack alongside katana's vendored openssl + rustls); the init exports `SSL_CERT_FILE` and `HOME=/` as belt-and-braces.
- **`build-config`** — pin `libssl3t64=3.0.13-0ubuntu3.11` (+ .deb sha256). Harmless for katana-only builds: the installer copies only sonames actually NEEDED.
- **`build.sh`** — `--paymaster-bin`/`--vrf-bin` flags (mirroring `--cryptsetup`); sidecar input sha256s recorded in `build-info.txt` (`PAYMASTER_BINARY_SHA256`/`VRF_BINARY_SHA256`) for provenance. The sidecars are *not* copied into the output tarball — they live inside the measured initrd; the recorded shas cover reproduction.
- **`amdsev-release.yml`** — downloads the two `*_linux_amd64.tar.gz` sidecar assets from the same katana release, verifies them against the release's `checksums.txt`, and always passes them to `build.sh` (no released image can silently lack them). Release notes gain sidecar checksum rows + source pins from `sidecar-versions.toml`.
- **`amdsev-initrd-test.yml`** — fetches sidecars from the latest katana release (the PR ref has no matching release), passes them to **both** build invocations so the reproducibility diff stays meaningful, and asserts `bin/paymaster-service`, `bin/vrf-server`, `libssl.so.3`, `libcrypto.so.3`, and `usr/lib/ssl/cert.pem` land in the initrd. Boot smoke test args unchanged (sidecar runtime behavior is covered by the hardware e2e + the appchain deployment, and the paymaster needs outbound HTTPS = flake surface).
- **`reproduce-release.sh`** — when build-info records the sidecar shas, download + sha-verify the assets and pass the flags; pre-sidecar `tee-vm-v0.1.x` tags reproduce unchanged.
- **`verify-build.sh`** — no change needed: sidecars live inside `initrd.img`, whose sha256 it already checks.

## Measurement impact

The initrd bytes change, so the next release (`tee-vm-v0.2.0+katana-…`) gets a **new launch measurement**, published as usual (`launch-measurement-<tag>.txt`). The proven SP1 program and `katanaTeeConfigHash` are untouched, so on-chain settlement against the deployed `AMDTeeRegistry` keeps verifying; external verifiers re-pin the published measurement.

Initrd grows ~15–20 MB gzipped (unstripped sidecars + openssl libs). Deliberately not stripped: keeping bytes identical to the release assets is what makes the recorded shas / reproduction trivial.

## Follow-up

- Cut `tee-vm-v0.2.0` via `amdsev-release-dispatch` after merge.
- cartridge-appchain enables the flags + bumps its pin (PR in that repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)