### PR TITLE
feat(tee-vm): dedicated snp-tools release stream, pinned in build-config

### DIFF
--- a/.github/workflows/amdsev-release.yml
+++ b/.github/workflows/amdsev-release.yml
@@ -374,22 +374,47 @@ jobs:
             echo "KATANA_ASSET_VARIANT=native"
           } >> output/qemu/build-info.txt
 
-      - name: Build snp-tools
-        # snp-tools binaries are NOT shipped as release artifacts (separate
-        # release stream). We build them here only so the next step can run
-        # snp-digest to compute the published launch measurement.
-        # snp-tools/.cargo/config.toml pins build.target, so the binary lands
-        # under target/<triple>/release; locate it explicitly rather than
-        # hardcoding the triple here.
-        working-directory: misc/AMDSEV/snp-tools
+      - name: Obtain snp-digest
+        # Needed by the next step to compute the published launch measurement.
+        # Preferred source: the snp-tools-v* release pinned in build-config
+        # (SNP_DIGEST_RELEASE + SNP_DIGEST_SHA256, cut by the
+        # amdsev-snp-tools-release workflow), checksum-verified — the same
+        # binary install.sh uses on SNP hosts, so the publisher and the
+        # verifiers run identical code. Empty pins fall back to building the
+        # crate from this checkout (snp-tools/.cargo/config.toml pins
+        # build.target, so the binary lands under target/<triple>/release;
+        # locate it explicitly rather than hardcoding the triple).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cargo build --release
-          SNP_DIGEST="$(find target -type f -name snp-digest -perm -u+x | head -n1)"
-          if [ -z "$SNP_DIGEST" ]; then
-            echo "snp-digest binary not found after build" >&2
-            exit 1
+          . ./build-config
+          if [ -n "${SNP_DIGEST_RELEASE:-}" ]; then
+            if [[ ! "${SNP_DIGEST_SHA256:-}" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "SNP_DIGEST_RELEASE is pinned but SNP_DIGEST_SHA256 is not a sha256" >&2
+              exit 1
+            fi
+            echo "Downloading pinned snp-digest from ${SNP_DIGEST_RELEASE}"
+            gh release download "$SNP_DIGEST_RELEASE" --repo "$GITHUB_REPOSITORY" \
+              --pattern "snp-digest-${SNP_DIGEST_RELEASE}" --output snp-digest
+            actual="$(sha256sum snp-digest | awk '{print $1}')"
+            if [ "$actual" != "$SNP_DIGEST_SHA256" ]; then
+              echo "pinned snp-digest checksum mismatch: got $actual, want $SNP_DIGEST_SHA256" >&2
+              exit 1
+            fi
+            chmod +x snp-digest
+            ./snp-digest --help >/dev/null
+            echo "SNP_DIGEST=$PWD/snp-digest" >> "$GITHUB_ENV"
+          else
+            echo "No SNP_DIGEST_RELEASE pin in build-config — building snp-tools from source"
+            cd snp-tools
+            cargo build --release
+            SNP_DIGEST="$(find target -type f -name snp-digest -perm -u+x | head -n1)"
+            if [ -z "$SNP_DIGEST" ]; then
+              echo "snp-digest binary not found after build" >&2
+              exit 1
+            fi
+            echo "SNP_DIGEST=$PWD/$SNP_DIGEST" >> "$GITHUB_ENV"
           fi
-          echo "SNP_DIGEST=$PWD/$SNP_DIGEST" >> "$GITHUB_ENV"
 
       - name: Compute sealed launch measurement
         run: |
@@ -444,6 +469,8 @@ jobs:
           tag="${VM_TAG}"
           # shellcheck disable=SC2153
           katana_ver="${KATANA_VER}"
+          # For SNP_DIGEST_RELEASE (the pinned verifier named in the notes).
+          . ./build-config
           # Pull values from build-info.txt for the human-readable summary.
           info_get() {
             awk -F= -v k="$1" '$1 == k { sub(/^[^=]*=/, ""); print; exit }' output/qemu/build-info.txt
@@ -520,6 +547,17 @@ jobs:
             echo "from \`OVMF.fd\` + \`vmlinuz\` + \`initrd.img\` + the canonical LUKS_UUID. Exits"
             echo "non-zero on any mismatch. For full from-source reproduction, see"
             echo "\`misc/AMDSEV/reproduce-release.sh\`."
+            echo
+            if [ -n "${SNP_DIGEST_RELEASE:-}" ]; then
+              echo "The measurement above was computed with snp-digest from"
+              echo "\`${SNP_DIGEST_RELEASE}\` (pinned in \`misc/AMDSEV/build-config\`) —"
+              echo "hosts running \`misc/AMDSEV/install.sh\` download and checksum-verify"
+              echo "the same pinned binary."
+            else
+              echo "The measurement above was computed with snp-digest built from this"
+              echo "tag's \`misc/AMDSEV/snp-tools\` source (no prebuilt pinned in"
+              echo "\`misc/AMDSEV/build-config\`)."
+            fi
             echo
             echo "## Full build provenance"
             echo

--- a/.github/workflows/amdsev-snp-tools-release.yml
+++ b/.github/workflows/amdsev-snp-tools-release.yml
@@ -1,0 +1,139 @@
+name: amdsev-snp-tools-release
+
+# Publishes a prebuilt snp-digest as a dedicated `snp-tools-v<X.Y.Z>` GitHub
+# Release. snp-digest changes far less often than the TEE VM image, so it
+# gets its own release stream instead of being rebuilt and re-attached on
+# every tee-vm-v* release; consumers pin ONE snp-tools release:
+#
+#   - misc/AMDSEV/build-config carries SNP_DIGEST_RELEASE + SNP_DIGEST_SHA256.
+#     The tee-vm release pipeline (amdsev-release.yml) downloads that pinned
+#     binary to compute the published launch measurement, and install.sh
+#     downloads it on SNP hosts so measurement verification needs no Rust
+#     toolchain. Empty pins mean both fall back to building from source.
+#
+# Runbook: dispatch this workflow with the new version, then open a PR
+# bumping the two pins in build-config to the new tag + the SHA256 printed
+# in the release notes. The prebuilt is a convenience copy, not the trust
+# root — auditors rebuild snp-digest from the tagged snp-tools source
+# (pinned rust-toolchain.toml + Cargo.lock) rather than trusting the asset.
+#
+# Cut a new release when the snp-tools crate changes in a way that affects
+# snp-digest's output or interface (measurement algorithm inputs, CLI flags),
+# then bump the pins. Runner-only build: snp-digest is pure userspace
+# hashing; no SNP hardware involved.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'snp-tools version to publish (SemVer, no prefix; e.g. 0.1.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: amdsev-snp-tools-release
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: misc/AMDSEV/snp-tools
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version and tag availability
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "version must be plain SemVer (optionally -rc.N), got: $VERSION" >&2
+            exit 1
+          fi
+          tag="snp-tools-v${VERSION}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release $tag already exists" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: misc/AMDSEV/snp-tools
+
+      - name: Test
+        # Same gate as PR CI (amdsev-snp-tools.yml): snp-digest computes the
+        # measurement verifiers pin against — never ship an untested build.
+        run: cargo test --release --locked
+
+      - name: Build snp-digest
+        # snp-tools/.cargo/config.toml pins build.target, so the binary lands
+        # under target/<triple>/release; locate it explicitly rather than
+        # hardcoding the triple here.
+        run: |
+          cargo build --release --locked
+          SNP_DIGEST="$(find target -type f -name snp-digest -perm -u+x | head -n1)"
+          if [ -z "$SNP_DIGEST" ]; then
+            echo "snp-digest binary not found after build" >&2
+            exit 1
+          fi
+          "$SNP_DIGEST" --help >/dev/null
+          echo "SNP_DIGEST=$PWD/$SNP_DIGEST" >> "$GITHUB_ENV"
+
+      - name: Stage release artifacts
+        id: stage
+        env:
+          TAG: ${{ steps.ctx.outputs.tag }}
+        run: |
+          mkdir -p release
+          cp "$SNP_DIGEST" "release/snp-digest-${TAG}"
+          sha="$(sha256sum "release/snp-digest-${TAG}" | awk '{print $1}')"
+          printf '%s\n' "$sha" > "release/snp-digest-${TAG}.sha256"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        env:
+          TAG: ${{ steps.ctx.outputs.tag }}
+          SHA: ${{ steps.stage.outputs.sha }}
+        run: |
+          toolchain="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml | head -n1)"
+          {
+            echo "# snp-tools ${TAG}"
+            echo
+            echo "Prebuilt \`snp-digest\` (x86_64 Linux, Rust ${toolchain}, \`--locked\`) — the"
+            echo "SEV-SNP launch-measurement calculator used by the TEE VM release pipeline"
+            echo "and by \`misc/AMDSEV/install.sh\` on SNP hosts."
+            echo
+            echo '```'
+            echo "snp-digest-${TAG} SHA-256: ${SHA}"
+            echo '```'
+            echo
+            echo "To adopt this release, bump both pins in \`misc/AMDSEV/build-config\`:"
+            echo
+            echo '```sh'
+            echo "SNP_DIGEST_RELEASE=\"${TAG}\""
+            echo "SNP_DIGEST_SHA256=\"${SHA}\""
+            echo '```'
+            echo
+            echo "This is a convenience copy, not the trust root: auditors should rebuild"
+            echo "\`snp-digest\` from this tag's \`misc/AMDSEV/snp-tools\` source (pinned"
+            echo "\`rust-toolchain.toml\` + \`Cargo.lock\`)."
+          } > release/release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ctx.outputs.tag }}
+          target_commitish: ${{ steps.ctx.outputs.sha }}
+          prerelease: ${{ contains(inputs.version, '-rc.') }}
+          body_path: misc/AMDSEV/snp-tools/release/release-notes.md
+          files: |
+            misc/AMDSEV/snp-tools/release/snp-digest-*

--- a/misc/AMDSEV/build-config
+++ b/misc/AMDSEV/build-config
@@ -103,3 +103,15 @@ LIBC6_DEV_PKG_SHA256="bbf5a155039042634961a61276650631ee47b9e721f91f8dbb731b0bbe
 # KATANA_LUKS_UUID); their measurement will differ from the published one and
 # they must recompute it themselves via sealed-cmdline.sh + snp-digest.
 KATANA_CANONICAL_LUKS_UUID="00000000-0000-0000-0000-000000000001"
+
+# Prebuilt snp-digest — a snp-tools-v* GitHub release cut by the
+# amdsev-snp-tools-release workflow. The tee-vm release pipeline downloads it
+# (instead of rebuilding the crate) to compute the published measurement, and
+# install.sh downloads it on SNP hosts so measurement verification needs no
+# Rust toolchain; both verify the download against SNP_DIGEST_SHA256, which
+# is trusted because THIS file is versioned in git at the consuming tag.
+# Empty pins = build snp-digest from source (the prebuilt is a convenience
+# copy, never the trust root). Bump both together, from the values printed
+# in the snp-tools release notes.
+SNP_DIGEST_RELEASE=""
+SNP_DIGEST_SHA256=""

--- a/misc/AMDSEV/docs/install.md
+++ b/misc/AMDSEV/docs/install.md
@@ -34,12 +34,15 @@ The installer needs no root; `run.sh` invokes `start-vm.sh` via `sudo`
   host has another version (or none), the installer offers to build it from
   source via the release's `scripts/build-qemu.sh` — locally under the
   install root (default) or into `/usr/local`.
-- **Rust (optional but recommended):** `cargo` is needed to build
-  `snp-digest`, which verifies the release's published launch measurement
-  and computes the expected measurement for your configuration. Without it
-  the install still completes (artifact checksums are always verified), but
-  attestation verification has no local expected value until you install
-  Rust and run `install.sh verify`.
+- **Rust (optional):** measurement verification uses `snp-digest`. Each
+  release's `build-config` pins a prebuilt `snp-tools-v*` release (tag +
+  SHA-256) that the installer downloads and checksum-verifies automatically,
+  so `cargo` is only needed as a fallback — for releases predating the pin,
+  or if you prefer building the verifier from source (the prebuilt is a
+  convenience copy, not the trust root). Without either, the install still
+  completes (artifact checksums are always verified), but attestation
+  verification has no local expected value until you run `install.sh verify`
+  with one of them available.
 
 ## What gets installed
 
@@ -155,7 +158,8 @@ a fresh file to keep the old disk recoverable under the old release.
   then reload `kvm_amd` (or reboot). The host kernel must support SNP.
 - **QEMU build fails** — install the build deps first:
   `sudo apt-get install -y build-essential ninja-build pkg-config libglib2.0-dev libpixman-1-dev python3-venv flex bison wget`.
-- **`cargo` missing / measurement not computed** — install Rust
+- **Measurement not computed** — the release pins no prebuilt `snp-digest`
+  (its `build-config` predates the pin) and `cargo` is missing. Install Rust
   (https://rustup.rs), then `~/.katana/tee-vm/install.sh verify`.
 - **vCPUs locked to 1** — the chosen release's launcher predates
   configurable vCPUs; pick a newer `tee-vm-v*` release.

--- a/misc/AMDSEV/docs/release-pipeline.md
+++ b/misc/AMDSEV/docs/release-pipeline.md
@@ -264,8 +264,41 @@ fetched from the **repo source at the same tag**
 `misc/AMDSEV` tree part of the published interface: renaming `start-vm.sh`,
 its flags/env vars (`KATANA_VCPUS`, `KATANA_MEMORY`, `HOST_RPC_PORT`, ...),
 `scripts/sealed-cmdline.sh`, `verify-build.sh`, the `snp-tools` crate path,
-or the tarball layout changes what installed hosts download on upgrade — the
-installer feature-detects where it can, but treat such renames as breaking.
+the `build-config` pin keys, or the tarball layout changes what installed
+hosts download on upgrade — the installer feature-detects where it can, but
+treat such renames as breaking.
+
+## The snp-tools release stream
+
+`snp-digest` (the measurement calculator) is published on its own release
+line, `snp-tools-v<X.Y.Z>`, cut on demand by the
+[`amdsev-snp-tools-release`](../../../.github/workflows/amdsev-snp-tools-release.yml)
+workflow (assets: `snp-digest-<tag>` for x86_64 Linux + a bare-hex
+`.sha256`). It changes far less often than the VM image, so one snp-tools
+release serves many tee-vm releases instead of being rebuilt per release.
+
+Consumers pin it in `build-config` (`SNP_DIGEST_RELEASE` +
+`SNP_DIGEST_SHA256`):
+
+- **This pipeline** downloads the pinned binary (checksum-verified) to
+  compute the published measurement — no cargo build in the release path.
+- **`install.sh`** reads the pins from the installed tag's `build-config`
+  and downloads the same binary on SNP hosts, so measurement verification
+  needs no Rust toolchain. The checksum is trusted because `build-config` is
+  versioned in git at the consuming tag.
+- **Empty pins** mean both fall back to building `snp-tools` from source
+  (also the behavior for tags predating the pins).
+
+The prebuilt is a plain runner build — a convenience copy, **not** the trust
+root, and not part of the reproducibility story (its checksum stays out of
+`build-info.txt`, so `reproduce-release.sh` is unaffected). Auditors verify
+it by rebuilding from the snp-tools tag's pinned source
+(`rust-toolchain.toml` + `Cargo.lock`).
+
+Runbook for a new snp-tools release: dispatch `amdsev-snp-tools-release`
+with the next version, then open a PR bumping both `build-config` pins to
+the tag + SHA-256 printed in its release notes. Cut one whenever the crate
+changes in a way that affects `snp-digest`'s output or interface.
 
 ## What moves the measurement between releases
 

--- a/misc/AMDSEV/install.sh
+++ b/misc/AMDSEV/install.sh
@@ -21,8 +21,9 @@
 #      when the host doesn't already have it
 #   6. Recomputes the EXPECTED LAUNCH MEASUREMENT for the chosen config —
 #      vCPU count is part of the SEV-SNP measurement (memory is not), so a
-#      non-default count needs its own expected value (computed with the
-#      release's snp-digest, built from source at the tag)
+#      non-default count needs its own expected value. Computed with
+#      snp-digest: the prebuilt snp-tools release pinned (tag + sha256) in
+#      the tag's build-config when available, else built from source (cargo)
 #   7. Writes config.env + a foreground run.sh and stops there. Persistence
 #      (systemd, tmux, a supervisor) is deliberately the operator's choice:
 #      `install.sh print-systemd` prints a sample unit but never installs it.
@@ -183,6 +184,7 @@ valid_mode()   { [[ "$1" == "sealed" || "$1" == "unsealed" ]]; }
 valid_int()    { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 >= 1 )); }
 valid_tag()    { [[ "$1" == tee-vm-v* ]]; }
 valid_uuid()   { [[ "$1" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; }
+valid_sha256() { [[ "$1" =~ ^[0-9a-f]{64}$ ]]; }
 
 # True when nothing is listening on 127.0.0.1:$1.
 port_free() {
@@ -208,10 +210,17 @@ parse_metrics_port() {
     printf '%s' "$port"
 }
 
+# Shared curl flags: fail loudly on a stalled network instead of hanging the
+# install (unauthenticated api.github.com in particular can stall when
+# rate-limited). No overall --max-time — the release tarball is hundreds of
+# MB and download time is connection-dependent; the speed floor below kills
+# genuinely dead transfers instead.
+CURL=(curl -fsSL --connect-timeout 15 --retry 2 --speed-limit 1024 --speed-time 60)
+
 # Latest published tee-vm-v* tag (the repo also publishes katana's own
 # vX.Y.Z releases, which carry no VM image).
 resolve_latest_tag() {
-    curl -fsSL "https://api.github.com/repos/${VM_REPO}/releases?per_page=30" \
+    "${CURL[@]}" --max-time 30 "https://api.github.com/repos/${VM_REPO}/releases?per_page=30" \
         | python3 -c 'import json,sys; rs=[r["tag_name"] for r in json.load(sys.stdin) if r["tag_name"].startswith("tee-vm-v")]; print(rs[0] if rs else "")'
 }
 
@@ -321,9 +330,9 @@ preflight() {
     if have cargo; then
         ok "cargo $(cargo --version 2>/dev/null | awk '{print $2}')"
     else
-        bad "cargo not found — needed to build snp-digest for measurement verification"
-        echo "       (not fatal: the wizard offers to install rustup, or the install"
-        echo "        falls back to checksum-only verification)"
+        bad "cargo not found — only needed to build snp-digest when the release"
+        echo "       pins no prebuilt snp-digest (not fatal: the wizard offers"
+        echo "       rustup, or the install falls back to checksum-only verification)"
     fi
 
     (( failures == 0 )) || fail "preflight failed ($failures issue(s)) — fix the items above and re-run"
@@ -343,7 +352,7 @@ fetch_release() {
     else
         log "Downloading katana-tee-vm-${tag}.tar.gz ..."
         mkdir -p "$boot_dir"
-        curl -fsSL -o "$TMP_DIR/release.tar.gz" \
+        "${CURL[@]}" -o "$TMP_DIR/release.tar.gz" \
             "https://github.com/${VM_REPO}/releases/download/${tag_url}/katana-tee-vm-${tag_url}.tar.gz" \
             || fail "could not download release tarball for $tag"
         tar xzf "$TMP_DIR/release.tar.gz" -C "$boot_dir"
@@ -360,7 +369,7 @@ fetch_release() {
         log "Launcher scripts for $tag already present — skipping download"
     else
         log "Fetching launcher scripts at tag $tag ..."
-        curl -fsSL -o "$TMP_DIR/src.tar.gz" \
+        "${CURL[@]}" -o "$TMP_DIR/src.tar.gz" \
             "https://github.com/${VM_REPO}/archive/refs/tags/${tag_url}.tar.gz" \
             || fail "could not download source tarball for tag $tag"
         extract_amdsev_subtree "$TMP_DIR/src.tar.gz" "$src_dir"
@@ -456,7 +465,7 @@ ensure_cargo() {
     log "Installing rustup ..."
     # --default-toolchain none: snp-tools/rust-toolchain.toml pins the exact
     # toolchain and rustup fetches it on first build.
-    curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+    "${CURL[@]}" https://sh.rustup.rs | sh -s -- -y --default-toolchain none
     # shellcheck disable=SC1091
     [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
     have cargo
@@ -469,6 +478,61 @@ build_snp_digest() {
     local src_dir="$1"
     (cd "$src_dir/snp-tools" && cargo build --release >&2)
     find "$src_dir/snp-tools/target" -type f -name snp-digest -perm -u+x 2>/dev/null | head -n1
+}
+
+# Read a KEY="value" assignment out of a build-config file without sourcing
+# it (extraction keeps this a data read, not code execution).
+build_config_get() {
+    sed -n "s/^${2}=\"\(.*\)\"\$/\1/p" "$1" | head -n1
+}
+
+# Fetch the prebuilt snp-digest pinned by the tag's build-config
+# (SNP_DIGEST_RELEASE names a snp-tools-v* release, SNP_DIGEST_SHA256 gates
+# the download — trusted because build-config is versioned in git at the
+# tee-vm tag being installed) and echo its path; non-zero when the tag has no
+# pin (predates it, or pins left empty), the checksum mismatches, or the
+# binary doesn't run — callers fall back to the source build. It lands where
+# verify-build.sh's discovery looks (snp-tools/target/release/), so the
+# release verification step finds it without changes. A convenience copy, not
+# the trust root: auditors build snp-digest from the pinned release's source.
+fetch_prebuilt_snp_digest() {
+    local src_dir="$1" rel sha_expected sha_actual rel_url dest
+    # The prebuilt targets x86_64 Linux — the only SNP host platform. Dry
+    # runs elsewhere (e.g. macOS) use the source-build or no-cargo paths.
+    [[ "$(uname -s)/$(uname -m)" == "Linux/x86_64" ]] || return 1
+    [[ -f "$src_dir/build-config" ]] || return 1
+    rel="$(build_config_get "$src_dir/build-config" SNP_DIGEST_RELEASE)"
+    sha_expected="$(build_config_get "$src_dir/build-config" SNP_DIGEST_SHA256)"
+    [[ -n "$rel" ]] || return 1
+    if ! valid_sha256 "$sha_expected"; then
+        warn "build-config pins SNP_DIGEST_RELEASE=$rel but SNP_DIGEST_SHA256 is not a sha256 — falling back to source build"
+        return 1
+    fi
+    rel_url="$(encode_tag "$rel")"
+    dest="$src_dir/snp-tools/target/release/snp-digest"
+
+    # Reuse an already-downloaded copy when it still matches the pin.
+    if [[ ! -x "$dest" ]] || [[ "$(sha256sum "$dest" | awk '{print $1}')" != "$sha_expected" ]]; then
+        "${CURL[@]}" -o "$TMP_DIR/snp-digest" \
+            "https://github.com/${VM_REPO}/releases/download/${rel_url}/snp-digest-${rel_url}" \
+            || { warn "could not download pinned snp-digest release $rel — falling back to source build"; return 1; }
+        sha_actual="$(sha256sum "$TMP_DIR/snp-digest" | awk '{print $1}')"
+        if [[ "$sha_actual" != "$sha_expected" ]]; then
+            warn "pinned snp-digest checksum mismatch (got $sha_actual, want $sha_expected) — falling back to source build"
+            return 1
+        fi
+        mkdir -p "$(dirname "$dest")"
+        cp "$TMP_DIR/snp-digest" "$dest"
+        chmod +x "$dest"
+    fi
+
+    # Smoke-run: catches a binary the host can't execute (e.g. libc mismatch).
+    if ! "$dest" --help >/dev/null 2>&1; then
+        warn "pinned snp-digest does not run on this host — falling back to source build"
+        rm -f "$dest"
+        return 1
+    fi
+    printf '%s' "$dest"
 }
 
 # Compute the expected launch measurement for the operator's configuration
@@ -514,12 +578,22 @@ compute_expected_measurement() {
 verify_and_measure() {
     local src_dir="$1" boot_dir="$2" snp_digest
 
-    if ! ensure_cargo; then
+    # Prefer the prebuilt verifier release pinned by the tag's build-config;
+    # build from source only when the tag has no pin (or the download fails).
+    snp_digest="$(fetch_prebuilt_snp_digest "$src_dir")" || snp_digest=""
+    if [[ -n "$snp_digest" ]]; then
+        log "Using prebuilt snp-digest $(build_config_get "$src_dir/build-config" SNP_DIGEST_RELEASE) (pinned in build-config, checksum verified)"
+    elif ensure_cargo; then
+        log "No usable prebuilt snp-digest for $TAG — building from source ..."
+        snp_digest="$(build_snp_digest "$src_dir")"
+        [[ -n "$snp_digest" ]] || fail "snp-tools built but no snp-digest binary was found"
+    else
         # Boot artifacts were already checksum-verified against build-info.txt
         # in fetch_release; only the measurement recompute is unavailable.
         rm -f "$TEE_HOME/expected-measurement.txt"
         warn "=================================================================="
-        warn "cargo unavailable — SKIPPING launch-measurement verification."
+        warn "no prebuilt snp-digest for $TAG and cargo unavailable —"
+        warn "SKIPPING launch-measurement verification."
         warn "Artifact checksums were verified, but the expected measurement for"
         warn "your configuration was NOT computed, so remote attestation results"
         warn "cannot be checked against a local expected value."
@@ -529,10 +603,6 @@ verify_and_measure() {
         EXPECTED_MEASUREMENT=""
         return 0
     fi
-
-    log "Building snp-digest from source at $TAG ..."
-    snp_digest="$(build_snp_digest "$src_dir")"
-    [[ -n "$snp_digest" ]] || fail "snp-tools built but no snp-digest binary was found"
 
     # Full release verification: every artifact SHA-256 plus the RECORDED
     # measurement (vcpus=1, canonical sealed UUID — the values the release

--- a/misc/AMDSEV/scripts/test-install.sh
+++ b/misc/AMDSEV/scripts/test-install.sh
@@ -94,6 +94,33 @@ check_false "valid_tag rejects a katana release tag"        valid_tag "v1.8.0"
 check_true  "valid_uuid accepts canonical lowercase" valid_uuid "00000000-0000-0000-0000-000000000001"
 check_false "valid_uuid rejects uppercase"           valid_uuid "00000000-0000-0000-0000-00000000000A"
 
+# Gates the pinned prebuilt snp-digest download (SNP_DIGEST_SHA256).
+check_true  "valid_sha256 accepts 64 hex"      valid_sha256 "$(printf 'a%.0s' {1..64})"
+check_false "valid_sha256 rejects 63 hex"      valid_sha256 "$(printf 'a%.0s' {1..63})"
+check_false "valid_sha256 rejects uppercase"   valid_sha256 "$(printf 'A%.0s' {1..64})"
+check_false "valid_sha256 rejects a 404 page"  valid_sha256 "Not Found"
+
+# ---- build-config pin extraction -----------------------------------------------
+# install.sh reads the SNP_DIGEST_RELEASE/SNP_DIGEST_SHA256 pins out of the
+# fetched tag's build-config without sourcing it (data read, not code exec).
+
+BC_FIXTURE="$WORK/build-config"
+cat > "$BC_FIXTURE" <<'EOF'
+# comment
+OVMF_COMMIT="fbe0805b"
+SNP_DIGEST_RELEASE="snp-tools-v0.1.0"
+SNP_DIGEST_SHA256=""
+EOF
+check "build_config_get reads a pinned value" \
+    "snp-tools-v0.1.0" "$(build_config_get "$BC_FIXTURE" SNP_DIGEST_RELEASE)"
+check "build_config_get reads an empty pin as empty" \
+    "" "$(build_config_get "$BC_FIXTURE" SNP_DIGEST_SHA256)"
+check "build_config_get returns nothing for a missing key" \
+    "" "$(build_config_get "$BC_FIXTURE" NO_SUCH_KEY)"
+# The real build-config must stay extractable by this exact parser.
+check_true "real build-config carries the SNP_DIGEST_RELEASE key" \
+    grep -q '^SNP_DIGEST_RELEASE="' "${SCRIPT_DIR}/../build-config"
+
 # ---- Tag URL encoding ----------------------------------------------------------
 
 check "encode_tag percent-encodes '+'" \


### PR DESCRIPTION
## Why

Every `tee-vm-v*` release rebuilt `snp-digest` from scratch just to compute its measurement, and #636's installer additionally required a Rust toolchain on every SNP host to verify measurements. The verifier changes far less often than the VM image — it should be released once and reused.

## What

- **New `amdsev-snp-tools-release` workflow** (dispatch with a version): `cargo test --locked`, build, smoke-run, publish `snp-tools-v<X.Y.Z>` with `snp-digest-<tag>` + a bare-hex `.sha256`. Release notes print the exact pin lines to adopt it.
- **`build-config` pins the chosen release** (`SNP_DIGEST_RELEASE` + `SNP_DIGEST_SHA256`) — the checksum is trusted because build-config is versioned in git at the consuming tag, so the pin travels with every tee-vm tag.
- **`amdsev-release.yml`**: "Build snp-tools" → "Obtain snp-digest": downloads the pinned binary (checksum-verified, smoke-run) to compute the published measurement, so the publisher and every verifying host run the *identical* binary; release notes name the pinned verifier. Empty pins fall back to the source build.
- **`install.sh`**: reads the pins from the installed tag's `build-config` (sed extraction, not sourcing), downloads once with checksum + smoke-run gates, caches across re-runs, and drops the binary where `verify-build.sh`'s discovery already looks. Fallback chain: pinned prebuilt → cargo build → checksum-only with a loud warning. Also hardens all downloads with connect timeouts, retries, and a 1 KB/s speed floor — a rate-limited GitHub API call used to hang the install indefinitely.
- The prebuilt is a convenience copy, never the trust root: auditors rebuild from the snp-tools tag's pinned source, and its checksum deliberately stays out of `build-info.txt` so `reproduce-release.sh` is unaffected. Docs updated (`release-pipeline.md` stream + runbook, `install.md` prerequisites).

## Validation

shellcheck clean (CI set), 46 unit tests green (`test-install.sh`, incl. new `build_config_get` extraction tests), actionlint clean on both workflows, and a live `--dry-run` install against the just-published `tee-vm-v0.3.0+katana-v1.8.0-rc.8` (no pins there yet → correct source-build fallback messaging).

## Rollout

1. Merge; dispatch `amdsev-snp-tools-release` with `0.1.0`.
2. Follow-up PR bumps the two `build-config` pins from the release notes — from then on neither the release pipeline nor any SNP host builds `snp-digest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
