### PR TITLE
feat(tee-vm): embed the cairo-native katana build in the TEE VM image

### DIFF
--- a/.github/workflows/amdsev-initrd-test.yml
+++ b/.github/workflows/amdsev-initrd-test.yml
@@ -7,18 +7,19 @@ name: amdsev-initrd-test
 # virtio-serial control channel, the forwarded RPC endpoint answers
 # starknet_chainId, and the graceful `stop` command powers the guest off.
 #
-# The embedded katana is built FROM THIS REF via scripts/build-gnu.sh — the
-# same script, profile, and TEE feature set as the published portable
-# release binary — so the boot test validates the tree under test end to
-# end (a PR that breaks `--tee sev-snp` fails here, before any release).
+# The embedded katana is built FROM THIS REF via scripts/build-gnu.sh
+# --native — the profile and feature set of the published `_native`
+# linux_amd64 binary (the one amdsev-release.yml embeds) — so the boot test
+# validates the tree under test end to end (a PR that breaks `--tee sev-snp`
+# or the in-guest cairo-native link path fails here, before any release).
 #
 # Runner
 # ------
 # Stock ubuntu-latest. No SEV-SNP hardware is needed: the smoke test boots
 # without OVMF/SEV, and the sealed-mode initrd takes its unsealed mount path
 # (plain ext4 on /dev/sda) when the cmdline carries no
-# KATANA_EXPECTED_LUKS_UUID. Docker (for the static cryptsetup build) and
-# /dev/kvm are both available on ubuntu-latest.
+# KATANA_EXPECTED_LUKS_UUID. Docker (for the static cryptsetup + ld builds)
+# and /dev/kvm are both available on ubuntu-latest.
 
 on:
   push:
@@ -42,7 +43,9 @@ defaults:
 jobs:
   build-katana:
     runs-on: ubuntu-latest-32-cores
-    timeout-minutes: 45
+    # 60 (was 45): the native feature statically links LLVM/MLIR and fat-LTOs
+    # the result — cold-cache builds run well past the old budget.
+    timeout-minutes: 60
     # katana-dev carries the full build toolchain including asdf/scarb for
     # the contract artifacts that katana-contracts embeds at compile time.
     container:
@@ -58,7 +61,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: amdsev-build-katana
+          # -native suffix: the native feature set compiles a very different
+          # dep graph (cairo-native, melior, llvm-sys) — don't thrash caches
+          # from the old portable builds.
+          key: amdsev-build-katana-native
 
       - name: Restore cached contract artifacts
         id: contracts-cache
@@ -74,15 +80,17 @@ jobs:
         working-directory: .
         run: make contracts
 
-      - name: Build katana (portable release configuration)
-        # build-gnu.sh is the script behind the published portable
-        # linux_amd64 binary: performance profile, deterministic RUSTFLAGS,
-        # and the client,init-slot,jemalloc,tee-snp,tee-mock feature set.
-        # ubuntu-latest is noble (glibc 2.39), matching the initrd's pinned
+      - name: Build katana (native release configuration)
+        # build-gnu.sh --native matches the FEATURE SET of the published
+        # `_native` linux_amd64 binary (the asset amdsev-release.yml embeds):
+        # performance profile plus client,init-slot,jemalloc,tee-snp,
+        # tee-mock,native. The katana-dev container ships LLVM/MLIR 19 with
+        # MLIR_SYS_190_PREFIX etc. preset, so no extra install step. The
+        # container is noble-based (glibc 2.39), matching the initrd's pinned
         # GLIBC_RUNTIME_PACKAGES, so the binary's symbol requirements cannot
         # exceed what the guest ships.
         working-directory: .
-        run: ./scripts/build-gnu.sh
+        run: ./scripts/build-gnu.sh --native
 
       - name: Upload katana binary
         uses: actions/upload-artifact@v4
@@ -187,11 +195,15 @@ jobs:
             --paymaster-bin "$PAYMASTER_BIN" --vrf-bin "$VRF_BIN" \
             kernel initrd
 
-      - name: Assert sidecars are bundled in the initrd
+      - name: Assert sidecars and native-linking inputs are bundled in the initrd
         run: |
           zcat output/qemu/initrd.img | cpio -t 2>/dev/null > /tmp/initrd-list
           rc=0
-          for f in bin/paymaster-service bin/vrf-server usr/lib/ssl/cert.pem; do
+          # bin/ld + lib64/libc.so + libc_nonshared.a are the cairo-native
+          # runtime-link inputs (see build-initrd.sh's "cairo-native link
+          # inputs" section).
+          for f in bin/paymaster-service bin/vrf-server usr/lib/ssl/cert.pem \
+                   bin/ld lib64/libc.so usr/lib/x86_64-linux-gnu/libc_nonshared.a; do
             grep -q "^\.\?/\?$f\$" /tmp/initrd-list || { echo "::error::$f missing from initrd"; rc=1; }
           done
           grep -q 'libssl\.so\.3' /tmp/initrd-list || { echo "::error::libssl.so.3 missing from initrd"; rc=1; }
@@ -205,8 +217,8 @@ jobs:
         # SOURCE_DATE_EPOCH, same pins, fresh output dir — any digest drift
         # here means nondeterminism crept into the packaging (unsorted
         # globs, leaked timestamps, host paths). The second build reuses the
-        # already-built static cryptsetup/snp-derivekey, so it only repeats
-        # the deb downloads and cpio packaging.
+        # already-built static cryptsetup/snp-derivekey/ld (skip-if-cached),
+        # so it only repeats the deb downloads and cpio packaging.
         run: |
           first="$(sha256sum output/qemu/initrd.img | awk '{print $1}')"
           ./build.sh --katana "$KATANA_BIN" \
@@ -224,7 +236,11 @@ jobs:
       - name: Boot smoke test
         # --output-dir is required: the script's default resolves relative to
         # scripts/, not the directory where build.sh writes its artifacts.
-        run: ./scripts/test-initrd.sh --output-dir output/qemu --timeout 300
+        # KATANA_TEST_NATIVE=1 boots with --enable-native-compilation and
+        # exercises the in-guest cairo-native link path (bundled /bin/ld +
+        # generated /lib64/libc.so) — valid because the katana under test is
+        # a --native build.
+        run: KATANA_TEST_NATIVE=1 ./scripts/test-initrd.sh --output-dir output/qemu --timeout 300
 
       - name: Upload initrd for debugging
         # Only on failure — the artifact exists to reproduce a failed boot

--- a/.github/workflows/amdsev-lint.yml
+++ b/.github/workflows/amdsev-lint.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: shellcheck scripts
         # shellcheck is preinstalled on ubuntu-latest runners.
-        run: shellcheck -S warning build.sh start-vm.sh verify-build.sh reproduce-release.sh scripts/*.sh
+        run: shellcheck -S warning build.sh start-vm.sh install.sh verify-build.sh reproduce-release.sh scripts/*.sh
 
       - name: shellcheck guest init (POSIX sh)
         # The init script ships inside the initrd and runs under busybox sh.
@@ -67,6 +67,15 @@ jobs:
         # trailing, duplicate, glob-adjacent). The forward is otherwise only
         # observable by booting the enclave and scraping /metrics.
         run: ./scripts/test-parse-metrics-port.sh
+
+      - name: Unit test install.sh helpers
+        # Fast, no-network tests for the operator installer: validators, tag
+        # URL-encoding, source-tarball subtree extraction, checksum gating,
+        # config.env round-trip, and that install.sh's parse_metrics_port copy
+        # stays in sync with start-vm.sh. The full download path is covered by
+        # the same script under KATANA_INSTALL_TEST_NETWORK=1 (manual — the
+        # release tarball is too heavy for every PR).
+        run: ./scripts/test-install.sh
 
       - name: actionlint (amdsev workflows only)
         working-directory: .

--- a/.github/workflows/amdsev-release.yml
+++ b/.github/workflows/amdsev-release.yml
@@ -180,14 +180,20 @@ jobs:
           # step (`latest` is already mapped to a real tag there). katana
           # releases ship several products per tag: katana_*, paymaster-service_*,
           # vrf-server_* — katana with portable (_linux_amd64.tar.gz) and
-          # CPU-tuned (_linux_amd64_native.tar.gz) variants. The `katana_`
+          # cairo-native (_linux_amd64_native.tar.gz) variants. The `katana_`
           # prefix selects the product (the sidecars are fetched by the next
-          # step); the anchored suffix selects the portable build over
-          # `_native`. A looser `*_linux_amd64.tar.gz` matches three tarballs
-          # and breaks the single-file `tar -xzf`.
+          # step); the `_native` suffix selects the cairo-native build
+          # (LLVM/MLIR statically linked; its DT_NEEDED set is covered by the
+          # initrd's GLIBC_RUNTIME_PACKAGES pins) so the guest supports
+          # --enable-native-compilation. The pattern uniquely matches one
+          # asset. NOTE: unlike the portable variant, the native asset is a
+          # plain GH-runner build — NOT reproducible-from-source yet; the
+          # image's verification story bottoms out at this asset's recorded
+          # sha256 (KATANA_BINARY_SHA256 + KATANA_ASSET_VARIANT in
+          # build-info.txt).
           gh release download "$KATANA_VER" \
             --repo dojoengine/katana \
-            --pattern 'katana_*_linux_amd64.tar.gz' \
+            --pattern 'katana_*_linux_amd64_native.tar.gz' \
             --dir .katana-dl/
           tar -xzf .katana-dl/*.tar.gz -C .katana-dl/
           KATANA_BIN="$(find "$PWD/.katana-dl" -type f -name katana -perm -u+x | head -n1)"
@@ -356,10 +362,17 @@ jobs:
         # build-info only records the binary's sha256; pin the human-readable
         # katana release tag too, so the provenance is self-describing and
         # reproduce-release.sh can cross-check it against the +katana- tag
-        # suffix.
+        # suffix. KATANA_ASSET_VARIANT tells reproduce-release.sh which
+        # release asset to fetch (`native` → *_linux_amd64_native.tar.gz);
+        # pre-native releases have no such key and fall back to the portable
+        # asset.
         env:
           KATANA_VER: ${{ steps.ctx.outputs.katana_ver }}
-        run: echo "KATANA_VERSION=${KATANA_VER}" >> output/qemu/build-info.txt
+        run: |
+          {
+            echo "KATANA_VERSION=${KATANA_VER}"
+            echo "KATANA_ASSET_VARIANT=native"
+          } >> output/qemu/build-info.txt
 
       - name: Build snp-tools
         # snp-tools binaries are NOT shipped as release artifacts (separate
@@ -457,7 +470,10 @@ jobs:
           {
             echo "# Katana TEE VM ${tag}"
             echo
-            echo "Sealed-mode SEV-SNP confidential VM image bundling Katana **${katana_ver}**."
+            echo "Sealed-mode SEV-SNP confidential VM image bundling Katana **${katana_ver}**"
+            echo "(cairo-native build — in-guest native execution is available behind katana's"
+            echo "\`--enable-native-compilation\` flag, off by default; deployments opt in via"
+            echo "their fw_cfg \`--katana-args\`)."
             echo
             echo "## Sealed launch measurement (SHA-384)"
             echo
@@ -479,7 +495,7 @@ jobs:
             echo "| \`OVMF.fd\` (guest BIOS firmware) | \`${OVMF_SHA}\` |"
             echo "| \`vmlinuz\` (kernel)              | \`${KERNEL_SHA}\` |"
             echo "| \`initrd.img\`                    | \`${INITRD_SHA}\` |"
-            echo "| \`katana\`                        | \`${KATANA_SHA}\` |"
+            echo "| \`katana\` (cairo-native build)   | \`${KATANA_SHA}\` |"
             echo "| \`paymaster-service\` (embedded in \`initrd.img\`) | \`${PAYMASTER_SHA}\` |"
             echo "| \`vrf-server\` (embedded in \`initrd.img\`)        | \`${VRF_SHA}\` |"
             echo
@@ -489,7 +505,7 @@ jobs:
             echo "|---|---|---|"
             echo "| OVMF (guest BIOS) | [\`${OVMF_GIT_URL}\`](${OVMF_GIT_URL%.git}/tree/${OVMF_COMMIT}) (branch \`${OVMF_BRANCH}\`) | \`${OVMF_COMMIT}\` |"
             echo "| Linux kernel      | Ubuntu \`linux-image-unsigned-${KERNEL_VERSION}-generic\` .deb | sha256 \`$(info_get KERNEL_PKG_SHA256)\` |"
-            echo "| Katana            | [\`dojoengine/katana\`](https://github.com/dojoengine/katana/releases/tag/${katana_ver}) | \`${katana_ver}\` |"
+            echo "| Katana            | [\`dojoengine/katana\`](https://github.com/dojoengine/katana/releases/tag/${katana_ver}) (\`katana_${katana_ver}_linux_amd64_native.tar.gz\`) | \`${katana_ver}\` |"
             echo "| paymaster-service | [\`cartridge-gg/paymaster\`](https://github.com/cartridge-gg/paymaster) (prebuilt \`${katana_ver}\` release asset) | \`${PAYMASTER_REV}\` |"
             echo "| vrf-server        | [\`cartridge-gg/vrf\`](https://github.com/cartridge-gg/vrf) (prebuilt \`${katana_ver}\` release asset) | \`${VRF_REV}\` |"
             echo

--- a/docs/amdsev.md
+++ b/docs/amdsev.md
@@ -67,7 +67,7 @@ Three layers of trust, outside-in:
 | **OVMF firmware** (`OVMF.fd`) | `misc/AMDSEV/build-ovmf.sh` → `output/qemu/OVMF.fd` | UEFI firmware. Built from [AMD's OVMF fork](https://github.com/AMDESE/ovmf) (`AmdSevX64.dsc`) which reserves the 1 KB hash-table region SEV-SNP uses to inject kernel/initrd/cmdline digests into the measurement. |
 | **Linux kernel** (`vmlinuz`) | `misc/AMDSEV/build-kernel.sh` → `output/qemu/vmlinuz` | Ubuntu-supplied kernel; SEV-SNP guest-side drivers (`tsm`, `sev-guest`) plus `dm-mod`, `dm-crypt`, `dm-integrity` are loaded from modules shipped inside the initrd. |
 | **initrd** (`initrd.img`) | `misc/AMDSEV/build-initrd.sh` → `output/qemu/initrd.img` | Self-contained root filesystem. Measured at launch. Contains the `init` script and every userspace binary the guest ever runs. See [initrd layout](#initrd-layout) below. |
-| **katana binary** | `scripts/build-gnu.sh` → `target/x86_64-unknown-linux-gnu/performance/katana`, or `scripts/build-reproducible-katana.sh` for the deterministic Docker-pinned build used by `release.yml` | Sequencer itself. Dynamically linked against glibc; the initrd vendors a pinned glibc runtime (`libc.so.6` and its dependencies) under `lib64/` and `usr/lib/x86_64-linux-gnu/`. Runtime package versions are pinned in `misc/AMDSEV/build-config` (`GLIBC_RUNTIME_PACKAGES` / `GLIBC_RUNTIME_PACKAGE_SHA256S`) and recorded in `build-info.txt` as `GLIBC_VERSION`. |
+| **katana binary** | The `katana_<ver>_linux_amd64_native.tar.gz` release asset (built by `release.yml` with `--features native`, LLVM/MLIR 19 statically linked); `scripts/build-gnu.sh --native` builds the same configuration from source | Sequencer itself, cairo-native-enabled (in-guest native execution behind `--enable-native-compilation`, off by default). Dynamically linked against glibc; the initrd vendors a pinned glibc runtime (`libc.so.6` and its dependencies) under `lib64/` and `usr/lib/x86_64-linux-gnu/`. Runtime package versions are pinned in `misc/AMDSEV/build-config` (`GLIBC_RUNTIME_PACKAGES` / `GLIBC_RUNTIME_PACKAGE_SHA256S`) and recorded in `build-info.txt` as `GLIBC_VERSION`. Note: unlike the previously embedded portable build, the native asset is not yet reproducible-from-source — image verification pins it by `KATANA_BINARY_SHA256`. |
 | **`snp-derivekey`** (new) | `crates/tee/src/bin/derivekey.rs` (built with `--features snp`) | Tiny helper the init script runs once at boot to derive the LUKS unseal key from `SNP_GET_DERIVED_KEY`. See [Sealed storage](#sealed-storage). |
 | **`cryptsetup`** (new) | Built from pinned source inside a pinned Alpine container (SECTION 3 of `build-initrd.sh`) | Drives LUKS2 open/format and dm-integrity setup. Static-musl, single binary, no runtime library dependencies. |
 | **`start-vm.sh`** | `misc/AMDSEV/start-vm.sh` | Host-side launcher. Wires OVMF + kernel + initrd + disk + virtio-serial control channel together and invokes QEMU with the correct `-object sev-snp-guest,…,kernel-hashes=on` flags. |
@@ -76,7 +76,7 @@ Three layers of trust, outside-in:
 
 ### initrd layout
 
-The initrd is a gzipped cpio archive with a single-user layout. The helper binaries (busybox, cryptsetup, snp-derivekey) are statically linked; katana is glibc-dynamic, and the initrd vendors a pinned glibc runtime alongside it.
+The initrd is a gzipped cpio archive with a single-user layout. The helper binaries (busybox, cryptsetup, snp-derivekey, ld) are statically linked; katana is glibc-dynamic, and the initrd vendors a pinned glibc runtime alongside it.
 
 ```
 /
@@ -86,7 +86,9 @@ The initrd is a gzipped cpio archive with a single-user layout. The helper binar
 │   ├── mount → busybox    (and tr, grep, mkfifo, mkfs.ext2, etc.)
 │   ├── katana             (glibc-dynamic; needs the runtime under lib64/ + usr/lib/)
 │   ├── snp-derivekey      (static; calls SNP_GET_DERIVED_KEY)
-│   └── cryptsetup         (static; LUKS2 + dm-integrity driver)
+│   ├── cryptsetup         (static; LUKS2 + dm-integrity driver)
+│   └── ld                 (static GNU ld; cairo-native links AOT-compiled classes
+│                           with it at runtime under --enable-native-compilation)
 ├── lib/modules/
 │   ├── tsm.ko             (TSM configfs interface for attestation reports)
 │   ├── sev-guest.ko       (/dev/sev-guest device for SNP ioctls)
@@ -94,9 +96,12 @@ The initrd is a gzipped cpio archive with a single-user layout. The helper binar
 │   ├── dm-crypt.ko        (block-level encryption)
 │   └── dm-integrity.ko    (sector-level authentication)
 ├── lib64/
-│   └── ld-linux-x86-64.so.2   (ELF interpreter; path is the one /bin/katana embeds)
+│   ├── ld-linux-x86-64.so.2   (ELF interpreter; path is the one /bin/katana embeds)
+│   └── libc.so            (generated linker script — resolves ld's `-lc` to the
+│                           vendored libc.so.6 + libc_nonshared.a)
 ├── usr/lib/x86_64-linux-gnu/
 │   ├── libc.so.6, libgcc_s.so.1, libm.so.6, libstdc++.so.6, libz.so.1, liblzma.so.5
+│   ├── libc_nonshared.a   (from the pinned libc6-dev deb; -lc link input)
 │   └── libnss_dns.so.2, libnss_files.so.2, libresolv.so.2  (optional NSS plugins)
 ├── init                   (BusyBox shell script; PID 1)
 ├── dev/, proc/, sys/, tmp/, etc/, mnt/
@@ -116,7 +121,7 @@ flowchart LR
         qemu_b["build-qemu.sh<br/>(QEMU 10.2 from source)"]
         ovmf_b["build-ovmf.sh<br/>(AMD OVMF fork)"]
         kernel_b["build-kernel.sh<br/>(Ubuntu vmlinuz extract)"]
-        katana_b["scripts/build-gnu.sh<br/>(glibc katana)"]
+        katana_b["katana binary<br/>(release _native asset, or<br/>scripts/build-gnu.sh --native)"]
         initrd_b["build-initrd.sh<br/>(cpio assembly)"]
     end
     out["output/qemu/<br/>{OVMF.fd, vmlinuz,<br/>initrd.img, katana,<br/>build-info.txt}"]
@@ -135,10 +140,10 @@ flowchart LR
 
 The `build-initrd.sh` step is the most dependency-heavy:
 
-1. Download pinned `.deb` packages via `apt-get download`: `busybox-static`, `linux-modules`, `linux-modules-extra`, plus the glibc runtime packages (`libc6`, `libgcc-s1`, `libstdc++6`, `zlib1g`, `liblzma5`) when the supplied katana binary is dynamically linked. Verify SHA256.
+1. Download pinned `.deb` packages via `apt-get download`: `busybox-static`, `linux-modules`, `linux-modules-extra`, plus the glibc runtime packages (`libc6`, `libgcc-s1`, `libstdc++6`, `zlib1g`, `liblzma5`) when the supplied katana binary is dynamically linked, and `libc6-dev` (for `libc_nonshared.a`) when a `ld` binary is bundled. Verify SHA256.
 2. Extract them into a staging directory with `dpkg-deb -x`.
-3. **Build a statically-linked `cryptsetup`** inside a pinned Alpine container (`CRYPTSETUP_BUILDER_IMAGE=alpine@sha256:…`). Alpine's musl + `*-static` packages (openssl, popt, argon2, …) produce a single binary with no runtime library dependencies, verified via `ldd`.
-4. Assemble the initrd directory: install busybox + symlinks, install `cryptsetup`, cherry-pick `tsm.ko` / `sev-guest.ko` / `dm-mod.ko` / `dm-crypt.ko` / `dm-integrity.ko`, copy the Katana binary, copy `snp-derivekey`, install the ELF interpreter (`lib64/ld-linux-x86-64.so.2`) and every `NEEDED` shared library walked transitively from `bin/katana` (plus a small set of optional NSS plugins), emit the `init` script.
+3. **Build a statically-linked `cryptsetup`** inside a pinned Alpine container (`CRYPTSETUP_BUILDER_IMAGE=alpine@sha256:…`). Alpine's musl + `*-static` packages (openssl, popt, argon2, …) produce a single binary with no runtime library dependencies, verified via `ldd`. **A statically-linked GNU `ld`** is built from pinned binutils source inside the same container (`scripts/build-binutils-ld.sh`) — cairo-native shells out to it at runtime.
+4. Assemble the initrd directory: install busybox + symlinks, install `cryptsetup`, cherry-pick `tsm.ko` / `sev-guest.ko` / `dm-mod.ko` / `dm-crypt.ko` / `dm-integrity.ko`, copy the Katana binary, copy `snp-derivekey`, install `bin/ld` plus its `-lc` link inputs (`libc_nonshared.a` and a generated `/lib64/libc.so` linker script pointing at the initrd's actual libc paths), install the ELF interpreter (`lib64/ld-linux-x86-64.so.2`) and every `NEEDED` shared library walked transitively from `bin/katana` (plus a small set of optional NSS plugins), emit the `init` script.
 5. Normalize timestamps to `SOURCE_DATE_EPOCH`, create a sorted reproducible cpio archive, gzip with `-n`.
 6. Record the actual glibc version (queried by running the installed `libc.so.6`) into a `glibc-version.txt` sidecar; `build.sh` promotes it into `build-info.txt` as `GLIBC_VERSION`.
 

--- a/docs/tee-deployment.md
+++ b/docs/tee-deployment.md
@@ -264,6 +264,14 @@ The script:
 - Sends `start <args>` over the virtio-serial control channel to launch
   Katana after boot.
 - Forwards Katana's port `5050` to host port `15051`.
+- Gives the guest 4G of RAM by default (override via `KATANA_MEMORY`). The
+  initramfs — including the cairo-native katana binary — unpacks into guest
+  RAM, so several GB are required; `-m` is not part of the launch
+  measurement, so sizing it differently doesn't change attestation.
+
+The embedded katana is the cairo-native release build: adding
+`--enable-native-compilation` to `--katana-args` turns on native execution
+of contract classes inside the enclave (off by default).
 
 Notes:
 

--- a/misc/AMDSEV/README.md
+++ b/misc/AMDSEV/README.md
@@ -24,7 +24,7 @@ Output is written to `output/qemu/`.
 
 ### Katana Binary
 
-`--katana` is required when building the initrd. Download a prebuilt linux-gnu binary from [dojoengine/katana releases](https://github.com/dojoengine/katana/releases) (the `*_linux_amd64.tar.gz` portable build).
+`--katana` is required when building the initrd. Download a prebuilt linux-gnu binary from [dojoengine/katana releases](https://github.com/dojoengine/katana/releases) — release images embed the `*_linux_amd64_native.tar.gz` cairo-native build (the portable `*_linux_amd64.tar.gz` build also works, but the guest then lacks `--enable-native-compilation` support).
 
 For reproducibility, the initrd does not copy glibc or shared libraries from the build host. Instead, `scripts/build-initrd.sh` downloads the exact runtime `.deb` packages listed in `build-config`, verifies their SHA-256 checksums, then copies the ELF interpreter and the shared libraries declared by Katana with `readelf`. If providing a custom dynamic binary with `--katana`, build it against a glibc compatible with the pinned runtime and make sure any extra shared libraries it needs are covered by `GLIBC_RUNTIME_PACKAGES` and `GLIBC_RUNTIME_PACKAGE_SHA256S`.
 
@@ -39,8 +39,9 @@ For reproducibility, the initrd does not copy glibc or shared libraries from the
 | `build-config` | Pinned versions and checksums for reproducible builds |
 | `scripts/build-ovmf.sh` | Builds OVMF firmware from AMD's fork with SEV-SNP support |
 | `scripts/build-kernel.sh` | Downloads and extracts Ubuntu kernel (`vmlinuz`) |
-| `scripts/build-initrd.sh` | Creates minimal initrd with busybox, SEV-SNP modules, snp-derivekey, cryptsetup, and katana |
+| `scripts/build-initrd.sh` | Creates minimal initrd with busybox, SEV-SNP modules, snp-derivekey, cryptsetup, ld (cairo-native runtime linker), and katana |
 | `scripts/build-cryptsetup.sh` | Builds static cryptsetup + mkfs.ext2 in an Alpine container |
+| `scripts/build-binutils-ld.sh` | Builds a static GNU ld in the same Alpine container (cairo-native links AOT-compiled classes with it in-guest) |
 | `scripts/build-qemu.sh` | Builds QEMU 10.2.0 from source with SEV-SNP support (operator host setup, not part of build pipeline) |
 | `scripts/sealed-cmdline.sh` | Single source of truth for the measured kernel cmdline |
 | `scripts/test-initrd.sh` | Isolated initrd boot smoke test in plain QEMU |
@@ -320,7 +321,8 @@ Two points deserve emphasis:
 
 - **The initrd hash transitively pins everything inside it**: the katana
   binary, busybox, the glibc runtime, kernel modules, cryptsetup,
-  snp-derivekey, and the init script itself — including init's security
+  snp-derivekey, ld and its libc link inputs, and the init script itself —
+  including init's security
   behavior (pinning `--db-dir`/`--chain`, stripping reserved flags from
   operator input). Because the initrd build is reproducible (see
   [Reproducible Builds](#reproducible-builds)), anyone can rebuild it from

--- a/misc/AMDSEV/README.md
+++ b/misc/AMDSEV/README.md
@@ -313,7 +313,7 @@ one of options A–C lands, treat a Katana upgrade under `--sealed` as a fresh d
 | Kernel (`vmlinuz`) | Pinned Ubuntu kernel `.deb` | SHA-256 entry in the SEV hashes table (`kernel-hashes=on`) |
 | Initrd (`initrd.img`) | `scripts/build-initrd.sh`, reproducible | SHA-256 entry in the hashes table |
 | Kernel cmdline | `scripts/sealed-cmdline.sh` | SHA-256 entry in the hashes table |
-| vCPU count and model | `start-vm.sh`: 1 × `EPYC-v4` | Each vCPU's initial register state (VMSA) is measured |
+| vCPU count and model | `start-vm.sh`: `--vcpus` (default 1) × `EPYC-v4` | Each vCPU's initial register state (VMSA) is measured — a non-default `--vcpus` produces a different digest; verifiers must pin the expected count |
 | Guest features | `sev-snp-guest` object: `0x1` (SNP active) | Field in the measured VMSA |
 | VMM type | QEMU | VMSA layout differs per VMM |
 

--- a/misc/AMDSEV/README.md
+++ b/misc/AMDSEV/README.md
@@ -2,6 +2,16 @@
 
 Build scripts for creating TEE (Trusted Execution Environment) components to run Katana inside AMD SEV-SNP confidential VMs.
 
+## Install (run a published release)
+
+Operators standing up a host to *run* the TEE VM (rather than build it) can use the one-command installer. It preflights the SEV-SNP host, downloads and verifies the latest `tee-vm-v*` release together with its matching launcher scripts, builds the pinned QEMU when the host lacks it, walks through vCPU/memory/disk/port configuration, and recomputes the expected launch measurement for the chosen config:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/dojoengine/katana/main/misc/AMDSEV/install.sh | bash
+```
+
+See [docs/install.md](docs/install.md) for prerequisites, the wizard walkthrough, non-interactive usage, upgrades, and persistence recipes.
+
 ## Requirements
 
 - **QEMU 10.2.0** - Only tested with this version. Earlier versions may lack required SEV-SNP features.
@@ -34,6 +44,7 @@ For reproducibility, the initrd does not copy glibc or shared libraries from the
 |------|-------------|
 | `build.sh` | Orchestrator entry point — builds OVMF, kernel, initrd; writes `build-info.txt` |
 | `start-vm.sh` | Starts a TEE VM with SEV-SNP and launches Katana asynchronously (consumer-facing) |
+| `install.sh` | One-command operator installer: preflight, release download + verification, wizard, run.sh generation — see [docs/install.md](docs/install.md) |
 | `verify-build.sh` | Verifies sha256s + sealed launch measurement of a build / downloaded release |
 | `reproduce-release.sh` | Rebuilds a published release from source and compares it byte-for-byte against the published artifacts |
 | `build-config` | Pinned versions and checksums for reproducible builds |
@@ -46,6 +57,7 @@ For reproducibility, the initrd does not copy glibc or shared libraries from the
 | `scripts/sealed-cmdline.sh` | Single source of truth for the measured kernel cmdline |
 | `scripts/test-initrd.sh` | Isolated initrd boot smoke test in plain QEMU |
 | `scripts/test-snp-e2e.sh` | End-to-end test on SEV-SNP hardware: sealed boot, attestation vs expected measurement, reboot reseal |
+| `scripts/test-install.sh` | Unit tests for install.sh's helpers (no network); full download dry-run under `KATANA_INSTALL_TEST_NETWORK=1` |
 | `snp-tools/` | Cargo crate with `snp-digest`, `snp-report`, `ovmf-metadata`, `snp-derivekey` |
 | `docs/release-pipeline.md` | How releases are built, measured, and published — see [Release Pipeline](docs/release-pipeline.md) |
 

--- a/misc/AMDSEV/build-config
+++ b/misc/AMDSEV/build-config
@@ -63,7 +63,30 @@ E2FSPROGS_SHA256="6dcd67ff9d8b13274ba3f088e4318be4f5b71412cd863524423fc49d39a637
 
 # Container image used to build static cryptsetup. Pinned by sha256 digest so
 # the build matches across hosts. Bump when upgrading Alpine.
+# (Also reused by build-binutils-ld.sh — one pinned builder image for all
+# static helper builds.)
 CRYPTSETUP_BUILDER_IMAGE="alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a"
+
+# GNU binutils source (static `ld` for in-guest cairo-native AOT linking).
+# The bundled katana is the cairo-native release build; with
+# --enable-native-compilation it AOT-compiles contract classes at runtime and
+# shells out to `ld` to link each one into a dlopen-able .so (see cairo-native
+# src/ffi.rs — the argv contract to re-verify when bumping cairo-native).
+# Built statically inside the pinned Alpine container above
+# (scripts/build-binutils-ld.sh) so it ships with no runtime libc dependency.
+# sha256 of binutils-$VERSION.tar.xz, cross-checked against
+# https://sourceware.org/pub/binutils/releases/sha512.sum.
+BINUTILS_VERSION="2.44"
+BINUTILS_SHA256="ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237"
+
+# libc6-dev (Ubuntu package). Provides libc_nonshared.a, one of the two inputs
+# behind the generated /lib64/libc.so linker script that lets the bundled ld
+# resolve `-lc` inside the initrd (build-initrd.sh generates the script; the
+# package's own libc.so references usr-merged absolute paths that don't exist
+# in the initrd). MUST stay in version lockstep with the libc6 entry in
+# GLIBC_RUNTIME_PACKAGES above — build-initrd.sh enforces this.
+LIBC6_DEV_PKG_VERSION="2.39-0ubuntu8.7"
+LIBC6_DEV_PKG_SHA256="bbf5a155039042634961a61276650631ee47b9e721f91f8dbb731b0bbe046df3"
 
 # Canonical LUKS UUID used to compute the SEV-SNP launch measurement that is
 # published with each release. This is the LUKS_UUID baked into the published

--- a/misc/AMDSEV/build.sh
+++ b/misc/AMDSEV/build.sh
@@ -26,6 +26,12 @@ export CRYPTSETUP_VERSION CRYPTSETUP_SHA256 CRYPTSETUP_BUILDER_IMAGE
 export LVM2_VERSION LVM2_SHA256
 export E2FSPROGS_VERSION E2FSPROGS_SHA256
 export GLIBC_RUNTIME_PACKAGES GLIBC_RUNTIME_PACKAGE_SHA256S
+# Native-compilation support pins. BINUTILS_* is consumed by
+# build-binutils-ld.sh (auto-invoked below when LD_BINARY isn't already
+# supplied); LIBC6_DEV_* is consumed by build-initrd.sh to assemble the
+# -lc link inputs for the bundled ld.
+export BINUTILS_VERSION BINUTILS_SHA256
+export LIBC6_DEV_PKG_VERSION LIBC6_DEV_PKG_SHA256
 # CA certificates bundle — consumed by build-initrd.sh to populate the enclave trust
 # stores (openssl + rustls paths). Without this export the cert step silently skips
 # and the released image ships NO CA bundle (outbound HTTPS fails).
@@ -85,6 +91,11 @@ function usage()
 	echo "  --vrf-bin PATH          Path to a prebuilt vrf-server binary (optional; katana"
 	echo "                          release asset). Bundled into the initrd so the guest"
 	echo "                          supports --vrf. Both-or-neither with --paymaster-bin."
+	echo "  --ld PATH               Path to a static GNU ld binary (optional; auto-built"
+	echo "                          via build-binutils-ld.sh if not provided). Bundled at"
+	echo "                          /bin/ld so the guest supports katana's"
+	echo "                          --enable-native-compilation (cairo-native links each"
+	echo "                          AOT-compiled class with ld at runtime)."
 	echo "  -h|--help               Usage information"
 	echo ""
 	echo "COMPONENTS (if none specified, builds all):"
@@ -147,6 +158,13 @@ while [ -n "$1" ]; do
 	--vrf-bin)
 		[ -z "$2" ] && usage
 		export VRF_BINARY="$2"
+		shift; shift
+		;;
+	--ld)
+		[ -z "$2" ] && usage
+		# Same export rationale as --snp-derivekey: build-initrd.sh runs
+		# as a child process and reads LD_BINARY from the env.
+		export LD_BINARY="$2"
 		shift; shift
 		;;
 	-h|--help)
@@ -277,6 +295,36 @@ if [ $BUILD_INITRD -eq 1 ] \
 	export CRYPTSETUP_BINARY MKFS_EXT2_BINARY
 	echo "Using cryptsetup: $CRYPTSETUP_BINARY"
 	echo "Using mkfs.ext2:  $MKFS_EXT2_BINARY"
+fi
+
+# Build a static GNU ld for in-guest cairo-native AOT linking unless the
+# operator opted out (KATANA_SKIP_LD_BUILD=1) or pre-supplied a path via
+# --ld. Deliberately NOT gated on KATANA_UNSEALED_BUILD: ld is orthogonal
+# to sealed storage — its own opt-out keeps Docker-less hosts and cheap dev
+# iteration working (build-initrd.sh warns instead of dying when LD_BINARY
+# is absent; the resulting image just doesn't support
+# --enable-native-compilation). Cached under output/binutils-static like
+# the cryptsetup outputs.
+if [ $BUILD_INITRD -eq 1 ] \
+   && [ "${KATANA_SKIP_LD_BUILD:-0}" -ne 1 ] \
+   && [ -z "${LD_BINARY:-}" ]; then
+	LD_OUT_DIR="${SCRIPT_DIR}/output/binutils-static"
+	LD_BINARY="${LD_OUT_DIR}/ld"
+
+	if [ ! -x "$LD_BINARY" ]; then
+		echo ""
+		echo "Building static GNU ld (cairo-native runtime linker)..."
+		"${SCRIPT_DIR}/scripts/build-binutils-ld.sh" "$LD_OUT_DIR" || {
+			echo "build-binutils-ld.sh failed"
+			exit 1
+		}
+	fi
+	if [ ! -x "$LD_BINARY" ]; then
+		echo "ERROR: ld binary missing at $LD_BINARY"
+		exit 1
+	fi
+	export LD_BINARY
+	echo "Using ld: $LD_BINARY"
 fi
 
 mkdir -p $INSTALL_DIR

--- a/misc/AMDSEV/docs/install.md
+++ b/misc/AMDSEV/docs/install.md
@@ -1,0 +1,163 @@
+# Installing the Katana TEE VM on an SEV-SNP host
+
+`install.sh` turns a machine with AMD SEV-SNP enabled into a Katana TEE VM
+host from a published release, in one command:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/dojoengine/katana/main/misc/AMDSEV/install.sh | bash
+```
+
+It preflights the host, downloads and verifies a `tee-vm-v*` release, walks
+through an interactive wizard (vCPUs, memory, data disk, ports, storage
+sealing), builds the pinned QEMU when the host lacks it, recomputes the
+expected launch measurement for the chosen configuration, and generates a
+foreground `run.sh`. It deliberately does **not** install a service:
+persistence is the operator's choice ([recipes below](#running-and-persistence)).
+
+The installer needs no root; `run.sh` invokes `start-vm.sh` via `sudo`
+(KVM and disk setup require it).
+
+## Host prerequisites
+
+- **AMD EPYC (Milan or newer) with SEV-SNP enabled in BIOS** (SME + SNP
+  settings), and an SNP-capable host kernel (6.11+, or a distro/vendor SNP
+  kernel) with `kvm_amd` loaded with `sev_snp=1`. The preflight checks
+  `/dev/sev`, `/sys/module/kvm_amd/parameters/sev_snp`, and `/dev/kvm`, and
+  prints remediation hints for whichever is missing.
+- **Bare metal.** On clouds this means a bare-metal AMD instance (for
+  example AWS `m6a.metal` / `c6a.metal`; equivalent AMD bare-metal offerings
+  on GCP/Azure/OVH/Latitude etc.). Regular confidential VMs are SNP *guests*
+  and cannot host nested SNP guests.
+- **Tools:** `curl tar sha256sum python3 dd mkfs.ext4 socat`
+  (`apt-get install -y curl tar coreutils python3 e2fsprogs socat`).
+- **QEMU** at the version pinned by the release (currently 10.2.0). If the
+  host has another version (or none), the installer offers to build it from
+  source via the release's `scripts/build-qemu.sh` — locally under the
+  install root (default) or into `/usr/local`.
+- **Rust (optional but recommended):** `cargo` is needed to build
+  `snp-digest`, which verifies the release's published launch measurement
+  and computes the expected measurement for your configuration. Without it
+  the install still completes (artifact checksums are always verified), but
+  attestation verification has no local expected value until you install
+  Rust and run `install.sh verify`.
+
+## What gets installed
+
+Everything lands under `--home` (default `~/.katana/tee-vm`):
+
+```
+~/.katana/tee-vm/
+├── config.env                  # all wizard answers, sourceable shell
+├── run.sh                      # generated foreground launcher
+├── expected-measurement.txt    # launch measurement for THIS host's config
+├── install.sh                  # self-copy: upgrades / verify / print-systemd
+├── data.img                    # persistent VM data disk (default path)
+├── qemu/                       # locally-built QEMU (only if built locally)
+├── current -> releases/<tag>
+└── releases/<tag>/
+    ├── boot/                   # OVMF.fd, vmlinuz, initrd.img, build-info.txt, ...
+    └── src/                    # misc/AMDSEV at the tag (start-vm.sh, scripts/, snp-tools/)
+```
+
+The release tarball carries only boot artifacts; the launcher scripts are
+fetched from the repo source **at the same tag** — they are a matched pair,
+and the boot artifacts + launcher of one release must not be mixed with
+another's.
+
+## The wizard
+
+Every question has a flag / env-var override, and `--yes` skips the wizard
+entirely (missing values fall back to config-file values from a previous
+run, then to defaults). Re-runs pre-fill from the existing `config.env`.
+
+| Question | Default | Flag / env | Notes |
+|---|---|---|---|
+| Release tag | latest `tee-vm-v*` | `--tag` / `KATANA_TEE_TAG` | |
+| vCPUs | 1 | `--vcpus` / `KATANA_VCPUS` | **Part of the launch measurement** — the expected measurement is recomputed for your value. Locked to 1 on releases whose launcher predates configurable vCPUs. |
+| Memory | 4G | `--memory` / `KATANA_MEMORY` | **Not measured** — size freely. The initramfs (including the katana binary) unpacks into guest RAM; 4G minimum advised. |
+| Data disk path | `<home>/data.img` | `--data-disk` / `KATANA_DATA_DISK` | Created if absent; never touched on upgrade. |
+| Data disk size (MB) | 1024 | `--disk-size-mb` / `KATANA_DISK_SIZE_MB` | Only asked when the disk doesn't exist yet. |
+| Host RPC port | 15051 | `--rpc-port` / `HOST_RPC_PORT` | Forwards to guest port 5050. |
+| Storage mode | unsealed | `--sealed` / `--unsealed` | Sealed = LUKS2 + dm-integrity, key derived in-guest and bound to the launch measurement — an upgrade re-keys the disk. See the README's *Storage sealing* section. |
+| Katana args | `start-vm.sh` default CSV | `--katana-args` | Unmeasured (delivered via fw_cfg). The `--metrics.port` inside it drives the metrics host forward. |
+
+Non-interactive example (provisioning tools, cloud-init):
+
+```sh
+curl -fsSL .../install.sh | bash -s -- --yes --vcpus 4 --memory 8G --rpc-port 15051
+```
+
+## Running and persistence
+
+```sh
+~/.katana/tee-vm/run.sh
+```
+
+runs the VM in the foreground: the `start-vm.sh` banner, then a live tail of
+the guest serial log. Ctrl+C triggers a graceful guest shutdown (katana
+TERM, sync, unmount, poweroff). The data disk persists, so the next run
+resumes the existing chain state.
+
+How (and whether) to keep it running is up to you:
+
+- **systemd** — `~/.katana/tee-vm/install.sh print-systemd` prints a sample
+  unit (auto-restart on failure, start on boot, graceful stop). It is only
+  printed, never installed; review it, then copy it to
+  `/etc/systemd/system/` per the instructions in its header.
+- **tmux / screen** — just run `run.sh` inside a session.
+- **anything else** — `run.sh` is a plain foreground process that exits
+  non-zero on failure; any supervisor can manage it.
+
+Once running:
+
+- RPC: `http://localhost:<rpc-port>` (starknet JSON-RPC + `tee_generateQuote`)
+- Metrics: `http://localhost:<metrics-port>` (from `--metrics.port` in the
+  katana args; on by default at 9100)
+
+## Verifying attestation
+
+The installer writes `expected-measurement.txt` — the SEV-SNP launch
+measurement your configuration should produce (it depends on the boot
+artifacts, kernel cmdline variant, and vCPU count; **not** on memory size,
+katana args, or disk contents). Compare it against a live quote:
+
+```sh
+curl -s -X POST http://localhost:15051 \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tee_generateQuote","params":[null,0]}'
+# decode with snp-report (built from releases/<tag>/src/snp-tools); the
+# measurement is the 48-byte field at offset 0x90 of the report.
+```
+
+`install.sh verify` re-checks the downloaded artifacts against
+`build-info.txt`, re-verifies the release's published measurement, and
+recomputes `expected-measurement.txt` for the saved configuration.
+
+## Upgrading
+
+Re-run the installer (`~/.katana/tee-vm/install.sh`, or re-curl it). The new
+release lands in its own `releases/<tag>/` directory — previous releases are
+kept, so rolling back is re-running with `--tag <old-tag>`. The wizard is
+pre-filled from `config.env`; the data disk is never touched.
+
+**Sealed mode caveat:** the sealed disk key is bound to the launch
+measurement, so changing releases re-keys the disk and the old data no
+longer unseals. The installer warns and asks for confirmation (or
+`KATANA_CONFIRM_SEALED_UPGRADE=1` non-interactively). Point `--data-disk` at
+a fresh file to keep the old disk recoverable under the old release.
+
+## Troubleshooting
+
+- **`/dev/sev not present`** — SNP disabled in BIOS, non-EPYC hardware, or a
+  virtualized (non-bare-metal) machine.
+- **`kvm_amd sev_snp not enabled`** —
+  `echo 'options kvm_amd sev_snp=1 sev=1 sev_es=1' | sudo tee /etc/modprobe.d/kvm-amd-snp.conf`,
+  then reload `kvm_amd` (or reboot). The host kernel must support SNP.
+- **QEMU build fails** — install the build deps first:
+  `sudo apt-get install -y build-essential ninja-build pkg-config libglib2.0-dev libpixman-1-dev python3-venv flex bison wget`.
+- **`cargo` missing / measurement not computed** — install Rust
+  (https://rustup.rs), then `~/.katana/tee-vm/install.sh verify`.
+- **vCPUs locked to 1** — the chosen release's launcher predates
+  configurable vCPUs; pick a newer `tee-vm-v*` release.
+- **Boot or runtime issues** — see the README's *Troubleshooting* section;
+  the serial log path is printed by `run.sh` at startup.

--- a/misc/AMDSEV/docs/release-pipeline.md
+++ b/misc/AMDSEV/docs/release-pipeline.md
@@ -257,6 +257,16 @@ Key facts:
 | `build-info-<tag>.txt` | Full provenance: pins, package checksums, artifact SHA-256s, `SOURCE_DATE_EPOCH`, reuse markers, measurement |
 | `launch-measurement-<tag>.txt` | The sealed launch measurement, bare hex, one line |
 
+The tarball carries boot artifacts only. `install.sh` (the operator
+installer, [docs/install.md](install.md)) pairs it with the launcher scripts
+fetched from the **repo source at the same tag**
+(`archive/refs/tags/<tag>.tar.gz` → `misc/AMDSEV/`). That makes the tag's
+`misc/AMDSEV` tree part of the published interface: renaming `start-vm.sh`,
+its flags/env vars (`KATANA_VCPUS`, `KATANA_MEMORY`, `HOST_RPC_PORT`, ...),
+`scripts/sealed-cmdline.sh`, `verify-build.sh`, the `snp-tools` crate path,
+or the tarball layout changes what installed hosts download on upgrade — the
+installer feature-detects where it can, but treat such renames as breaking.
+
 ## What moves the measurement between releases
 
 | Change | Measurement effect |

--- a/misc/AMDSEV/docs/release-pipeline.md
+++ b/misc/AMDSEV/docs/release-pipeline.md
@@ -121,17 +121,28 @@ pipeline behaviors follow directly from this:
 `nasm`, `iasl`, `uuid-dev` (EDK2/OVMF build), `musl-tools` (static
 `snp-derivekey`), `zstd`, `cpio` (initrd packaging), plus the
 `x86_64-unknown-linux-musl` Rust target. Docker (for the static cryptsetup
-container build) is preinstalled on the runner.
+and static `ld` container builds) is preinstalled on the runner.
 
 ### 3. Resolve and download katana
 
 The version resolved from the tag (or dispatch input) is downloaded from
 [dojoengine/katana releases](https://github.com/dojoengine/katana/releases)
-with the pattern `katana_*_linux_amd64.tar.gz`. Both anchors matter: the
-`katana_` prefix excludes the `paymaster-service_*` / `vrf-server_*` tarballs
-that newer katana releases ship alongside it, and the anchored suffix excludes
-the CPU-tuned `_native` variant — releases embed the **portable** build, which
-is the one produced by katana's reproducible-build pipeline.
+with the pattern `katana_*_linux_amd64_native.tar.gz`. The `katana_` prefix
+excludes the `paymaster-service_*` / `vrf-server_*` tarballs that katana
+releases ship alongside it; the `_native` suffix selects the **cairo-native**
+build (LLVM/MLIR 19 statically linked), so the guest supports katana's
+`--enable-native-compilation` flag. The embedded variant is recorded in the
+provenance as `KATANA_ASSET_VARIANT=native`.
+
+> **Honesty note on reproducibility.** The portable
+> (`katana_*_linux_amd64.tar.gz`) asset is produced by katana's
+> reproducible-build pipeline; the `_native` asset is **not** — it is a plain
+> GitHub-runner build that cannot yet be independently rebuilt from source.
+> Reproducing the VM image (below) still works byte-for-byte, because
+> reproduction downloads the same release asset and verifies it against the
+> recorded `KATANA_BINARY_SHA256`; what is lost, until the reproducible
+> pipeline learns the `native` feature, is source-level verifiability of the
+> katana binary itself.
 
 ### 4. Reuse OVMF/kernel from the previous release (when pins match)
 
@@ -184,12 +195,18 @@ not satisfied by reuse. All version pins and package checksums come from
   via `readelf`, copied only from the pinned packages — never from the build
   host); embeds the init script; and packs a reproducible cpio (sorted file
   order, normalized modes, `SOURCE_DATE_EPOCH` timestamps, `--reproducible`).
-  Two helper binaries are built on demand for the sealed-storage flow:
-  - static `cryptsetup` + `mkfs.ext2`, compiled from pinned sources inside a
-    digest-pinned Alpine container (`scripts/build-cryptsetup.sh`, needs
-    Docker);
+  Helper binaries are built on demand:
+  - static `cryptsetup` + `mkfs.ext2` (sealed-storage flow), compiled from
+    pinned sources inside a digest-pinned Alpine container
+    (`scripts/build-cryptsetup.sh`, needs Docker);
   - static `snp-derivekey` (musl), from the `snp-tools` crate — it performs
-    the `SNP_GET_DERIVED_KEY` ioctl in-guest to unlock the LUKS data disk.
+    the `SNP_GET_DERIVED_KEY` ioctl in-guest to unlock the LUKS data disk;
+  - static GNU `ld` from pinned binutils source, inside the same
+    digest-pinned Alpine container (`scripts/build-binutils-ld.sh`, needs
+    Docker) — cairo-native shells out to it at runtime to link AOT-compiled
+    contract classes. Its `-lc` link inputs (`libc_nonshared.a` from the
+    pinned `libc6-dev` deb plus a generated `/lib64/libc.so` linker script)
+    are assembled by `build-initrd.sh`.
 
 `build.sh` then writes `build-info.txt`. It **merges** with an existing
 `build-info.txt`, overwriting only the fields of components it actually built
@@ -236,7 +253,7 @@ Key facts:
 
 | Asset | Contents |
 |---|---|
-| `katana-tee-vm-<tag>.tar.gz` | `OVMF.fd`, `vmlinuz`, `initrd.img`, `katana` (the embedded binary, for convenience), `build-info.txt`, `launch-measurement.txt` |
+| `katana-tee-vm-<tag>.tar.gz` | `OVMF.fd`, `vmlinuz`, `initrd.img`, `katana` (the embedded cairo-native binary, for convenience), `build-info.txt`, `launch-measurement.txt` |
 | `build-info-<tag>.txt` | Full provenance: pins, package checksums, artifact SHA-256s, `SOURCE_DATE_EPOCH`, reuse markers, measurement |
 | `launch-measurement-<tag>.txt` | The sealed launch measurement, bare hex, one line |
 
@@ -247,6 +264,7 @@ Key facts:
 | New katana version | Initrd hash changes → new measurement |
 | Any change to `scripts/build-initrd.sh` or the init script | Initrd hash changes → new measurement |
 | Bumping any package pin in `build-config` (busybox, glibc, kernel modules…) | Initrd hash changes → new measurement |
+| Bumping `BINUTILS_VERSION` or `LIBC6_DEV_PKG_VERSION` (cairo-native link toolchain) | Initrd hash changes → new measurement |
 | Bumping `OVMF_COMMIT` | OVMF rebuilt → new measurement |
 | Bumping `KERNEL_VERSION` | Kernel hash changes → new measurement |
 | Changing `KATANA_CANONICAL_LUKS_UUID` | Measured cmdline changes → new measurement |

--- a/misc/AMDSEV/install.sh
+++ b/misc/AMDSEV/install.sh
@@ -1,0 +1,1036 @@
+#!/bin/bash
+# ==============================================================================
+# INSTALL.SH - One-command installer for the Katana TEE VM (AMD SEV-SNP)
+# ==============================================================================
+#
+# Sets up a host with AMD SEV-SNP enabled (bare metal, or a cloud bare-metal
+# instance) to run the Katana TEE VM from a published release:
+#
+#   curl -fsSL https://raw.githubusercontent.com/dojoengine/katana/main/misc/AMDSEV/install.sh | bash
+#
+# What it does:
+#   1. Preflights the host (AMD SEV-SNP, KVM, required tools, free ports)
+#   2. Downloads a tee-vm-v* release (boot artifacts) AND the matching
+#      launcher scripts from the repo source at the same tag — they are a
+#      matched pair; the release tarball alone does not include start-vm.sh
+#   3. Verifies artifact checksums and the SEV-SNP launch measurement
+#   4. Walks through an interactive wizard for vCPUs, memory, data disk,
+#      RPC port, storage sealing and Katana args (every answer also has a
+#      flag / env-var override; --yes skips the wizard entirely)
+#   5. Builds QEMU (the pinned version from the release's build-qemu.sh)
+#      when the host doesn't already have it
+#   6. Recomputes the EXPECTED LAUNCH MEASUREMENT for the chosen config —
+#      vCPU count is part of the SEV-SNP measurement (memory is not), so a
+#      non-default count needs its own expected value (computed with the
+#      release's snp-digest, built from source at the tag)
+#   7. Writes config.env + a foreground run.sh and stops there. Persistence
+#      (systemd, tmux, a supervisor) is deliberately the operator's choice:
+#      `install.sh print-systemd` prints a sample unit but never installs it.
+#
+# The installer itself does not need root; run.sh invokes start-vm.sh via
+# sudo (KVM + disk setup need it).
+#
+# Layout created under --home (default ~/.katana/tee-vm):
+#   config.env                  all wizard answers, sourceable
+#   run.sh                      generated foreground launcher
+#   expected-measurement.txt    launch measurement for THIS host's config
+#   install.sh                  self-copy, for upgrades / verify / print-systemd
+#   data.img                    persistent VM data disk (default path)
+#   qemu/                       locally-built QEMU (only if built locally)
+#   current -> releases/<tag>   convenience symlink
+#   releases/<tag>/boot/        OVMF.fd, vmlinuz, initrd.img, build-info.txt, ...
+#   releases/<tag>/src/         misc/AMDSEV at the tag (start-vm.sh, scripts/, snp-tools/)
+#
+# Upgrades: re-run this script (the self-copy at ~/.katana/tee-vm/install.sh
+# works too). New releases land in their own releases/<tag>/ dir; the data
+# disk is never touched. Sealed-mode operators: the disk key is bound to the
+# launch measurement, so upgrading re-keys the disk (see docs/amdsev.md).
+#
+# ==============================================================================
+
+set -euo pipefail
+
+# ------------------------------------------------------------------------------
+# Defaults and env overrides. Flags (parsed in main) override env, env
+# overrides the built-in default, and the wizard prompts for whatever is
+# still unset when running interactively.
+# ------------------------------------------------------------------------------
+VM_REPO="${KATANA_TEE_VM_REPO:-dojoengine/katana}"
+TEE_HOME="${KATANA_TEE_HOME:-$HOME/.katana/tee-vm}"
+TEE_HOME_EXPLICIT=0
+[[ -n "${KATANA_TEE_HOME:-}" ]] && TEE_HOME_EXPLICIT=1
+TAG="${KATANA_TEE_TAG:-}"
+VCPUS="${KATANA_VCPUS:-}"
+MEMORY="${KATANA_MEMORY:-}"
+RPC_PORT="${HOST_RPC_PORT:-}"
+DATA_DISK="${KATANA_DATA_DISK:-}"
+DISK_SIZE_MB="${KATANA_DISK_SIZE_MB:-}"
+LUKS_UUID="${KATANA_LUKS_UUID:-}"
+SEALED_MODE=""     # "", "sealed", "unsealed"
+KATANA_ARGS_CSV=""
+ASSUME_YES=0
+DRY_RUN=0
+INTERACTIVE=0
+# Set to 1 to skip the SEV-SNP hardware checks (CI / dry-runs on non-SNP
+# machines). The install is then only useful for testing the install flow.
+SKIP_SNP_CHECK="${KATANA_INSTALL_SKIP_SNP_CHECK:-0}"
+
+# Must match start-vm.sh's default --katana-args (the guest RPC port 5050 is
+# a convention shared with KATANA_RPC_PORT there).
+DEFAULT_KATANA_ARGS_CSV="--http.addr,0.0.0.0,--http.port,5050,--tee,sev-snp,--metrics,--metrics.addr,0.0.0.0,--metrics.port,9100"
+DEFAULT_VCPUS=1
+DEFAULT_MEMORY="4G"
+DEFAULT_RPC_PORT=15051
+DEFAULT_DISK_SIZE_MB=1024
+
+usage() {
+    echo "Usage: install.sh [COMMAND] [OPTIONS]"
+    echo ""
+    echo "Install and configure the Katana TEE VM (AMD SEV-SNP) from a published"
+    echo "release. Interactive wizard by default; every answer has a flag/env"
+    echo "override and --yes makes the whole run non-interactive."
+    echo ""
+    echo "Commands:"
+    echo "  install               Preflight, download, verify, configure (default)"
+    echo "  verify                Re-verify the installed release + recompute the"
+    echo "                        expected launch measurement for the saved config"
+    echo "  print-systemd         Print a sample systemd unit (never installs it)"
+    echo ""
+    echo "Options (env var in parentheses):"
+    echo "  --tag TAG             Pin a tee-vm-v* release (KATANA_TEE_TAG)"
+    echo "                        Default: latest published tee-vm-v* release"
+    echo "  --vcpus N             Guest vCPU count (KATANA_VCPUS). Default: 1."
+    echo "                        PART OF the SEV-SNP launch measurement — the"
+    echo "                        expected measurement is recomputed for your value."
+    echo "  --memory SIZE         Guest RAM, e.g. 4G or 2048M (KATANA_MEMORY)."
+    echo "                        Default: 4G. NOT part of the measurement."
+    echo "  --rpc-port PORT       Host port forwarded to guest RPC 5050"
+    echo "                        (HOST_RPC_PORT). Default: 15051."
+    echo "  --data-disk PATH      Persistent data disk file (KATANA_DATA_DISK)."
+    echo "                        Default: <home>/data.img, created if absent."
+    echo "  --disk-size-mb N      Size when creating the data disk"
+    echo "                        (KATANA_DISK_SIZE_MB). Default: 1024."
+    echo "  --sealed | --unsealed Storage mode. Default: unsealed. Sealed binds the"
+    echo "                        disk key to the launch measurement (re-keys on"
+    echo "                        upgrade — see docs/amdsev.md, Sealed storage)."
+    echo "  --katana-args CSV     Comma-separated Katana CLI args (unmeasured,"
+    echo "                        delivered via fw_cfg). Default: start-vm.sh's."
+    echo "  --home DIR            Install root (KATANA_TEE_HOME)."
+    echo "                        Default: ~/.katana/tee-vm"
+    echo "  --yes                 Non-interactive: accept flags/env/defaults"
+    echo "  --dry-run             Everything except QEMU build, rustup install,"
+    echo "                        and data-disk creation. Combine with"
+    echo "                        KATANA_INSTALL_SKIP_SNP_CHECK=1 on non-SNP hosts."
+    echo "  -h, --help            Show this help"
+}
+
+# ------------------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------------------
+log()  { echo "$*"; }
+warn() { echo "Warning: $*" >&2; }
+fail() { echo "Error: $*" >&2; exit 1; }
+ok()   { printf '  [ok] %s\n' "$1"; }
+bad()  { printf '  [!!] %s\n' "$1"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+TMP_DIR=""
+cleanup() {
+    # Guarded `if` (not `[[ ]] &&`) so a no-op cleanup can't turn the EXIT
+    # trap — and with it the script's exit status — into a failure.
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Prompt on /dev/tty (curl | bash consumes stdin with the script body).
+# $1 prompt, $2 default; echoes the answer. Non-interactive => the default.
+ask() {
+    local ans=""
+    if [[ "$INTERACTIVE" -eq 1 ]]; then
+        read -r -p "  $1 [$2]: " ans < /dev/tty || ans=""
+    fi
+    printf '%s' "${ans:-$2}"
+}
+
+# $1 prompt, $2 default, $3 validator function. Re-prompts until valid when
+# interactive; hard-fails on an invalid non-interactive value.
+ask_validated() {
+    local ans
+    while true; do
+        ans="$(ask "$1" "$2")"
+        if "$3" "$ans"; then
+            printf '%s' "$ans"
+            return 0
+        fi
+        [[ "$INTERACTIVE" -eq 1 ]] || fail "invalid value for '$1': '$ans'"
+        echo "  invalid value: '$ans' — try again" > /dev/tty
+    done
+}
+
+# $1 prompt, $2 default (y/n). Returns 0 for yes.
+ask_yn() {
+    local ans
+    ans="$(ask "$1 (y/n)" "$2")"
+    [[ "$ans" =~ ^[Yy] ]]
+}
+
+valid_port()   { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 >= 1 && $1 <= 65535 )); }
+valid_vcpus()  { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 >= 1 )); }
+valid_memory() { [[ "$1" =~ ^[0-9]+[MG]$ ]]; }
+valid_mode()   { [[ "$1" == "sealed" || "$1" == "unsealed" ]]; }
+valid_int()    { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 >= 1 )); }
+valid_tag()    { [[ "$1" == tee-vm-v* ]]; }
+valid_uuid()   { [[ "$1" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; }
+
+# True when nothing is listening on 127.0.0.1:$1.
+port_free() {
+    ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# The tag/asset name carries a '+' (SemVer build metadata); percent-encode it
+# so curl sends a literal '+' in the URL path rather than a space.
+encode_tag() { printf '%s' "${1//+/%2B}"; }
+
+# Copied from start-vm.sh (parse_metrics_port) — keep in sync. The installer
+# needs it before a release (and its start-vm.sh) has been chosen, so it
+# can't extract the original at runtime the way the unit tests do.
+parse_metrics_port() {
+    local prev="" arg port=""
+    local -a args
+    IFS=',' read -ra args <<< "$1"
+    for arg in "${args[@]}"; do
+        case "$arg" in --metrics.port=*) port="${arg#*=}" ;; esac
+        [[ "$prev" == "--metrics.port" ]] && port="$arg"
+        prev="$arg"
+    done
+    printf '%s' "$port"
+}
+
+# Latest published tee-vm-v* tag (the repo also publishes katana's own
+# vX.Y.Z releases, which carry no VM image).
+resolve_latest_tag() {
+    curl -fsSL "https://api.github.com/repos/${VM_REPO}/releases?per_page=30" \
+        | python3 -c 'import json,sys; rs=[r["tag_name"] for r in json.load(sys.stdin) if r["tag_name"].startswith("tee-vm-v")]; print(rs[0] if rs else "")'
+}
+
+# Read a single value from a build-info.txt by key.
+info_get() {
+    awk -F= -v k="$2" '$1 == k { sub(/^[^=]*=/, ""); print; exit }' "$1"
+}
+
+# True when the three boot artifacts in $1 match the SHA-256s recorded in
+# $1/build-info.txt (same loop as test-snp-e2e.sh).
+boot_checksums_ok() {
+    local boot="$1" pair f k actual expected
+    [[ -f "$boot/build-info.txt" ]] || return 1
+    for pair in "OVMF.fd:OVMF_SHA256" "vmlinuz:KERNEL_SHA256" "initrd.img:INITRD_SHA256"; do
+        f="${pair%%:*}"; k="${pair##*:}"
+        [[ -f "$boot/$f" ]] || return 1
+        actual="$(sha256sum "$boot/$f" | awk '{print $1}')"
+        expected="$(info_get "$boot/build-info.txt" "$k")"
+        [[ -n "$expected" && "$actual" == "$expected" ]] || return 1
+    done
+    return 0
+}
+
+# Extract misc/AMDSEV/ out of a repo source tarball into $2. The archive's
+# top-level directory name mangles the '+' in the tag, so strip it by depth
+# instead of naming it.
+extract_amdsev_subtree() {
+    local tarball="$1" dest="$2"
+    mkdir -p "$dest"
+    if tar --version 2>/dev/null | grep -q 'GNU tar'; then
+        tar xzf "$tarball" -C "$dest" --strip-components=3 --wildcards '*/misc/AMDSEV/*'
+    else
+        # bsdtar treats patterns as globs without a flag.
+        tar xzf "$tarball" -C "$dest" --strip-components=3 '*/misc/AMDSEV/*'
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Preflight
+# ------------------------------------------------------------------------------
+preflight() {
+    local failures=0 t missing_tools=()
+
+    log ""
+    log "Preflight checks"
+
+    if [[ "$SKIP_SNP_CHECK" == "1" ]]; then
+        bad "SEV-SNP hardware checks SKIPPED (KATANA_INSTALL_SKIP_SNP_CHECK=1)"
+    else
+        if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
+            ok "Linux x86_64"
+        else
+            bad "not Linux x86_64 ($(uname -s) $(uname -m)) — SEV-SNP hosts are x86_64 Linux"
+            failures=$((failures + 1))
+        fi
+
+        if [[ -e /dev/sev ]]; then
+            ok "/dev/sev present (AMD SEV firmware)"
+        else
+            bad "/dev/sev not present — not an SNP-capable host?"
+            echo "       SEV-SNP needs an AMD EPYC (Milan or newer) HOST with SNP enabled"
+            echo "       in BIOS (SME + SNP settings) and an SNP-capable host kernel."
+            echo "       On clouds, that means a bare-metal AMD instance (e.g. AWS"
+            echo "       m6a.metal / c6a.metal); regular confidential VMs cannot host"
+            echo "       nested SEV-SNP guests."
+            failures=$((failures + 1))
+        fi
+
+        if [[ "$(cat /sys/module/kvm_amd/parameters/sev_snp 2>/dev/null)" == "Y" ]]; then
+            ok "kvm_amd sev_snp = Y"
+        else
+            bad "kvm_amd sev_snp not enabled"
+            echo "       Enable with:  echo 'options kvm_amd sev_snp=1 sev=1 sev_es=1' \\"
+            echo "                       | sudo tee /etc/modprobe.d/kvm-amd-snp.conf"
+            echo "       then reload kvm_amd (or reboot). Needs an SNP host kernel."
+            failures=$((failures + 1))
+        fi
+
+        if [[ -e /dev/kvm ]]; then
+            ok "/dev/kvm present"
+        else
+            bad "/dev/kvm not present — KVM unavailable"
+            failures=$((failures + 1))
+        fi
+    fi
+
+    # The installer needs the first group itself; start-vm.sh needs the rest
+    # at boot time (root check, disk mkfs, control channel).
+    for t in curl tar sha256sum python3 grep awk dd mkfs.ext4 socat; do
+        if have "$t"; then
+            continue
+        fi
+        missing_tools+=("$t")
+    done
+    if (( ${#missing_tools[@]} == 0 )); then
+        ok "tools: curl tar sha256sum python3 dd mkfs.ext4 socat"
+    else
+        bad "missing tools: ${missing_tools[*]}"
+        echo "       On Debian/Ubuntu: sudo apt-get install -y curl tar coreutils python3 e2fsprogs socat"
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            warn "continuing anyway (--dry-run)"
+        else
+            failures=$((failures + 1))
+        fi
+    fi
+
+    if have cargo; then
+        ok "cargo $(cargo --version 2>/dev/null | awk '{print $2}')"
+    else
+        bad "cargo not found — needed to build snp-digest for measurement verification"
+        echo "       (not fatal: the wizard offers to install rustup, or the install"
+        echo "        falls back to checksum-only verification)"
+    fi
+
+    (( failures == 0 )) || fail "preflight failed ($failures issue(s)) — fix the items above and re-run"
+}
+
+# ------------------------------------------------------------------------------
+# Download release + matching launcher scripts
+# ------------------------------------------------------------------------------
+fetch_release() {
+    local tag="$1" tag_url boot_dir src_dir
+    tag_url="$(encode_tag "$tag")"
+    boot_dir="$TEE_HOME/releases/$tag/boot"
+    src_dir="$TEE_HOME/releases/$tag/src"
+
+    if boot_checksums_ok "$boot_dir"; then
+        log "Release $tag already downloaded and checksums match — skipping download"
+    else
+        log "Downloading katana-tee-vm-${tag}.tar.gz ..."
+        mkdir -p "$boot_dir"
+        curl -fsSL -o "$TMP_DIR/release.tar.gz" \
+            "https://github.com/${VM_REPO}/releases/download/${tag_url}/katana-tee-vm-${tag_url}.tar.gz" \
+            || fail "could not download release tarball for $tag"
+        tar xzf "$TMP_DIR/release.tar.gz" -C "$boot_dir"
+        boot_checksums_ok "$boot_dir" \
+            || fail "downloaded artifacts do not match the SHA-256s recorded in build-info.txt"
+        log "  boot artifacts verified against build-info.txt"
+    fi
+
+    # The release tarball carries only boot artifacts. The launcher scripts
+    # (start-vm.sh, scripts/, snp-tools/) come from the repo source AT THE
+    # SAME TAG — they are a matched pair; a launcher from another version may
+    # assemble a different (unverifiable) boot configuration.
+    if [[ -f "$src_dir/start-vm.sh" ]]; then
+        log "Launcher scripts for $tag already present — skipping download"
+    else
+        log "Fetching launcher scripts at tag $tag ..."
+        curl -fsSL -o "$TMP_DIR/src.tar.gz" \
+            "https://github.com/${VM_REPO}/archive/refs/tags/${tag_url}.tar.gz" \
+            || fail "could not download source tarball for tag $tag"
+        extract_amdsev_subtree "$TMP_DIR/src.tar.gz" "$src_dir"
+        [[ -f "$src_dir/start-vm.sh" ]] || fail "source tarball for $tag has no misc/AMDSEV/start-vm.sh"
+        chmod +x "$src_dir"/*.sh "$src_dir"/scripts/*.sh 2>/dev/null || true
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# QEMU
+# ------------------------------------------------------------------------------
+# Echo the QEMU version pinned by the release's build-qemu.sh (single source
+# of truth — don't hardcode it here too).
+pinned_qemu_version() {
+    sed -n 's/^QEMU_VERSION="\(.*\)"$/\1/p' "$1/scripts/build-qemu.sh" | head -n1
+}
+
+# Echo the qemu-system-x86_64 binary matching version $1: a previously
+# locally-built one under $TEE_HOME/qemu first, then PATH. Empty if neither.
+find_qemu() {
+    local want="$1" candidate
+    for candidate in "$TEE_HOME/qemu/bin/qemu-system-x86_64" "$(command -v qemu-system-x86_64 || true)"; do
+        [[ -n "$candidate" && -x "$candidate" ]] || continue
+        if "$candidate" --version 2>/dev/null | head -n1 | grep -q "version ${want}"; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 0
+}
+
+ensure_qemu() {
+    local src_dir="$1" want found choice
+    want="$(pinned_qemu_version "$src_dir")"
+    [[ -n "$want" ]] || fail "could not read QEMU_VERSION from $src_dir/scripts/build-qemu.sh"
+
+    found="$(find_qemu "$want")"
+    if [[ -n "$found" ]]; then
+        log "QEMU $want found: $found"
+        if [[ "$found" == "$TEE_HOME/qemu/bin/qemu-system-x86_64" ]]; then
+            QEMU_PREFIX="$TEE_HOME/qemu"
+        else
+            QEMU_PREFIX=""
+        fi
+        return 0
+    fi
+
+    log "QEMU $want not found on this host (other versions may lack required"
+    log "SEV-SNP features — the TEE VM is only tested against $want)."
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        warn "skipping QEMU build (--dry-run)"
+        QEMU_PREFIX=""
+        return 0
+    fi
+
+    choice="$(ask_validated "Build QEMU $want from source? (local/global/skip)" "local" valid_qemu_choice)"
+    case "$choice" in
+        skip)
+            warn "QEMU $want not installed — run.sh will fail until it is."
+            warn "Build later with: $src_dir/scripts/build-qemu.sh --prefix $TEE_HOME/qemu"
+            QEMU_PREFIX=""
+            ;;
+        local|global)
+            echo "  Build dependencies (Debian/Ubuntu):"
+            echo "    sudo apt-get install -y build-essential ninja-build pkg-config \\"
+            echo "        libglib2.0-dev libpixman-1-dev python3-venv flex bison wget"
+            if [[ "$choice" == "global" ]]; then
+                "$src_dir/scripts/build-qemu.sh" --global
+                QEMU_PREFIX=""
+            else
+                "$src_dir/scripts/build-qemu.sh" --prefix "$TEE_HOME/qemu"
+                QEMU_PREFIX="$TEE_HOME/qemu"
+            fi
+            [[ -n "$(find_qemu "$want")" ]] || fail "QEMU build finished but qemu-system-x86_64 $want still not found"
+            ;;
+    esac
+}
+valid_qemu_choice() { [[ "$1" == "local" || "$1" == "global" || "$1" == "skip" ]]; }
+
+# ------------------------------------------------------------------------------
+# Measurement verification (snp-digest)
+# ------------------------------------------------------------------------------
+ensure_cargo() {
+    have cargo && return 0
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        return 1
+    fi
+    if [[ "$INTERACTIVE" -eq 1 ]]; then
+        ask_yn "cargo not found — install Rust via rustup (needed to build snp-digest)?" "y" || return 1
+    elif [[ "${KATANA_INSTALL_RUSTUP:-0}" != "1" ]]; then
+        return 1
+    fi
+    log "Installing rustup ..."
+    # --default-toolchain none: snp-tools/rust-toolchain.toml pins the exact
+    # toolchain and rustup fetches it on first build.
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+    # shellcheck disable=SC1091
+    [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+    have cargo
+}
+
+# Build snp-digest from the source at the tag and echo its path. The crate
+# pins its own toolchain + target triple, so the binary lands under a
+# target-specific subdirectory — find it like verify-build.sh does.
+build_snp_digest() {
+    local src_dir="$1"
+    (cd "$src_dir/snp-tools" && cargo build --release >&2)
+    find "$src_dir/snp-tools/target" -type f -name snp-digest -perm -u+x 2>/dev/null | head -n1
+}
+
+# Compute the expected launch measurement for the operator's configuration
+# and write it (with provenance) to $TEE_HOME/expected-measurement.txt.
+# vCPU count feeds the digest; memory does not. The sealed cmdline variant
+# measures differently from unsealed, and depends on the LUKS UUID.
+compute_expected_measurement() {
+    local snp_digest="$1" src_dir="$2" boot_dir="$3" cmdline measurement
+
+    if [[ "$SEALED" == "1" ]]; then
+        # shellcheck disable=SC1091
+        . "$src_dir/scripts/sealed-cmdline.sh"
+        cmdline="$(build_sealed_cmdline "$LUKS_UUID")"
+    else
+        cmdline="console=ttyS0"
+    fi
+
+    measurement="$("$snp_digest" \
+        --ovmf="$boot_dir/OVMF.fd" \
+        --kernel="$boot_dir/vmlinuz" \
+        --initrd="$boot_dir/initrd.img" \
+        --append="$cmdline" \
+        --vcpus="$VCPUS" --cpu=epyc-v4 --vmm=qemu --guest-features=0x1)"
+    [[ "$measurement" =~ ^[0-9a-f]{96}$ ]] \
+        || fail "snp-digest produced an unexpected measurement: '$measurement'"
+
+    {
+        echo "# Expected SEV-SNP launch measurement for THIS host's configuration."
+        echo "# Compare against offset 0x90 of a tee_generateQuote report (decode"
+        echo "# with snp-report). Generated by install.sh."
+        echo "# tag=$TAG"
+        echo "# vcpus=$VCPUS (measured)"
+        echo "# memory=$MEMORY (not measured)"
+        echo "# mode=$([[ "$SEALED" == "1" ]] && echo sealed || echo unsealed)"
+        [[ "$SEALED" == "1" ]] && echo "# luks_uuid=$LUKS_UUID"
+        echo "# cmdline=$cmdline"
+        echo "$measurement"
+    } > "$TEE_HOME/expected-measurement.txt"
+
+    EXPECTED_MEASUREMENT="$measurement"
+}
+
+verify_and_measure() {
+    local src_dir="$1" boot_dir="$2" snp_digest
+
+    if ! ensure_cargo; then
+        # Boot artifacts were already checksum-verified against build-info.txt
+        # in fetch_release; only the measurement recompute is unavailable.
+        rm -f "$TEE_HOME/expected-measurement.txt"
+        warn "=================================================================="
+        warn "cargo unavailable — SKIPPING launch-measurement verification."
+        warn "Artifact checksums were verified, but the expected measurement for"
+        warn "your configuration was NOT computed, so remote attestation results"
+        warn "cannot be checked against a local expected value."
+        warn "Install Rust (https://rustup.rs) and run:"
+        warn "    $TEE_HOME/install.sh verify"
+        warn "=================================================================="
+        EXPECTED_MEASUREMENT=""
+        return 0
+    fi
+
+    log "Building snp-digest from source at $TAG ..."
+    snp_digest="$(build_snp_digest "$src_dir")"
+    [[ -n "$snp_digest" ]] || fail "snp-tools built but no snp-digest binary was found"
+
+    # Full release verification: every artifact SHA-256 plus the RECORDED
+    # measurement (vcpus=1, canonical sealed UUID — the values the release
+    # was published with). verify-build.sh finds snp-digest in the src tree.
+    log "Verifying release checksums + published launch measurement ..."
+    "$src_dir/verify-build.sh" "$boot_dir" \
+        || fail "release verification failed — do not boot these artifacts"
+
+    log "Computing expected launch measurement for your config (vcpus=$VCPUS, $([[ "$SEALED" == "1" ]] && echo sealed || echo unsealed)) ..."
+    compute_expected_measurement "$snp_digest" "$src_dir" "$boot_dir"
+}
+
+# ------------------------------------------------------------------------------
+# Data disk
+# ------------------------------------------------------------------------------
+# start-vm.sh only auto-creates its own default disk path and refuses a
+# user-specified --data-disk that doesn't exist, so the installer provisions
+# it the same way start-vm.sh provisions the default (dd + mkfs.ext4 for
+# unsealed; raw for sealed — the guest luksFormats on first boot).
+provision_data_disk() {
+    if [[ -f "$DATA_DISK" ]]; then
+        log "Data disk exists: $DATA_DISK (left untouched)"
+        return 0
+    fi
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        warn "skipping data disk creation (--dry-run): $DATA_DISK"
+        return 0
+    fi
+    log "Creating data disk: $DATA_DISK (${DISK_SIZE_MB}MB)"
+    mkdir -p "$(dirname "$DATA_DISK")"
+    dd if=/dev/zero of="$DATA_DISK" bs=1M count="$DISK_SIZE_MB" status=none
+    if [[ "$SEALED" == "1" ]]; then
+        log "  left raw — the guest will luksFormat it on first boot"
+    else
+        mkfs.ext4 -F -q "$DATA_DISK"
+        log "  formatted as plain ext4"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Config + run.sh
+# ------------------------------------------------------------------------------
+load_config() {
+    if [[ -f "$TEE_HOME/config.env" ]]; then
+        # shellcheck disable=SC1091
+        . "$TEE_HOME/config.env"
+        return 0
+    fi
+    return 1
+}
+
+write_config() {
+    mkdir -p "$TEE_HOME"
+    {
+        echo "# Katana TEE VM configuration — written by install.sh, sourced by run.sh."
+        echo "# Re-run install.sh to change values (it pre-fills the wizard from this file)."
+        # %q so values with spaces/globs round-trip through `source` intact.
+        printf 'KATANA_TEE_TAG=%q\n'      "$TAG"
+        printf 'VCPUS=%q\n'               "$VCPUS"
+        printf 'MEMORY=%q\n'              "$MEMORY"
+        printf 'DATA_DISK=%q\n'           "$DATA_DISK"
+        printf 'DISK_SIZE_MB=%q\n'        "$DISK_SIZE_MB"
+        printf 'HOST_RPC_PORT=%q\n'       "$RPC_PORT"
+        printf 'SEALED=%q\n'              "$SEALED"
+        printf 'LUKS_UUID=%q\n'           "$LUKS_UUID"
+        printf 'KATANA_ARGS_CSV=%q\n'     "$KATANA_ARGS_CSV"
+        printf 'QEMU_PREFIX=%q\n'         "$QEMU_PREFIX"
+        printf 'LAUNCHER_HAS_VCPUS=%q\n'  "$LAUNCHER_HAS_VCPUS"
+        printf 'LAUNCHER_HAS_MEMORY=%q\n' "$LAUNCHER_HAS_MEMORY"
+    } > "$TEE_HOME/config.env"
+}
+
+write_run_sh() {
+    # Static launcher: all values come from config.env at run time, so
+    # editing config.env is enough — no need to regenerate run.sh.
+    cat > "$TEE_HOME/run.sh" <<'EOF'
+#!/bin/bash
+# Generated by install.sh — launches the Katana TEE VM in the FOREGROUND
+# (serial log follows; Ctrl+C triggers a graceful guest shutdown).
+# Persistence (systemd, tmux, a supervisor) is deliberately the operator's
+# choice — `install.sh print-systemd` prints a sample unit.
+set -euo pipefail
+TEE_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$TEE_HOME/config.env"
+
+BOOT="$TEE_HOME/releases/$KATANA_TEE_TAG/boot"
+SRC="$TEE_HOME/releases/$KATANA_TEE_TAG/src"
+
+# Locally-built QEMU (if any) first; `sudo env PATH=...` below carries it
+# past sudo's secure_path.
+if [[ -n "${QEMU_PREFIX:-}" ]]; then
+    PATH="$QEMU_PREFIX/bin:$PATH"
+fi
+
+ENV_VARS=("PATH=$PATH" "HOST_RPC_PORT=$HOST_RPC_PORT")
+# Resources ride env vars (not flags) so the same run.sh works with older
+# launchers too: a launcher without KATANA_VCPUS/KATANA_MEMORY support keeps
+# its hardcoded values, which is exactly what its published measurement pins.
+[[ "${LAUNCHER_HAS_VCPUS:-0}" == "1" ]] && ENV_VARS+=("KATANA_VCPUS=$VCPUS")
+[[ "${LAUNCHER_HAS_MEMORY:-0}" == "1" ]] && ENV_VARS+=("KATANA_MEMORY=$MEMORY")
+
+ARGS=(
+    --ovmf "$BOOT/OVMF.fd"
+    --kernel "$BOOT/vmlinuz"
+    --initrd "$BOOT/initrd.img"
+    --data-disk "$DATA_DISK"
+    --katana-args "$KATANA_ARGS_CSV"
+)
+if [[ "${SEALED:-0}" == "1" ]]; then
+    ARGS+=(--sealed --luks-uuid "$LUKS_UUID")
+fi
+
+# start-vm.sh needs root for KVM and disk setup.
+exec sudo env "${ENV_VARS[@]}" "$SRC/start-vm.sh" "${ARGS[@]}"
+EOF
+    chmod +x "$TEE_HOME/run.sh"
+}
+
+# Keep a durable copy of the installer for upgrades / verify / print-systemd
+# (a curl | bash invocation has no on-disk script to re-run). Prefer the
+# copy shipped in the source at the installed tag; fall back to this script
+# file when the tag predates install.sh.
+persist_installer() {
+    local src_dir="$1" self="${BASH_SOURCE[0]:-}"
+    if [[ -f "$src_dir/install.sh" ]]; then
+        cp "$src_dir/install.sh" "$TEE_HOME/install.sh"
+    elif [[ -n "$self" && -f "$self" ]]; then
+        cp "$self" "$TEE_HOME/install.sh"
+    else
+        warn "could not persist a copy of install.sh (running from a pipe and"
+        warn "release $TAG predates the installer) — re-curl it for upgrades"
+        return 0
+    fi
+    chmod +x "$TEE_HOME/install.sh"
+}
+
+print_systemd_unit() {
+    # Printed, never installed: the installer stays unopinionated about how
+    # (or whether) the VM is supervised.
+    cat <<EOF
+# Sample systemd unit for the Katana TEE VM. Review, then install with:
+#   sudo cp katana-tee-vm.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now katana-tee-vm
+[Unit]
+Description=Katana TEE VM (AMD SEV-SNP)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$TEE_HOME/run.sh
+Restart=on-failure
+RestartSec=5
+# start-vm.sh's EXIT trap performs a graceful guest shutdown (katana TERM,
+# sync, unmount, poweroff) on SIGTERM — give it time before SIGKILL. The
+# data disk is persistent, so restarts resume the existing chain state.
+KillMode=mixed
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+# ------------------------------------------------------------------------------
+# Wizard
+# ------------------------------------------------------------------------------
+run_wizard() {
+    local src_dir="$1" nproc_max
+
+    log ""
+    log "Configuration (Enter accepts the default; flags/env vars override)"
+
+    # --- vCPUs / memory: gated on what the tag's launcher supports ----------
+    LAUNCHER_HAS_VCPUS=0
+    LAUNCHER_HAS_MEMORY=0
+    grep -q 'KATANA_VCPUS' "$src_dir/start-vm.sh" && LAUNCHER_HAS_VCPUS=1
+    grep -q 'KATANA_MEMORY' "$src_dir/start-vm.sh" && LAUNCHER_HAS_MEMORY=1
+
+    if [[ "$LAUNCHER_HAS_VCPUS" == "1" ]]; then
+        if [[ -z "$VCPUS" ]]; then
+            echo "  vCPU count is PART OF the SEV-SNP launch measurement; the expected"
+            echo "  measurement will be recomputed for your value."
+            nproc_max="$(nproc 2>/dev/null || echo 0)"
+            VCPUS="$(ask_validated "vCPUs" "$WIZ_DEF_VCPUS" valid_vcpus)"
+            if [[ "$nproc_max" != "0" ]] && (( VCPUS > nproc_max )); then
+                fail "vCPUs ($VCPUS) exceeds host CPU count ($nproc_max)"
+            fi
+        else
+            valid_vcpus "$VCPUS" || fail "invalid --vcpus: '$VCPUS'"
+        fi
+    else
+        if [[ -n "$VCPUS" && "$VCPUS" != "1" ]]; then
+            fail "release $TAG's launcher predates configurable vCPUs — pick a newer release or keep --vcpus 1"
+        fi
+        VCPUS=1
+        log "  vCPUs: locked to 1 (release $TAG's launcher predates configurable vCPUs)"
+    fi
+
+    if [[ "$LAUNCHER_HAS_MEMORY" == "1" ]]; then
+        if [[ -z "$MEMORY" ]]; then
+            echo "  Memory is NOT part of the measurement — size freely. The initramfs"
+            echo "  (incl. the katana binary) unpacks into guest RAM: 4G minimum advised."
+            MEMORY="$(ask_validated "Memory (e.g. 4G, 2048M)" "$WIZ_DEF_MEMORY" valid_memory)"
+        else
+            valid_memory "$MEMORY" || fail "invalid --memory: '$MEMORY'"
+        fi
+    else
+        if [[ -n "$MEMORY" ]]; then
+            fail "release $TAG's launcher predates configurable memory — pick a newer release or drop --memory"
+        fi
+        MEMORY=""
+        log "  Memory: launcher default (release $TAG's launcher predates configurable memory)"
+    fi
+
+    # --- Data disk -----------------------------------------------------------
+    if [[ -z "$DATA_DISK" ]]; then
+        DATA_DISK="$(ask "Data disk path" "$WIZ_DEF_DISK")"
+    fi
+    if [[ -f "$DATA_DISK" ]]; then
+        DISK_SIZE_MB="${DISK_SIZE_MB:-$WIZ_DEF_DISK_MB}"
+    elif [[ -z "$DISK_SIZE_MB" ]]; then
+        DISK_SIZE_MB="$(ask_validated "Data disk size in MB (created now)" "$WIZ_DEF_DISK_MB" valid_int)"
+    else
+        valid_int "$DISK_SIZE_MB" || fail "invalid --disk-size-mb: '$DISK_SIZE_MB'"
+    fi
+
+    # --- RPC port ------------------------------------------------------------
+    if [[ -z "$RPC_PORT" ]]; then
+        RPC_PORT="$(ask_validated "Host RPC port (forwards to guest 5050)" "$WIZ_DEF_RPC_PORT" valid_port)"
+    else
+        valid_port "$RPC_PORT" || fail "invalid --rpc-port: '$RPC_PORT'"
+    fi
+    # Warn rather than fail: on an upgrade re-run the currently-running TEE VM
+    # legitimately holds this port — it only needs to be free at boot time.
+    port_free "$RPC_PORT" || warn "port $RPC_PORT is currently in use (a running TEE VM? it must be free when run.sh boots)"
+
+    # --- Storage mode ----------------------------------------------------------
+    if [[ -z "$SEALED_MODE" ]]; then
+        echo "  Sealed storage binds the disk key to the launch measurement: strong"
+        echo "  at-rest protection, but a release upgrade re-keys the disk and the"
+        echo "  old data no longer unseals (docs/amdsev.md, Sealed storage)."
+        SEALED_MODE="$(ask_validated "Storage mode (unsealed/sealed)" "$WIZ_DEF_SEALED_MODE" valid_mode)"
+    fi
+    if [[ "$SEALED_MODE" == "sealed" ]]; then
+        SEALED=1
+        if [[ -z "$LUKS_UUID" ]]; then
+            if have uuidgen; then
+                LUKS_UUID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+            else
+                LUKS_UUID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+            fi
+            log "  Generated LUKS UUID: $LUKS_UUID (persisted in config.env; part of"
+            log "  the sealed launch measurement, stable across boots on this host)"
+        fi
+        valid_uuid "$LUKS_UUID" || fail "invalid LUKS UUID: '$LUKS_UUID'"
+    else
+        SEALED=0
+        LUKS_UUID=""
+    fi
+
+    # --- Katana args -----------------------------------------------------------
+    if [[ -z "$KATANA_ARGS_CSV" ]]; then
+        if ask_yn "Keep these Katana args? ($WIZ_DEF_ARGS)" "y"; then
+            KATANA_ARGS_CSV="$WIZ_DEF_ARGS"
+        else
+            KATANA_ARGS_CSV="$(ask "Katana args (comma-separated; keep --http.port 5050)" "$WIZ_DEF_ARGS")"
+        fi
+    fi
+    local metrics_port
+    metrics_port="$(parse_metrics_port "$KATANA_ARGS_CSV")"
+    if [[ -n "$metrics_port" ]]; then
+        valid_port "$metrics_port" || fail "invalid --metrics.port in katana args: '$metrics_port'"
+        port_free "$metrics_port" || warn "metrics port $metrics_port is currently in use (it must be free when run.sh boots)"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Subcommands
+# ------------------------------------------------------------------------------
+cmd_install() {
+    local prev_tag="" prev_sealed=""
+
+    # Pre-fill the wizard from an existing install (upgrade / re-run path).
+    # Precedence: flag/env > saved config > built-in default. Sourcing
+    # config.env would clobber the flag values (same variable names), so
+    # stash them first and restore after; the config values become the
+    # wizard's prompt defaults instead.
+    local f_vcpus="$VCPUS" f_memory="$MEMORY" f_rpc="$RPC_PORT" f_disk="$DATA_DISK"
+    local f_disk_mb="$DISK_SIZE_MB" f_args="$KATANA_ARGS_CSV" f_sealed_mode="$SEALED_MODE"
+    local f_luks="$LUKS_UUID"
+    WIZ_DEF_VCPUS="$DEFAULT_VCPUS"
+    WIZ_DEF_MEMORY="$DEFAULT_MEMORY"
+    WIZ_DEF_RPC_PORT="$DEFAULT_RPC_PORT"
+    WIZ_DEF_DISK="$TEE_HOME/data.img"
+    WIZ_DEF_DISK_MB="$DEFAULT_DISK_SIZE_MB"
+    WIZ_DEF_SEALED_MODE="unsealed"
+    WIZ_DEF_ARGS="$DEFAULT_KATANA_ARGS_CSV"
+    SEALED="" LUKS_UUID="" QEMU_PREFIX=""
+    if load_config; then
+        prev_tag="${KATANA_TEE_TAG:-}"
+        prev_sealed="${SEALED:-0}"
+        [[ -n "${VCPUS:-}" ]]           && WIZ_DEF_VCPUS="$VCPUS"
+        [[ -n "${MEMORY:-}" ]]          && WIZ_DEF_MEMORY="$MEMORY"
+        [[ -n "${HOST_RPC_PORT:-}" ]]   && WIZ_DEF_RPC_PORT="$HOST_RPC_PORT"
+        [[ -n "${DATA_DISK:-}" ]]       && WIZ_DEF_DISK="$DATA_DISK"
+        [[ -n "${DISK_SIZE_MB:-}" ]]    && WIZ_DEF_DISK_MB="$DISK_SIZE_MB"
+        [[ -n "${KATANA_ARGS_CSV:-}" ]] && WIZ_DEF_ARGS="$KATANA_ARGS_CSV"
+        [[ "$prev_sealed" == "1" ]]     && WIZ_DEF_SEALED_MODE="sealed"
+        log "Existing install found at $TEE_HOME (tag ${prev_tag:-<none>}) — values pre-filled"
+    fi
+    VCPUS="$f_vcpus"
+    MEMORY="$f_memory"
+    RPC_PORT="$f_rpc"
+    DATA_DISK="$f_disk"
+    DISK_SIZE_MB="$f_disk_mb"
+    KATANA_ARGS_CSV="$f_args"
+    SEALED_MODE="$f_sealed_mode"
+    # No flag for the LUKS UUID (env KATANA_LUKS_UUID only) — reuse the saved
+    # one so a sealed re-run keeps its measurement-stable UUID.
+    [[ -z "$f_luks" ]] || LUKS_UUID="$f_luks"
+    QEMU_PREFIX=""
+    EXPECTED_MEASUREMENT=""
+
+    log "Katana TEE VM installer"
+    log "======================="
+
+    preflight
+
+    # --- Resolve the release tag ---------------------------------------------
+    if [[ -z "$TAG" ]]; then
+        log ""
+        log "Resolving latest TEE-VM release (tee-vm-v*) ..."
+        local latest
+        latest="$(resolve_latest_tag)"
+        [[ -n "$latest" ]] || fail "no published tee-vm-v* releases found in $VM_REPO"
+        TAG="$(ask_validated "Release tag" "$latest" valid_tag)"
+    else
+        valid_tag "$TAG" || fail "not a TEE-VM release tag (want tee-vm-v*): '$TAG'"
+    fi
+
+    # Sealed upgrade guard: the sealed disk key is bound to the launch
+    # measurement, so a release change re-keys the disk — the old data will
+    # NOT unseal under the new release.
+    if [[ "$prev_sealed" == "1" && -n "$prev_tag" && "$TAG" != "$prev_tag" ]]; then
+        warn "sealed-mode release change: $prev_tag -> $TAG re-keys the data disk;"
+        warn "the existing sealed data will no longer unseal. Use a fresh --data-disk"
+        warn "to keep the old disk recoverable under the old release."
+        if [[ "$INTERACTIVE" -eq 1 ]]; then
+            ask_yn "Continue anyway?" "n" || fail "aborted by user"
+        elif [[ "${KATANA_CONFIRM_SEALED_UPGRADE:-0}" != "1" ]]; then
+            fail "refusing a sealed-mode release change non-interactively — set KATANA_CONFIRM_SEALED_UPGRADE=1 to proceed"
+        fi
+    fi
+
+    mkdir -p "$TEE_HOME"
+    fetch_release "$TAG"
+    local boot_dir="$TEE_HOME/releases/$TAG/boot"
+    local src_dir="$TEE_HOME/releases/$TAG/src"
+
+    run_wizard "$src_dir"
+    ensure_qemu "$src_dir"
+    verify_and_measure "$src_dir" "$boot_dir"
+    provision_data_disk
+
+    write_config
+    write_run_sh
+    persist_installer "$src_dir"
+    ln -sfn "releases/$TAG" "$TEE_HOME/current"
+
+    # --- Summary ---------------------------------------------------------------
+    local metrics_port
+    metrics_port="$(parse_metrics_port "$KATANA_ARGS_CSV")"
+    log ""
+    log "============================================================"
+    log "Installed: $TAG"
+    log "Install root:  $TEE_HOME"
+    if [[ -n "$EXPECTED_MEASUREMENT" ]]; then
+        log "Expected launch measurement (vcpus=$VCPUS, $([[ "$SEALED" == "1" ]] && echo sealed || echo unsealed)):"
+        log "  $EXPECTED_MEASUREMENT"
+        log "  (saved to $TEE_HOME/expected-measurement.txt)"
+    else
+        log "Expected launch measurement: NOT computed (no cargo) — run"
+        log "  $TEE_HOME/install.sh verify   after installing Rust"
+    fi
+    log ""
+    log "Run the VM (foreground):        $TEE_HOME/run.sh"
+    log "  RPC:      http://localhost:$RPC_PORT   (starknet JSON-RPC + tee_generateQuote)"
+    if [[ -n "$metrics_port" ]]; then
+        log "  Metrics:  http://localhost:$metrics_port"
+    fi
+    log "  Data:     $DATA_DISK (persists across restarts)"
+    log ""
+    log "Persistence is up to you — print a sample systemd unit with:"
+    log "                                $TEE_HOME/install.sh print-systemd"
+    log "Re-verify the release:          $TEE_HOME/install.sh verify"
+    log "Upgrade to the latest release:  $TEE_HOME/install.sh"
+    log "============================================================"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        log "(dry run: QEMU build, rustup install and data-disk creation were skipped)"
+    fi
+}
+
+cmd_verify() {
+    load_config || fail "no install found at $TEE_HOME (run install first)"
+    TAG="$KATANA_TEE_TAG"
+    RPC_PORT="$HOST_RPC_PORT"
+    EXPECTED_MEASUREMENT=""
+    local boot_dir="$TEE_HOME/releases/$TAG/boot"
+    local src_dir="$TEE_HOME/releases/$TAG/src"
+    [[ -d "$boot_dir" && -d "$src_dir" ]] || fail "release $TAG is missing under $TEE_HOME/releases"
+
+    boot_checksums_ok "$boot_dir" || fail "boot artifact checksums do NOT match build-info.txt"
+    log "Boot artifact checksums OK"
+    verify_and_measure "$src_dir" "$boot_dir"
+    if [[ -n "$EXPECTED_MEASUREMENT" ]]; then
+        log ""
+        log "Expected launch measurement (vcpus=$VCPUS, $([[ "$SEALED" == "1" ]] && echo sealed || echo unsealed)):"
+        log "  $EXPECTED_MEASUREMENT"
+    fi
+}
+
+cmd_print_systemd() {
+    # config.env is optional here — the unit only needs the install root.
+    print_systemd_unit
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+main() {
+    local command="install"
+    if [[ $# -gt 0 ]]; then
+        case "$1" in
+            install|verify|print-systemd)
+                command="$1"
+                shift
+                ;;
+        esac
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --tag)          [[ $# -ge 2 ]] || fail "--tag requires a value";          TAG="$2"; shift 2 ;;
+            --vcpus)        [[ $# -ge 2 ]] || fail "--vcpus requires a value";        VCPUS="$2"; shift 2 ;;
+            --memory)       [[ $# -ge 2 ]] || fail "--memory requires a value";       MEMORY="$2"; shift 2 ;;
+            --rpc-port)     [[ $# -ge 2 ]] || fail "--rpc-port requires a value";     RPC_PORT="$2"; shift 2 ;;
+            --data-disk)    [[ $# -ge 2 ]] || fail "--data-disk requires a value";    DATA_DISK="$2"; shift 2 ;;
+            --disk-size-mb) [[ $# -ge 2 ]] || fail "--disk-size-mb requires a value"; DISK_SIZE_MB="$2"; shift 2 ;;
+            --katana-args)  [[ $# -ge 2 ]] || fail "--katana-args requires a value";  KATANA_ARGS_CSV="$2"; shift 2 ;;
+            --home)         [[ $# -ge 2 ]] || fail "--home requires a value";         TEE_HOME="$2"; TEE_HOME_EXPLICIT=1; shift 2 ;;
+            --sealed)       SEALED_MODE="sealed"; shift ;;
+            --unsealed)     SEALED_MODE="unsealed"; shift ;;
+            --yes)          ASSUME_YES=1; shift ;;
+            --dry-run)      DRY_RUN=1; shift ;;
+            -h|--help)      usage; exit 0 ;;
+            *)              echo "Error: unknown option: $1" >&2; echo "" >&2; usage >&2; exit 1 ;;
+        esac
+    done
+
+    # When invoked from a persisted copy (~/.katana/tee-vm/install.sh) without
+    # an explicit --home / KATANA_TEE_HOME, operate on the install the copy
+    # lives in — not the default path — so upgrades/verify/print-systemd of a
+    # relocated install target the right one.
+    if [[ "$TEE_HOME_EXPLICIT" -eq 0 ]]; then
+        local self_dir=""
+        if [[ -n "${BASH_SOURCE[0]:-}" && -f "${BASH_SOURCE[0]}" ]]; then
+            self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        fi
+        if [[ -n "$self_dir" && -f "$self_dir/config.env" ]]; then
+            TEE_HOME="$self_dir"
+        fi
+    fi
+
+    # Interactive only when the operator can actually answer: not --yes, and
+    # /dev/tty is usable (curl | bash keeps stdin busy with the script body,
+    # so the terminal — not stdin — is the deciding factor).
+    if [[ "$ASSUME_YES" -eq 0 ]] && { : < /dev/tty; } 2>/dev/null; then
+        INTERACTIVE=1
+    elif [[ "$ASSUME_YES" -eq 0 && "$command" == "install" ]]; then
+        fail "no terminal available for the wizard — re-run non-interactively, e.g.:
+    curl -fsSL .../install.sh | bash -s -- --yes [--vcpus N] [--memory SIZE] ..."
+    fi
+
+    TMP_DIR="$(mktemp -d /tmp/katana-tee-install.XXXXXX)"
+
+    case "$command" in
+        install)       cmd_install ;;
+        verify)        cmd_verify ;;
+        print-systemd) cmd_print_systemd ;;
+    esac
+}
+
+# Test hook: KATANA_INSTALL_LIB=1 sources the helpers without running main
+# (see scripts/test-install.sh).
+if [[ "${KATANA_INSTALL_LIB:-0}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+main "$@"

--- a/misc/AMDSEV/reproduce-release.sh
+++ b/misc/AMDSEV/reproduce-release.sh
@@ -10,8 +10,10 @@
 #
 # The script:
 #   1. Downloads the release's build-info.txt (the published provenance).
-#   2. Downloads the exact katana binary the release embedded, verified
-#      against the recorded KATANA_BINARY_SHA256.
+#   2. Downloads the exact katana binary the release embedded (the release
+#      asset variant recorded as KATANA_ASSET_VARIANT — `native` for current
+#      releases, portable for pre-native ones), verified against the recorded
+#      KATANA_BINARY_SHA256.
 #   3. Rebuilds OVMF + kernel + initrd from source with SOURCE_DATE_EPOCH
 #      set to the recorded value (OVMF derives its own epoch from the pinned
 #      OVMF commit — see scripts/build-ovmf.sh).
@@ -29,8 +31,9 @@
 #     OS image can yield a different (but still internally consistent)
 #     OVMF.fd.
 #   - The OVMF build takes ~10 minutes; the full run ~15.
-#   - Docker is needed (static cryptsetup build), plus cargo with the
-#     x86_64-unknown-linux-musl target (snp-derivekey).
+#   - Docker is needed (static cryptsetup + static ld builds — see
+#     scripts/build-cryptsetup.sh and scripts/build-binutils-ld.sh), plus
+#     cargo with the x86_64-unknown-linux-musl target (snp-derivekey).
 #
 # Usage:
 #   ./reproduce-release.sh TAG [--workdir DIR]
@@ -158,11 +161,23 @@ if [[ -n "$RECORDED_KATANA_VER" && "$RECORDED_KATANA_VER" != "$KATANA_VER" ]]; t
     die "katana version mismatch: tag says '$KATANA_VER' but build-info records '$RECORDED_KATANA_VER'"
 fi
 
-log "Downloading katana $KATANA_VER (portable linux_amd64 build)"
-KATANA_TARBALL="$WORKDIR/katana_${KATANA_VER}_linux_amd64.tar.gz"
+# Which release asset variant was embedded. Recorded by amdsev-release.yml
+# as KATANA_ASSET_VARIANT (`native` = the cairo-native build,
+# katana_<ver>_linux_amd64_native.tar.gz). Releases from before the native
+# switch have no such key and embedded the portable build. The recorded
+# KATANA_BINARY_SHA256 below stays the authoritative gate either way.
+RECORDED_VARIANT="$(info_get KATANA_ASSET_VARIANT)"
+case "$RECORDED_VARIANT" in
+    native)      ASSET_SUFFIX="_native" ;;
+    ""|portable) ASSET_SUFFIX="" ;;
+    *)           die "unknown KATANA_ASSET_VARIANT '$RECORDED_VARIANT' in published build-info" ;;
+esac
+
+log "Downloading katana $KATANA_VER (${RECORDED_VARIANT:-portable} linux_amd64 build)"
+KATANA_TARBALL="$WORKDIR/katana_${KATANA_VER}_linux_amd64${ASSET_SUFFIX}.tar.gz"
 curl -fsSL -o "$KATANA_TARBALL" \
-    "https://github.com/${KATANA_REPO}/releases/download/${KATANA_VER}/katana_${KATANA_VER}_linux_amd64.tar.gz" \
-    || die "could not download katana $KATANA_VER from $KATANA_REPO"
+    "https://github.com/${KATANA_REPO}/releases/download/${KATANA_VER}/katana_${KATANA_VER}_linux_amd64${ASSET_SUFFIX}.tar.gz" \
+    || die "could not download katana $KATANA_VER (${RECORDED_VARIANT:-portable}) from $KATANA_REPO"
 
 mkdir -p "$WORKDIR/katana-bin"
 tar -xzf "$KATANA_TARBALL" -C "$WORKDIR/katana-bin"

--- a/misc/AMDSEV/scripts/build-binutils-ld.sh
+++ b/misc/AMDSEV/scripts/build-binutils-ld.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# ==============================================================================
+# BUILD-BINUTILS-LD.SH
+# ==============================================================================
+#
+# Build the static GNU `ld` binary the initrd needs for in-guest cairo-native
+# AOT linking, inside a pinned Alpine container.
+#
+# Why the guest needs a linker at all: the bundled katana is the cairo-native
+# release build. With --enable-native-compilation, it AOT-compiles each
+# contract class at runtime and shells out to `ld` (PATH lookup; the guest
+# init exports PATH=/bin) to link the emitted object into a dlopen-able .so:
+#
+#   ld --hash-style=gnu -shared -L/lib/../lib64 -L/usr/lib/../lib64 \
+#      -o <out.so> -lc <in.o>
+#
+# That argv is an internal detail of cairo-native (src/ffi.rs in the locked
+# cairo-native crate) — re-verify it when bumping cairo-native, since a future
+# version could add flags or switch linkers. The `-lc` input is provided by
+# the /lib64/libc.so linker script that build-initrd.sh generates.
+#
+# `make all-ld` builds only bfd + libiberty + ld (skips gas, gold, binutils
+# proper, gprofng). The static link needs TWO make phases:
+#
+#   make configure-host              runs every host sub-configure with clean
+#                                    LDFLAGS — a command-line LDFLAGS override
+#                                    would leak into the sub-configures' link
+#                                    tests, and gcc does not understand the
+#                                    libtool-only `-all-static`, so configure
+#                                    would bail with GCC_NO_EXECUTABLES.
+#   make all-ld LDFLAGS=-all-static  the sub-configures are already cached, so
+#                                    the override now only reaches the actual
+#                                    (libtool-driven) link of ld — `-all-static`
+#                                    is the libtool spelling for a fully static
+#                                    executable. (A plain `-static` does NOT
+#                                    work: libtool swallows it as "prefer
+#                                    static libtool libs" and still links
+#                                    libc/libz dynamically.)
+#
+# Release tarballs ship pregenerated ldgram.c/ldlex.c, so no flex/bison is
+# needed. MAKEINFO=true skips doc generation (no texinfo in the container).
+#
+# Usage:
+#   ./build-binutils-ld.sh OUTPUT_DIR
+#
+# The script writes one file:
+#   $OUTPUT_DIR/ld
+# Statically linked (verified via ldd). It gets baked into the initrd at
+# /bin/ld by build-initrd.sh, which expects $LD_BINARY to point at it (or an
+# operator-supplied equivalent).
+#
+# Environment (all required; build-config provides defaults):
+#   SOURCE_DATE_EPOCH         Reproducibility anchor.
+#   BINUTILS_VERSION          e.g. 2.44
+#   BINUTILS_SHA256           sha256 of binutils-$VERSION.tar.xz
+#   CRYPTSETUP_BUILDER_IMAGE  pinned alpine@sha256:... container image
+#                             (shared with build-cryptsetup.sh)
+#
+# Optional:
+#   CRYPTSETUP_BUILDER        container CLI (default: docker)
+#
+# ==============================================================================
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 OUTPUT_DIR"
+    echo ""
+    echo "Builds a static GNU ld inside a pinned Alpine container."
+    echo "Writes \$OUTPUT_DIR/ld."
+    echo ""
+    echo "All env vars listed in the script header are required; source"
+    echo "misc/AMDSEV/build-config to get the canonical pinned values."
+    exit 1
+}
+
+if [[ $# -lt 1 ]] || [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    usage
+fi
+
+log_section() { echo ""; echo "=========================================="; echo "$*"; echo "=========================================="; }
+log_info()    { echo "  [INFO] $*"; }
+log_ok()      { echo "  [OK] $*"; }
+log_warn()    { echo "  [WARN] $*"; }
+die()         { echo "ERROR: $*" >&2; exit 1; }
+
+to_abs_path() {
+    local path="$1"
+    if [[ "$path" = /* ]]; then
+        printf '%s\n' "$path"
+    else
+        printf '%s/%s\n' "$(pwd -P)" "$path"
+    fi
+}
+
+OUTPUT_DIR="$(to_abs_path "$1")"
+
+# Required env vars (build-config supplies all of these).
+: "${SOURCE_DATE_EPOCH:?SOURCE_DATE_EPOCH must be set}"
+: "${BINUTILS_VERSION:?BINUTILS_VERSION must be set}"
+: "${BINUTILS_SHA256:?BINUTILS_SHA256 must be set}"
+: "${CRYPTSETUP_BUILDER_IMAGE:?CRYPTSETUP_BUILDER_IMAGE must be set (pinned alpine@sha256:... digest)}"
+
+CRYPTSETUP_BUILDER="${CRYPTSETUP_BUILDER:-docker}"
+command -v "$CRYPTSETUP_BUILDER" >/dev/null 2>&1 \
+    || die "Container runtime '$CRYPTSETUP_BUILDER' not found. Install docker/podman or set CRYPTSETUP_BUILDER."
+
+REQUIRED_TOOLS=(curl tar sha256sum awk ldd)
+for tool in "${REQUIRED_TOOLS[@]}"; do
+    command -v "$tool" >/dev/null 2>&1 || die "Required host tool not found: $tool"
+done
+
+mkdir -p "$OUTPUT_DIR"
+[[ -w "$OUTPUT_DIR" ]] || die "Output directory is not writable: $OUTPUT_DIR"
+
+log_section "Building static GNU ld"
+echo "Configuration:"
+echo "  Output dir:        $OUTPUT_DIR"
+echo "  binutils:          ${BINUTILS_VERSION}"
+echo "  Container image:   ${CRYPTSETUP_BUILDER_IMAGE}"
+echo "  Container runtime: ${CRYPTSETUP_BUILDER}"
+echo "  SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH}"
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+    local exit_code=$?
+    [[ -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+log_info "Working directory: $WORK_DIR"
+
+# ==============================================================================
+# Download + verify source (host-side)
+# ==============================================================================
+
+log_section "Download Sources"
+pushd "$WORK_DIR" >/dev/null
+
+BINUTILS_TARBALL="binutils-${BINUTILS_VERSION}.tar.xz"
+BINUTILS_URL="https://ftp.gnu.org/gnu/binutils/${BINUTILS_TARBALL}"
+
+log_info "Downloading $BINUTILS_URL"
+curl -fLsS -o "$BINUTILS_TARBALL" "$BINUTILS_URL"
+ACTUAL_SHA256="$(sha256sum "$BINUTILS_TARBALL" | awk '{print $1}')"
+[[ "$ACTUAL_SHA256" == "$BINUTILS_SHA256" ]] \
+    || die "binutils checksum mismatch (expected $BINUTILS_SHA256, got $ACTUAL_SHA256)"
+log_ok "binutils source verified"
+
+log_info "Extracting source"
+tar -xf "$BINUTILS_TARBALL"
+
+# ==============================================================================
+# Containerised build (Alpine + musl)
+# ==============================================================================
+
+log_section "Build Inside Container"
+log_info "Image: $CRYPTSETUP_BUILDER_IMAGE"
+
+# The container runs as root (apk add requires it). Once the build is done,
+# chown the output binary to the invoking host user so the cleanup trap's
+# rm -rf "$WORK_DIR" doesn't trip over root-owned files.
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+
+"$CRYPTSETUP_BUILDER" run --rm \
+    -v "$WORK_DIR:/build" \
+    -w "/build" \
+    -e "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" \
+    -e "HOST_UID=${HOST_UID}" \
+    -e "HOST_GID=${HOST_GID}" \
+    -e "BINUTILS_VERSION=${BINUTILS_VERSION}" \
+    "$CRYPTSETUP_BUILDER_IMAGE" \
+    sh -euc '
+        apk add --no-cache build-base zlib-dev zlib-static
+
+        cd "/build/binutils-${BINUTILS_VERSION}"
+        # --target=x86_64-unknown-linux-gnu: self-documenting; the default
+        #   emulation is elf_x86_64 either way, and the built-in SEARCH_DIRs
+        #   are irrelevant — cairo-native passes explicit -L paths and the
+        #   -lc input lives at /lib64/libc.so in the initrd.
+        # --disable-plugins: no dlopen-based LTO plugin machinery in a
+        #   static binary.
+        # --without-zstd: bfd only uses zstd for compressed debug sections,
+        #   which cairo-native-emitted objects never carry — avoids a
+        #   libzstd static dep.
+        ./configure \
+            --target=x86_64-unknown-linux-gnu \
+            --disable-nls \
+            --disable-werror \
+            --disable-plugins \
+            --disable-gprofng \
+            --disable-gdb --disable-gdbserver --disable-sim \
+            --disable-shared --enable-static \
+            --without-zstd \
+            --with-system-zlib
+        # Two-phase make — see the header comment: configure-host first with
+        # clean LDFLAGS (gcc chokes on the libtool-only -all-static in
+        # configure link tests), then the real build with -all-static so the
+        # libtool link of ld is fully static.
+        make -j"$(nproc)" configure-host MAKEINFO=true
+        make -j"$(nproc)" all-ld LDFLAGS="-all-static" MAKEINFO=true
+        strip ld/ld-new
+        cp ld/ld-new /build/ld-static
+
+        chown "${HOST_UID}:${HOST_GID}" /build/ld-static
+        # Intermediate build artefacts stay root-owned inside /build. The host
+        # owns $WORK_DIR itself, so the trap'"'"'s rm -rf can still unlink
+        # them; but make the leaf directories writable by the host user so any
+        # follow-up inspection (find, ls) does not hit permission errors.
+        chown -R "${HOST_UID}:${HOST_GID}" /build
+    '
+
+popd >/dev/null
+
+# ==============================================================================
+# Verify + install to OUTPUT_DIR
+# ==============================================================================
+
+log_section "Verify + Install"
+
+[[ -x "$WORK_DIR/ld-static" ]] \
+    || die "container build did not produce $WORK_DIR/ld-static"
+
+log_info "Verifying static linkage"
+LDD_OUT="$(ldd "$WORK_DIR/ld-static" 2>&1 || true)"
+if echo "$LDD_OUT" | grep -qE "not a dynamic executable|statically linked"; then
+    log_ok "ld is statically linked"
+else
+    log_warn "ld may not be fully static:"
+    echo "$LDD_OUT" | sed 's/^/    /'
+    die "ld must be statically linked to run in the initrd"
+fi
+
+log_info "Verifying functionality"
+"$WORK_DIR/ld-static" --version | head -1 | grep -q "GNU ld" \
+    || die "built ld does not identify as GNU ld"
+"$WORK_DIR/ld-static" --help 2>/dev/null | grep -q "elf_x86_64" \
+    || die "built ld does not support the elf_x86_64 emulation"
+log_ok "ld is functional ($("$WORK_DIR/ld-static" --version | head -1))"
+
+log_info "Normalising timestamps for reproducibility"
+touch -d "@${SOURCE_DATE_EPOCH}" "$WORK_DIR/ld-static"
+
+log_info "Installing into $OUTPUT_DIR"
+install -m 0755 "$WORK_DIR/ld-static" "$OUTPUT_DIR/ld"
+touch -d "@${SOURCE_DATE_EPOCH}" "$OUTPUT_DIR/ld"
+
+echo ""
+echo "=========================================="
+echo "[OK] Built static binary"
+echo "=========================================="
+echo "  $OUTPUT_DIR/ld"
+echo "=========================================="

--- a/misc/AMDSEV/scripts/build-initrd.sh
+++ b/misc/AMDSEV/scripts/build-initrd.sh
@@ -28,6 +28,14 @@
 # paths. Decoupling the source build from this script means an unsealed-only
 # initrd run never needs Docker on the host.
 #
+# Native-compilation support similarly consumes a pre-built static `ld`
+# (LD_BINARY, built by `misc/AMDSEV/scripts/build-binutils-ld.sh`, auto-run
+# by build.sh when `--ld` isn't passed): the bundled cairo-native katana
+# shells out to `ld` at runtime to link each AOT-compiled contract class
+# into a dlopen-able .so. The `-lc` link inputs the guest-side ld needs
+# (libc_nonshared.a + a generated /lib64/libc.so linker script) come from
+# the pinned libc6-dev package (LIBC6_DEV_PKG_VERSION/SHA256).
+#
 # Usage:
 #   ./build-initrd.sh KATANA_BINARY OUTPUT_INITRD [KERNEL_VERSION]
 #
@@ -101,6 +109,16 @@ usage() {
     echo "                                   release asset). Bundled at /bin so the guest"
     echo "                                   supports --vrf. Both-or-neither with"
     echo "                                   PAYMASTER_BINARY."
+    echo "  LD_BINARY                        Path to a pre-built static GNU ld (build via"
+    echo "                                   misc/AMDSEV/scripts/build-binutils-ld.sh)."
+    echo "                                   Installed at /bin/ld; required for katana's"
+    echo "                                   --enable-native-compilation to work in the"
+    echo "                                   guest (cairo-native links each AOT-compiled"
+    echo "                                   class with \`ld ... -lc\` at runtime). When"
+    echo "                                   set, LIBC6_DEV_PKG_VERSION/SHA256 must also"
+    echo "                                   be set (libc_nonshared.a + a generated"
+    echo "                                   /lib64/libc.so give -lc something to"
+    echo "                                   resolve against)."
     echo "  KATANA_UNSEALED_BUILD            Set to 1 to opt OUT of the sealed build."
     echo "                                   Produces an unsealed-only initrd that mounts"
     echo "                                   /dev/sda as plain ext4: no cryptsetup, no"
@@ -203,6 +221,9 @@ echo "  snp-derivekey binary:  ${SNP_DERIVEKEY_BINARY:-<not set>}"
 echo "Sidecar binaries (optional):"
 echo "  paymaster-service:     ${PAYMASTER_BINARY:-<not set>}"
 echo "  vrf-server:            ${VRF_BINARY:-<not set>}"
+echo "Native-compilation support (optional):"
+echo "  ld binary:             ${LD_BINARY:-<not set>}"
+echo "  libc6-dev:             ${LIBC6_DEV_PKG_VERSION:-<not set>}"
 
 if [[ -z "${SOURCE_DATE_EPOCH:-}" ]]; then
     die "SOURCE_DATE_EPOCH must be set for reproducible builds"
@@ -308,6 +329,33 @@ else
     log_warn "PAYMASTER_BINARY/VRF_BINARY not set — image will NOT support --paymaster/--vrf in the guest"
 fi
 
+# Static GNU ld for in-guest cairo-native AOT linking, prebuilt by
+# build-binutils-ld.sh (build.sh --ld / auto-build). Optional: when unset the
+# image builds WITHOUT a linker and katana's --enable-native-compilation flag
+# fails in the guest (cairo-native cannot link AOT-compiled classes). Release
+# builds always supply it (build.sh auto-builds). When set, the pinned
+# libc6-dev package is also required — it provides the -lc link inputs (see
+# the "cairo-native link inputs" install step below).
+LD_BINARY="${LD_BINARY:-}"
+if [[ -n "$LD_BINARY" ]]; then
+    LD_BINARY="$(to_abs_path "$LD_BINARY")"
+    [[ -x "$LD_BINARY" ]] \
+        || die "LD_BINARY=$LD_BINARY does not exist or is not executable"
+    : "${LIBC6_DEV_PKG_VERSION:?LD_BINARY is set but LIBC6_DEV_PKG_VERSION is not (source build-config)}"
+    : "${LIBC6_DEV_PKG_SHA256:?LD_BINARY is set but LIBC6_DEV_PKG_SHA256 is not (source build-config)}"
+    # libc6-dev must move in lockstep with the libc6 runtime pin: the
+    # generated /lib64/libc.so points -lc at the runtime libc.so.6, and a
+    # version skew between libc_nonshared.a and libc.so.6 is a silent ABI
+    # hazard. GLIBC_RUNTIME_PACKAGES is a space-separated name=version list,
+    # so a plain substring match on the exact entry is sufficient.
+    case " ${GLIBC_RUNTIME_PACKAGES:-} " in
+        *" libc6=${LIBC6_DEV_PKG_VERSION} "*) ;;
+        *) die "LIBC6_DEV_PKG_VERSION=${LIBC6_DEV_PKG_VERSION} does not match the libc6 entry in GLIBC_RUNTIME_PACKAGES (${GLIBC_RUNTIME_PACKAGES:-<unset>}) — keep both pins in lockstep" ;;
+    esac
+else
+    log_warn "LD_BINARY not set — image will NOT support --enable-native-compilation in the guest"
+fi
+
 log_ok "Preflight validation complete (sealed-storage build: $([ "$SEALED_STORAGE_BUILD" -eq 1 ] && echo yes || echo no))"
 
 elf_interpreter() {
@@ -324,9 +372,11 @@ fi
 
 # All bundled dynamic ELF executables must share one interpreter — the dynamic
 # runtime installer walks a single pinned-glibc package pool. Static binaries
-# (no interpreter) are fine alongside dynamic ones.
+# (no interpreter) are fine alongside dynamic ones. The canonical ld (musl
+# static) contributes nothing here; an operator-supplied dynamic ld is held
+# to the same single-interpreter rule as everything else.
 RUNTIME_INTERPRETER="$KATANA_INTERPRETER"
-for extra_bin in "$PAYMASTER_BINARY" "$VRF_BINARY"; do
+for extra_bin in "$PAYMASTER_BINARY" "$VRF_BINARY" "$LD_BINARY"; do
     [[ -n "$extra_bin" ]] || continue
     extra_interp="$(elf_interpreter "$extra_bin" || true)"
     [[ -n "$extra_interp" ]] || continue
@@ -593,6 +643,25 @@ if [[ -n "$VRF_BINARY" ]]; then
     cp "$VRF_BINARY" bin/vrf-server
     chmod +x bin/vrf-server
     log_ok "vrf-server installed"
+fi
+
+# ------------------------------------------------------------------------------
+# Install static GNU ld (cairo-native runtime linker, optional)
+# ------------------------------------------------------------------------------
+# cairo-native's AOT path shells out to `ld` (PATH lookup; the init exports
+# PATH=/bin) to link each compiled class into a dlopen-able .so:
+#   ld --hash-style=gnu -shared -L/lib/../lib64 -L/usr/lib/../lib64 -o <so> -lc <o>
+# (argv per cairo-native src/ffi.rs — re-verify when bumping cairo-native.)
+# The -lc input is provided by the generated /lib64/libc.so linker script
+# (see the "cairo-native link inputs" section below).
+if [[ -n "$LD_BINARY" ]]; then
+    log_info "Installing ld from $LD_BINARY"
+    cp "$LD_BINARY" bin/ld
+    chmod +x bin/ld
+    if ! bin/ld --version >/dev/null 2>&1; then
+        die "Installed ld binary is not functional"
+    fi
+    log_ok "ld installed"
 fi
 
 # ------------------------------------------------------------------------------
@@ -925,6 +994,10 @@ log_ok "Katana installed"
 DYNAMIC_ELF_ROOTS=(bin/katana)
 [[ -n "$PAYMASTER_BINARY" ]] && DYNAMIC_ELF_ROOTS+=(bin/paymaster-service)
 [[ -n "$VRF_BINARY" ]] && DYNAMIC_ELF_ROOTS+=(bin/vrf-server)
+# bin/ld is normally static (musl) and walker-neutral — elf_needed yields
+# nothing for it. Listing it means an operator-supplied *dynamic* ld fails
+# loudly here (missing lib in the pinned pool) instead of at runtime.
+[[ -n "$LD_BINARY" ]] && DYNAMIC_ELF_ROOTS+=(bin/ld)
 
 if [[ -n "$RUNTIME_INTERPRETER" ]]; then
     install_dynamic_runtime "$RUNTIME_INTERPRETER"
@@ -948,6 +1021,55 @@ if [[ -n "$RUNTIME_INTERPRETER" ]]; then
             log_warn "Could not parse glibc version from $libc_so"
         fi
     fi
+fi
+
+# ------------------------------------------------------------------------------
+# cairo-native link inputs: libc_nonshared.a + generated /lib64/libc.so
+# ------------------------------------------------------------------------------
+# The bundled ld resolves `-lc` by searching its -L dirs (cairo-native passes
+# -L/lib/../lib64, which resolves to /lib64 at open() time) for libc.so.
+# Ubuntu's real /usr/lib/x86_64-linux-gnu/libc.so is a linker script whose
+# absolute paths (/lib/x86_64-linux-gnu/...) assume a usr-merged filesystem
+# and do not exist in this initrd, so we GENERATE an equivalent script
+# pointing at the initrd's actual paths. libc_nonshared.a comes from the
+# pinned libc6-dev deb (preflight enforces version lockstep with the libc6
+# runtime pin). Both files are read-only inputs to ld — 0644 from the
+# SECTION 4 mode sweep is correct.
+if [[ -n "$LD_BINARY" ]]; then
+    [[ -n "$RUNTIME_INTERPRETER" ]] \
+        || die "LD_BINARY is set but katana is statically linked — no libc.so.6 in the image for -lc to resolve"
+    [[ -n "${libc_so:-}" ]] \
+        || die "LD_BINARY is set but libc.so.6 was not installed by the dynamic runtime walk"
+    LIBC_SO_REL="${libc_so#"$INITRD_DIR"/}"
+
+    log_info "Downloading libc6-dev=${LIBC6_DEV_PKG_VERSION}"
+    LIBC_DEV_WORK="$WORK_DIR/libc6-dev"
+    mkdir -p "$LIBC_DEV_WORK"
+    ( cd "$LIBC_DEV_WORK" && apt-get download "libc6-dev=${LIBC6_DEV_PKG_VERSION}" )
+    LIBC_DEV_DEB="$(find "$LIBC_DEV_WORK" -maxdepth 1 -name 'libc6-dev_*.deb' | head -1)"
+    [[ -f "$LIBC_DEV_DEB" ]] || die "libc6-dev .deb not downloaded"
+    LIBC_DEV_ACTUAL="$(sha256sum "$LIBC_DEV_DEB" | awk '{print $1}')"
+    [[ "$LIBC_DEV_ACTUAL" == "$LIBC6_DEV_PKG_SHA256" ]] || \
+        die "libc6-dev checksum mismatch (expected $LIBC6_DEV_PKG_SHA256, got $LIBC_DEV_ACTUAL)"
+    log_ok "libc6-dev checksum verified"
+    dpkg-deb -x "$LIBC_DEV_DEB" "$LIBC_DEV_WORK/extracted"
+
+    NONSHARED_SRC="$LIBC_DEV_WORK/extracted/usr/lib/x86_64-linux-gnu/libc_nonshared.a"
+    [[ -f "$NONSHARED_SRC" ]] || die "libc_nonshared.a not found in libc6-dev package"
+    NONSHARED_REL="usr/lib/x86_64-linux-gnu/libc_nonshared.a"
+    mkdir -p "$(dirname "$NONSHARED_REL")"
+    cp "$NONSHARED_SRC" "$NONSHARED_REL"
+
+    # Same GROUP shape as Ubuntu's stock script: the shared libc, the
+    # nonshared archive (stack-protector locals etc.), and the dynamic
+    # loader as AS_NEEDED. Deterministic — a pure function of pinned inputs.
+    cat > lib64/libc.so <<LIBC_SO_EOF
+/* GNU ld script generated by build-initrd.sh — paths match this initrd's
+   layout. Lets cairo-native's runtime \`ld ... -lc\` resolve libc. */
+OUTPUT_FORMAT(elf64-x86-64)
+GROUP ( /${LIBC_SO_REL} /${NONSHARED_REL} AS_NEEDED ( ${RUNTIME_INTERPRETER} ) )
+LIBC_SO_EOF
+    log_ok "cairo-native link inputs installed (/lib64/libc.so -> /${LIBC_SO_REL})"
 fi
 
 # ------------------------------------------------------------------------------
@@ -1782,6 +1904,7 @@ find . -type f -exec chmod 0644 {} +
 chmod 0755 bin/busybox bin/katana init
 [[ -n "$PAYMASTER_BINARY" ]] && chmod 0755 bin/paymaster-service
 [[ -n "$VRF_BINARY" ]] && chmod 0755 bin/vrf-server
+[[ -n "$LD_BINARY" ]] && chmod 0755 bin/ld
 if [[ "$SEALED_STORAGE_BUILD" -eq 1 ]]; then
     chmod 0755 bin/cryptsetup bin/mkfs.ext2
     [[ -n "$SNP_DERIVEKEY_BINARY" ]] && chmod 0755 bin/snp-derivekey

--- a/misc/AMDSEV/scripts/test-initrd.sh
+++ b/misc/AMDSEV/scripts/test-initrd.sh
@@ -34,6 +34,18 @@
 #   TEST_DISK_SIZE              Ephemeral test disk size (default: 1G)
 #   CHAIN_CONFIG_GENESIS_SIZE   Synthetic genesis size for chain-disk regression
 #                               test (default: 18M, matching production)
+#   QEMU_MEMORY                 Guest RAM (default: 4G). The initramfs unpacks
+#                               into guest RAM; the cairo-native katana binary
+#                               alone is several hundred MB, so this mirrors
+#                               start-vm.sh's default rather than the old 512M.
+#   KATANA_TEST_NATIVE          Set to 1 to exercise cairo-native in the guest:
+#                               boots katana with --enable-native-compilation,
+#                               forces a Sierra class through the executor via
+#                               starknet_call, and fails on any native-compile
+#                               error in the serial log. Requires an initrd
+#                               with /bin/ld and a katana built with the
+#                               'native' feature (an unknown flag kills a
+#                               non-native katana — hence opt-in).
 # ==============================================================================
 
 set -euo pipefail
@@ -57,6 +69,15 @@ CHAIN_CONFIG_GENESIS_SIZE="${CHAIN_CONFIG_GENESIS_SIZE:-18M}"
 # after QEMU starts. virtio-blk + ext2 mount takes <1s in practice; this
 # bound catches a regression long before BOOT_TIMEOUT would.
 CHAIN_MOUNT_TIMEOUT=30
+# Guest RAM. The initramfs (rootfs) lives entirely in guest RAM and the
+# cairo-native katana binary is several hundred MB unstripped, so 512M no
+# longer boots; 4G mirrors start-vm.sh's default and leaves headroom for the
+# AOT-compile working set.
+QEMU_MEMORY="${QEMU_MEMORY:-4G}"
+# Opt-in cairo-native exercise (see header). Bounded wait for the async
+# compile pool after the forcing call.
+KATANA_TEST_NATIVE="${KATANA_TEST_NATIVE:-0}"
+NATIVE_COMPILE_WAIT=30
 
 TEMP_DIR="$(mktemp -d /tmp/katana-amdsev-initrd-test.XXXXXX)"
 SERIAL_LOG="${TEMP_DIR}/serial.log"
@@ -163,6 +184,57 @@ print_serial_output() {
         echo "=== Serial output ===" >&2
         tail -n 200 "$SERIAL_LOG" >&2 || true
     fi
+}
+
+# Exercise the in-guest cairo-native AOT path. A starknet_call against the
+# predeployed OpenZeppelin UDC — a Sierra (Cairo 1) class at a FIXED genesis
+# address — pulls the class through the executor's ClassCache; with
+# --enable-native-compilation every Sierra insert spawns an async cairo-native
+# compile, which in the guest runs the bundled /bin/ld against the generated
+# /lib64/libc.so. The default fee tokens are Legacy (Cairo 0) classes and
+# would NOT trigger a compile, hence the UDC.
+#
+# The call's calldata is shaped validly for deploy_contract
+# (class_hash=0x1, salt, not_from_zero, empty calldata) but targets an
+# undeclared class, so katana answers with a ContractError — that's fine:
+# the ClassCache insert (and thus the native compile) happens when the UDC
+# class is LOADED, before the entrypoint reverts. We assert the RPC layer
+# actually executed something (any JSON-RPC response) and then fail on the
+# executor's compile-failure log line. Compilation is async, so
+# absence-of-error after the bounded wait is a necessary-but-not-sufficient
+# signal — good enough to catch a missing/broken ld, missing libc.so, or a
+# dlopen failure, which all log loudly.
+verify_native_compilation() {
+    # sn_keccak("deploy_contract") — cross-checked against
+    # entry_points_by_type.EXTERNAL in the bundled UDC contract_class.json.
+    local udc_address="0x02ceed65a4bd731034c01113685c831b01c15d7d432f71afb1cf1634b53a2125"
+    local deploy_contract_selector="0x2730079d734ee55315f4f141eaed376bddd8c2133523d223a344c5604e0f7f8"
+
+    log "Native mode: forcing a Sierra class through the executor (starknet_call on UDC)"
+    local response
+    response="$(curl -s --max-time 10 -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"starknet_call","params":{"request":{"contract_address":"'"$udc_address"'","entry_point_selector":"'"$deploy_contract_selector"'","calldata":["0x1","0x0","0x0","0x0"]},"block_id":"latest"},"id":1}' \
+        "http://127.0.0.1:${HOST_RPC_PORT}" || true)"
+
+    if ! echo "$response" | grep -q '"jsonrpc"'; then
+        print_serial_output
+        die "Native mode: starknet_call produced no JSON-RPC response: '${response:-<none>}'"
+    fi
+    log "Native mode: UDC call answered (compile trigger fired): $response"
+
+    log "Native mode: waiting ${NATIVE_COMPILE_WAIT}s for the async compile pool"
+    local waited
+    for ((waited = 1; waited <= NATIVE_COMPILE_WAIT; waited++)); do
+        assert_qemu_running "Guest died during native compilation"
+        # Fail fast on the executor's error line (cache.rs, tracing::error).
+        if grep -aq "Failed to compile native class" "$SERIAL_LOG"; then
+            print_serial_output
+            die "cairo-native runtime compilation failed in guest (see serial log)"
+        fi
+        sleep 1
+    done
+    log "Native mode: no compile errors in serial log after ${NATIVE_COMPILE_WAIT}s"
 }
 
 assert_qemu_running() {
@@ -406,6 +478,14 @@ run_boot_smoke_test() {
         "--tee" "sev-snp" \
         > "$KATANA_ARGS_FILE"
 
+    # Opt-in: exercise the in-guest cairo-native path (needs a katana built
+    # with the 'native' feature — the flag is unknown to a portable build
+    # and would kill it at startup).
+    if [ "$KATANA_TEST_NATIVE" -eq 1 ]; then
+        printf '%s\n' "--enable-native-compilation" >> "$KATANA_ARGS_FILE"
+        log "Native mode: added --enable-native-compilation to guest args"
+    fi
+
     KVM_OPTS=()
     if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
         KVM_OPTS=(-enable-kvm -cpu host)
@@ -417,7 +497,7 @@ run_boot_smoke_test() {
 
     "$qemu_bin" \
         "${KVM_OPTS[@]}" \
-        -m 512M \
+        -m "$QEMU_MEMORY" \
         -smp 1 \
         -nographic \
         -serial "file:$SERIAL_LOG" \
@@ -476,6 +556,10 @@ run_boot_smoke_test() {
     fi
 
     log "RPC check passed: $response"
+
+    if [ "$KATANA_TEST_NATIVE" -eq 1 ]; then
+        verify_native_compilation
+    fi
 
     # Graceful stop: the guest must acknowledge, run its teardown (visible
     # in the serial log), and power off — which makes QEMU exit. The ack

--- a/misc/AMDSEV/scripts/test-install.sh
+++ b/misc/AMDSEV/scripts/test-install.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# ==============================================================================
+# TEST-INSTALL.SH - Unit tests for install.sh's helper functions.
+# ==============================================================================
+#
+# install.sh is the operator-facing entry point for standing up a TEE VM host
+# from a published release. Its download/verify/wizard flow composes small
+# helpers (validators, tag encoding, checksum gates, config round-trip,
+# launcher feature detection); this exercises them directly — fast, no QEMU,
+# no network — the same pattern as test-parse-metrics-port.sh. install.sh
+# exposes them via the KATANA_INSTALL_LIB=1 source guard.
+#
+# An optional END-TO-END DRY RUN against a real published release (network,
+# ~hundreds of MB) is gated behind KATANA_INSTALL_TEST_NETWORK=1 — too heavy
+# for every CI run, but the full download+verify path in one command.
+#
+# Run from anywhere; exits non-zero on any failed assertion.
+# ==============================================================================
+
+# SC2034: many globals here are consumed by functions sourced out of
+# install.sh (write_config/write_run_sh), which shellcheck can't see through
+# the KATANA_INSTALL_LIB source indirection.
+# shellcheck disable=SC2034
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="${SCRIPT_DIR}/../install.sh"
+START_VM="${SCRIPT_DIR}/../start-vm.sh"
+[[ -f "$INSTALL_SH" ]] || { echo "install.sh not found at $INSTALL_SH" >&2; exit 1; }
+[[ -f "$START_VM" ]] || { echo "start-vm.sh not found at $START_VM" >&2; exit 1; }
+
+WORK="$(mktemp -d /tmp/katana-test-install.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Source install.sh as a library (defines helpers, skips main). It sets
+# set -e; undo that so failed assertions report instead of aborting.
+# shellcheck disable=SC1090
+KATANA_INSTALL_LIB=1 . "$INSTALL_SH"
+set +e +o pipefail
+
+FAILS=0
+check() {
+    # $1 description, $2 expected, $3 actual
+    if [[ "$3" == "$2" ]]; then
+        echo "ok   - $1"
+    else
+        echo "FAIL - $1"
+        echo "         want: [$2]"
+        echo "         got:  [$3]"
+        FAILS=$((FAILS + 1))
+    fi
+}
+check_true() {
+    # $1 description, then the command to run
+    local desc="$1"; shift
+    if "$@"; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc"
+        FAILS=$((FAILS + 1))
+    fi
+}
+check_false() {
+    local desc="$1"; shift
+    if "$@"; then
+        echo "FAIL - $desc"
+        FAILS=$((FAILS + 1))
+    else
+        echo "ok   - $desc"
+    fi
+}
+
+# ---- Validators --------------------------------------------------------------
+
+check_true  "valid_port accepts 15051"        valid_port 15051
+check_false "valid_port rejects 0"            valid_port 0
+check_false "valid_port rejects 65536"        valid_port 65536
+check_false "valid_port rejects non-numeric"  valid_port abc
+
+check_true  "valid_vcpus accepts 4"           valid_vcpus 4
+check_false "valid_vcpus rejects 0"           valid_vcpus 0
+check_false "valid_vcpus rejects 2.5"         valid_vcpus 2.5
+
+check_true  "valid_memory accepts 4G"         valid_memory 4G
+check_true  "valid_memory accepts 2048M"      valid_memory 2048M
+check_false "valid_memory rejects 4"          valid_memory 4
+check_false "valid_memory rejects 4g"         valid_memory 4g
+check_false "valid_memory rejects 4GB"        valid_memory 4GB
+
+check_true  "valid_tag accepts tee-vm-v0.1.0+katana-v1.8.0" valid_tag "tee-vm-v0.1.0+katana-v1.8.0"
+check_false "valid_tag rejects a katana release tag"        valid_tag "v1.8.0"
+
+check_true  "valid_uuid accepts canonical lowercase" valid_uuid "00000000-0000-0000-0000-000000000001"
+check_false "valid_uuid rejects uppercase"           valid_uuid "00000000-0000-0000-0000-00000000000A"
+
+# ---- Tag URL encoding ----------------------------------------------------------
+
+check "encode_tag percent-encodes '+'" \
+    "tee-vm-v0.1.0%2Bkatana-v1.8.0-rc.5" \
+    "$(encode_tag "tee-vm-v0.1.0+katana-v1.8.0-rc.5")"
+check "encode_tag is a no-op without '+'" \
+    "tee-vm-v0.1.0" "$(encode_tag "tee-vm-v0.1.0")"
+
+# ---- parse_metrics_port stays in sync with start-vm.sh ------------------------
+# install.sh carries a copy (it needs the function before a release's
+# start-vm.sh has been fetched). Extract the original and compare behavior.
+
+ORIG_FN="$WORK/orig-parse.sh"
+awk '/^parse_metrics_port\(\)/{f=1} f{print} f && /^}$/{exit}' "$START_VM" \
+    | sed 's/^parse_metrics_port()/orig_parse_metrics_port()/' > "$ORIG_FN"
+# shellcheck disable=SC1090
+. "$ORIG_FN"
+if ! declare -f orig_parse_metrics_port >/dev/null; then
+    echo "FAIL - could not extract parse_metrics_port from start-vm.sh" >&2
+    FAILS=$((FAILS + 1))
+else
+    for csv in \
+        "--http.addr,0.0.0.0,--http.port,5050,--tee,sev-snp,--metrics,--metrics.addr,0.0.0.0,--metrics.port,9100" \
+        "--http.port,5050,--tee,sev-snp" \
+        "--tee,sev-snp,--metrics,--metrics.port=9200" \
+        "--metrics.port" \
+        "--http.cors-origins,*,--metrics.port,9100"; do
+        check "parse_metrics_port copy matches start-vm.sh for: $csv" \
+            "$(orig_parse_metrics_port "$csv")" \
+            "$(parse_metrics_port "$csv")"
+    done
+fi
+
+# ---- Launcher feature detection -------------------------------------------------
+# The same greps run_wizard uses to decide whether the fetched launcher
+# supports configurable resources. The in-repo start-vm.sh must support both.
+
+check_true "start-vm.sh advertises KATANA_VCPUS"  grep -q "KATANA_VCPUS" "$START_VM"
+check_true "start-vm.sh advertises KATANA_MEMORY" grep -q "KATANA_MEMORY" "$START_VM"
+
+# ---- Source-tarball subtree extraction ------------------------------------------
+# GitHub source tarballs nest everything under <repo>-<mangled tag>/, and the
+# tag's '+' mangles unpredictably — extraction must strip by depth, not name.
+
+FAKE_REPO="$WORK/katana-tee-vm-v0.1.0-katana-v1.8.0"
+mkdir -p "$FAKE_REPO/misc/AMDSEV/scripts"
+echo "#!/bin/bash" > "$FAKE_REPO/misc/AMDSEV/start-vm.sh"
+echo "#!/bin/bash" > "$FAKE_REPO/misc/AMDSEV/scripts/sealed-cmdline.sh"
+echo "other" > "$FAKE_REPO/README.md"
+tar czf "$WORK/src.tar.gz" -C "$WORK" "$(basename "$FAKE_REPO")"
+extract_amdsev_subtree "$WORK/src.tar.gz" "$WORK/extracted" 2>/dev/null
+check_true  "extract_amdsev_subtree extracts start-vm.sh" test -f "$WORK/extracted/start-vm.sh"
+check_true  "extract_amdsev_subtree extracts scripts/"    test -f "$WORK/extracted/scripts/sealed-cmdline.sh"
+check_false "extract_amdsev_subtree skips non-AMDSEV files" test -f "$WORK/extracted/README.md"
+
+# ---- boot_checksums_ok -----------------------------------------------------------
+
+if command -v sha256sum >/dev/null 2>&1; then
+    BOOT="$WORK/boot"
+    mkdir -p "$BOOT"
+    printf 'ovmf' > "$BOOT/OVMF.fd"
+    printf 'kern' > "$BOOT/vmlinuz"
+    printf 'init' > "$BOOT/initrd.img"
+    {
+        echo "OVMF_SHA256=$(sha256sum "$BOOT/OVMF.fd" | awk '{print $1}')"
+        echo "KERNEL_SHA256=$(sha256sum "$BOOT/vmlinuz" | awk '{print $1}')"
+        echo "INITRD_SHA256=$(sha256sum "$BOOT/initrd.img" | awk '{print $1}')"
+    } > "$BOOT/build-info.txt"
+    check_true "boot_checksums_ok passes on matching artifacts" boot_checksums_ok "$BOOT"
+    printf 'tampered' >> "$BOOT/initrd.img"
+    check_false "boot_checksums_ok fails on a tampered artifact" boot_checksums_ok "$BOOT"
+    rm -rf "$BOOT"
+else
+    echo "skip - boot_checksums_ok tests (no sha256sum on this host)"
+fi
+
+# ---- config.env round-trip --------------------------------------------------------
+
+TEE_HOME="$WORK/tee-home"
+TAG="tee-vm-v0.9.9+katana-v9.9.9"
+VCPUS=4
+MEMORY="4G"
+DATA_DISK="$TEE_HOME/data disk.img"   # space: exercises the %q quoting
+DISK_SIZE_MB=2048
+RPC_PORT=15051
+SEALED=1
+LUKS_UUID="00000000-0000-0000-0000-000000000001"
+KATANA_ARGS_CSV="--http.cors-origins,*,--metrics.port,9100"
+QEMU_PREFIX="$TEE_HOME/qemu"
+LAUNCHER_HAS_VCPUS=1
+LAUNCHER_HAS_MEMORY=1
+write_config
+write_run_sh
+
+KATANA_TEE_TAG="" HOST_RPC_PORT="" DATA_DISK="" KATANA_ARGS_CSV=""
+check_true "load_config finds the written config" load_config
+check "config round-trips the tag"           "$TAG"  "$KATANA_TEE_TAG"
+check "config round-trips the RPC port"      "15051" "$HOST_RPC_PORT"
+check "config round-trips a path with space" "$TEE_HOME/data disk.img" "$DATA_DISK"
+check "config round-trips a glob arg intact" "--http.cors-origins,*,--metrics.port,9100" "$KATANA_ARGS_CSV"
+
+check_true "run.sh is generated executable" test -x "$TEE_HOME/run.sh"
+check_true "run.sh parses (bash -n)" bash -n "$TEE_HOME/run.sh"
+
+# ---- print-systemd -----------------------------------------------------------------
+
+UNIT="$(print_systemd_unit)"
+check_true "systemd unit points ExecStart at run.sh" \
+    grep -q "ExecStart=$TEE_HOME/run.sh" <<<"$UNIT"
+check_true "systemd unit restarts on failure" \
+    grep -q "Restart=on-failure" <<<"$UNIT"
+
+# ---- Optional: end-to-end dry run against a real release (network) -----------------
+
+if [[ "${KATANA_INSTALL_TEST_NETWORK:-0}" == "1" ]]; then
+    echo ""
+    echo "--- network dry run (KATANA_INSTALL_TEST_NETWORK=1) ---"
+    E2E_HOME="$WORK/e2e-home"
+    if KATANA_INSTALL_SKIP_SNP_CHECK=1 bash "$INSTALL_SH" --yes --dry-run --home "$E2E_HOME"; then
+        check_true "dry run writes config.env" test -f "$E2E_HOME/config.env"
+        check_true "dry run writes run.sh"     test -x "$E2E_HOME/run.sh"
+        check_true "dry run downloads boot artifacts" \
+            test -f "$E2E_HOME/current/boot/build-info.txt"
+        check_true "dry run fetches the matching launcher" \
+            test -f "$E2E_HOME/current/src/start-vm.sh"
+    else
+        echo "FAIL - network dry run exited non-zero"
+        FAILS=$((FAILS + 1))
+    fi
+fi
+
+echo ""
+if (( FAILS == 0 )); then
+    echo "test-install: PASS"
+    exit 0
+else
+    echo "test-install: FAIL ($FAILS assertion(s))"
+    exit 1
+fi

--- a/misc/AMDSEV/start-vm.sh
+++ b/misc/AMDSEV/start-vm.sh
@@ -30,7 +30,9 @@
 #
 # SEV-SNP guest configuration:
 #   GUEST_POLICY      - 0x30000 (SMT allowed, debug disabled)
-#   VCPU_COUNT        - 1
+#   VCPU_COUNT        - --vcpus (default 1). Each vCPU's VMSA is measured, so
+#                       a different count produces a different launch
+#                       measurement. Verifiers must pin the expected count.
 #   GUEST_FEATURES    - 0x1 (SNP active)
 #
 # CPU and platform:
@@ -44,7 +46,8 @@
 # into the launch digest. The guest treats them as untrusted operator input
 # and strips flags it owns (--db-*, --data-dir, --chain) before use.
 #
-# To compute expected measurement, use snp-digest from snp-tools:
+# To compute expected measurement, use snp-digest from snp-tools (match
+# --vcpus to the count the VM boots with):
 #   cargo build -p snp-tools
 #   ./target/debug/snp-digest --ovmf=OVMF.fd --kernel=vmlinuz --initrd=initrd.img \
 #       --append="console=ttyS0" --vcpus=1 --cpu=epyc-v4 --vmm=qemu --guest-features=0x1
@@ -57,6 +60,7 @@ usage() {
     echo "Usage: $0 --ovmf PATH --kernel PATH --initrd PATH"
     echo "          [--katana-args CSV] [--chain-dir DIR] [--no-start]"
     echo "          [--data-disk PATH] [--luks-uuid UUID] [--sealed] [--unsealed]"
+    echo "          [--vcpus N] [--memory SIZE]"
     echo ""
     echo "Starts a SEV-SNP VM and launches Katana asynchronously via control channel."
     echo "Unsealed storage (plain ext4 on /dev/sda) is the DEFAULT. Opt into sealed"
@@ -111,10 +115,17 @@ usage() {
     echo "  --unsealed            Plain ext4 on /dev/sda (the default). The cmdline does"
     echo "                        NOT carry KATANA_EXPECTED_LUKS_UUID. Accepted explicitly"
     echo "                        for clarity and backward compatibility."
-    echo "  (memory)              Guest RAM size. Env var: KATANA_MEMORY (default: 4G)."
+    echo "  --vcpus N             Guest vCPU count (default: 1). PART OF the launch"
+    echo "                        measurement — each vCPU's VMSA is measured, so a"
+    echo "                        different count produces a different measurement."
+    echo "                        Recompute the expected value with snp-digest --vcpus=N"
+    echo "                        (the exact command is printed at startup)."
+    echo "                        Env var: KATANA_VCPUS"
+    echo "  --memory SIZE         Guest RAM size, e.g. 4G or 2048M (default: 4G)."
     echo "                        The initramfs (incl. the cairo-native katana binary)"
     echo "                        unpacks into guest RAM, so several GB are required."
     echo "                        NOT part of the launch measurement — size freely."
+    echo "                        Env var: KATANA_MEMORY"
     echo "  -h, --help            Show this help"
 }
 
@@ -155,6 +166,19 @@ SEAL_MODE_EXPLICIT=""
 # ride fw_cfg (unmeasured) and port forwards are host networking.
 KATANA_RPC_PORT=5050
 HOST_RPC_PORT="${HOST_RPC_PORT:-15051}"
+
+# VM resources. vCPU count IS part of the launch measurement (each vCPU's VMSA
+# is measured) — overriding --vcpus changes the expected measurement; recompute
+# with snp-digest --vcpus=N (see header). Memory is NOT measured.
+#
+# MEMORY sizing: the initramfs is the guest rootfs and lives entirely in RAM,
+# and the bundled cairo-native katana binary alone is several hundred MB —
+# 512M no longer boots. 4G leaves headroom for katana's working set and the
+# cairo-native AOT compile pool. The memfd backend below uses prealloc=false,
+# so untouched guest pages cost the host nothing until first use (SNP pins
+# pages as they are touched, not up front).
+VCPU_COUNT="${KATANA_VCPUS:-1}"
+MEMORY="${KATANA_MEMORY:-4G}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -255,6 +279,24 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
 
+        --vcpus)
+            [[ $# -ge 2 ]] || {
+                echo "Error: --vcpus requires a value"
+                exit 1
+            }
+            VCPU_COUNT="$2"
+            shift 2
+            ;;
+
+        --memory)
+            [[ $# -ge 2 ]] || {
+                echo "Error: --memory requires a value"
+                exit 1
+            }
+            MEMORY="$2"
+            shift 2
+            ;;
+
         -h|--help)
             usage
             exit 0
@@ -290,6 +332,15 @@ if (( ${#missing[@]} > 0 )); then
     usage
     exit 1
 fi
+
+[[ "$VCPU_COUNT" =~ ^[0-9]+$ && "$VCPU_COUNT" -ge 1 ]] || {
+    echo "Error: invalid --vcpus (positive integer expected): '$VCPU_COUNT'"
+    exit 1
+}
+[[ "$MEMORY" =~ ^[0-9]+[MG]$ ]] || {
+    echo "Error: invalid --memory (e.g. 4G, 2048M): '$MEMORY'"
+    exit 1
+}
 
 # Unsealed storage is the default; sealed storage is opt-in via --sealed.
 # When sealed, resolve the LUKS UUID. Default: read from ~/.katana/luks-uuid,
@@ -334,23 +385,12 @@ fi
 # above and validated to be non-empty + readable before we get here.
 KERNEL_CMDLINE="console=ttyS0"
 
-# SEV-SNP guest configuration
+# SEV-SNP guest configuration. VCPU_COUNT and MEMORY are initialised with the
+# other defaults above — before flag parsing — so --vcpus / --memory can
+# override them. VCPU_COUNT feeds the measurement; MEMORY does not.
 GUEST_POLICY="0x30000"
-VCPU_COUNT=1
 CBITPOS=51
 REDUCED_PHYS_BITS=1
-
-# VM resources
-#
-# MEMORY sizing: the initramfs is the guest rootfs and lives entirely in RAM,
-# and the bundled cairo-native katana binary alone is several hundred MB —
-# 512M no longer boots. 4G leaves headroom for katana's working set and the
-# cairo-native AOT compile pool. The memfd backend below uses prealloc=false,
-# so untouched guest pages cost the host nothing until first use (SNP pins
-# pages as they are touched, not up front). `-m` is NOT part of the SEV-SNP
-# launch measurement — operators can size freely via KATANA_MEMORY without
-# changing the published measurement.
-MEMORY="${KATANA_MEMORY:-4G}"
 CPU_TYPE="EPYC-v4"
 
 # The RPC networking ports (KATANA_RPC_PORT / HOST_RPC_PORT) are initialised with

--- a/misc/AMDSEV/start-vm.sh
+++ b/misc/AMDSEV/start-vm.sh
@@ -111,6 +111,10 @@ usage() {
     echo "  --unsealed            Plain ext4 on /dev/sda (the default). The cmdline does"
     echo "                        NOT carry KATANA_EXPECTED_LUKS_UUID. Accepted explicitly"
     echo "                        for clarity and backward compatibility."
+    echo "  (memory)              Guest RAM size. Env var: KATANA_MEMORY (default: 4G)."
+    echo "                        The initramfs (incl. the cairo-native katana binary)"
+    echo "                        unpacks into guest RAM, so several GB are required."
+    echo "                        NOT part of the launch measurement — size freely."
     echo "  -h, --help            Show this help"
 }
 
@@ -337,7 +341,16 @@ CBITPOS=51
 REDUCED_PHYS_BITS=1
 
 # VM resources
-MEMORY="512M"
+#
+# MEMORY sizing: the initramfs is the guest rootfs and lives entirely in RAM,
+# and the bundled cairo-native katana binary alone is several hundred MB —
+# 512M no longer boots. 4G leaves headroom for katana's working set and the
+# cairo-native AOT compile pool. The memfd backend below uses prealloc=false,
+# so untouched guest pages cost the host nothing until first use (SNP pins
+# pages as they are touched, not up front). `-m` is NOT part of the SEV-SNP
+# launch measurement — operators can size freely via KATANA_MEMORY without
+# changing the published measurement.
+MEMORY="${KATANA_MEMORY:-4G}"
 CPU_TYPE="EPYC-v4"
 
 # The RPC networking ports (KATANA_RPC_PORT / HOST_RPC_PORT) are initialised with

--- a/scripts/build-gnu.sh
+++ b/scripts/build-gnu.sh
@@ -18,19 +18,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 STRICT_MODE=0
+NATIVE_MODE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --strict)
             STRICT_MODE=1
             shift
             ;;
+        --native)
+            NATIVE_MODE=1
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $0 [--strict]"
+            echo "Usage: $0 [--strict] [--native]"
             echo ""
             echo "Build a dynamically linked Katana binary using glibc."
             echo ""
             echo "OPTIONS:"
             echo "  --strict  Require vendored dependencies for reproducible builds"
+            echo "  --native  Add the 'native' cargo feature (cairo-native execution)."
+            echo "            Requires LLVM/MLIR 19 (MLIR_SYS_190_PREFIX etc.)."
             echo "  -h|--help Show this help message"
             exit 0
             ;;
@@ -133,13 +140,36 @@ echo "  OFFLINE_FLAG: ${OFFLINE_FLAG:-<none>}"
 # `tee-mock` enables `--tee mock`, letting operators and tests exercise the
 # TEE RPC surface without SNP hardware. Without it the binary fails with:
 #   "Mock TEE provider requires the 'tee-mock' feature"
+FEATURES="client,init-slot,jemalloc,tee-snp,tee-mock"
+
+# `--native` adds cairo-native execution (the `--enable-native-compilation`
+# runtime flag). This matches the FEATURE SET of the published
+# `_linux_amd64_native` release asset, not its bytes: this script keeps its
+# deterministic RUSTFLAGS (including the `-C link-arg=-s` strip), so the
+# output is functionally equivalent but hashes differently. Used by
+# amdsev-initrd-test.yml to exercise the TEE image's native configuration
+# from PR source.
+if [[ $NATIVE_MODE -eq 1 ]]; then
+    if [[ -z "${MLIR_SYS_190_PREFIX:-}" || -z "${LLVM_SYS_191_PREFIX:-}" ]]; then
+        echo "ERROR: --native requires LLVM/MLIR 19."
+        echo "       Install llvm-19 llvm-19-dev libmlir-19-dev mlir-19-tools libpolly-19-dev"
+        echo "       (see the 'Install LLVM ( Linux )' step in .github/workflows/release.yml"
+        echo "       for the apt.llvm.org recipe), then export:"
+        echo "           MLIR_SYS_190_PREFIX=/usr/lib/llvm-19"
+        echo "           LLVM_SYS_191_PREFIX=/usr/lib/llvm-19"
+        echo "           TABLEGEN_190_PREFIX=/usr/lib/llvm-19"
+        exit 1
+    fi
+    FEATURES="${FEATURES},native"
+fi
+
 cargo build \
     $OFFLINE_FLAG \
     --locked \
     --target x86_64-unknown-linux-gnu \
     --profile performance \
     --no-default-features \
-    --features "client,init-slot,jemalloc,tee-snp,tee-mock" \
+    --features "$FEATURES" \
     --bin katana
 
 BINARY_PATH="$PROJECT_ROOT/target/x86_64-unknown-linux-gnu/performance/katana"


### PR DESCRIPTION
## Why

The TEE VM image embeds the **portable** katana release asset, so enclave deployments cannot use cairo-native execution; enabling it needs the `_native` binary plus cairo-native's runtime link toolchain inside the busybox initrd (it shells out to `ld ... -lc` to link each AOT-compiled class into a dlopen-able `.so`).

## What

- Switch the embedded asset to `katana_*_linux_amd64_native.tar.gz` (its DT_NEEDED set is already covered by the existing glibc pins) and record `KATANA_ASSET_VARIANT=native` in build-info so `reproduce-release.sh` fetches the right asset, with a portable fallback for older releases.
- Bundle a static GNU `ld` built from pinned binutils 2.44 in the same digest-pinned Alpine container as cryptsetup (new `scripts/build-binutils-ld.sh`; two-phase make — `configure-host` with clean LDFLAGS, then `all-ld LDFLAGS=-all-static` — because gcc rejects the libtool-only flag in sub-configure link tests and plain `-static` gets swallowed by libtool), plus its `-lc` inputs: `libc_nonshared.a` from a new pinned `libc6-dev` deb and a generated `/lib64/libc.so` linker script pointing at the initrd's actual libc paths.
- Guest resources become `start-vm.sh --vcpus/--memory` flags (env: `KATANA_VCPUS`/`KATANA_MEMORY`); the memory default goes 512M → 4G since the initramfs (incl. the 332 MB unstripped native binary) lives in guest RAM. Memory is unmeasured; vCPU count feeds the measurement and the docs say to recompute with `snp-digest --vcpus=N`.
- CI (`amdsev-initrd-test`) now builds katana from PR source with the new `build-gnu.sh --native` flag, asserts the ld/libc.so/libc_nonshared.a bundling, and boots with `KATANA_TEST_NATIVE=1`: katana runs with `--enable-native-compilation` and a `starknet_call` on the predeployed (Sierra) UDC forces a class through the executor's native-compile pool, failing on any `Failed to compile native class` in the serial log.

Native execution stays **opt-in at runtime**: deployments add `--enable-native-compilation` to their fw_cfg `--katana-args`.

## Operator installer

New `misc/AMDSEV/install.sh` (curl-able one-liner, documented in `docs/install.md`) stands up an SEV-SNP host from a published release: preflight with remediation hints, download + checksum/measurement verification of a `tee-vm-v*` release **paired with the launcher scripts fetched from the repo source at the same tag**, pinned-QEMU build when missing, and an interactive wizard (vCPUs/memory/data disk/ports/sealing; every answer flag/env-overridable, `--yes` for automation). Because vCPUs feed the measurement, the expected value is recomputed for the chosen config with `snp-digest` built from source at the tag (checksum-only fallback with a loud warning when cargo is absent). Persistence is deliberately the operator's choice: the installer writes `config.env` + a foreground `run.sh`; `install.sh print-systemd` only prints a sample unit. `run.sh` passes resources via the new env vars, feature-detected against the fetched launcher, so releases predating the flags degrade to their measured defaults. Unit-tested by `scripts/test-install.sh` (wired into `amdsev-lint`; full-download dry run behind `KATANA_INSTALL_TEST_NETWORK=1`), and `release-pipeline.md` now flags the tag's `misc/AMDSEV` tree as a published interface.

## Reproducibility note

The `_native` asset is a plain GH-runner build, **not** reproducible-from-source yet — image verification bottoms out at its recorded `KATANA_BINARY_SHA256` (docs state this explicitly). Follow-up: teach `build-reproducible-katana.sh` the `native` feature.

## Validation (SEV-SNP host, Ubuntu 24.04/KVM)

Full sealed build with all auto-built helpers (`ldd`-verified static ld), byte-identical initrd across two builds, cpio content assertions, and the QEMU boot test: guest logs `Cairo native enabled=true`, the UDC Sierra call executes, zero native-compile errors, graceful stop.

Installer: shellcheck-clean, 39 unit tests green, and an end-to-end dry run against the real latest release (`tee-vm-v0.2.0+katana-v1.8.0-rc.8`) — download, verification, launcher fetch, feature-detection (correctly locks vCPUs to 1 on that pre-flag release), config/run.sh generation, idempotent re-run. The multi-vCPU boot + `tee_generateQuote`-vs-expected-measurement check needs the next release cut from this branch.

## Measurement impact

Initrd bytes change → the next `tee-vm-v*` release gets a new launch measurement (published as usual). Follow-ups after merge: dry-run `amdsev-release`, cut the next tee-vm release via `amdsev-release-dispatch`, and enable the flag + bump the pin in cartridge-appchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)