### PR TITLE
chore(tee-vm): pin prebuilt snp-digest to snp-tools-v0.1.0

### DIFF
--- a/misc/AMDSEV/build-config
+++ b/misc/AMDSEV/build-config
@@ -113,5 +113,5 @@ KATANA_CANONICAL_LUKS_UUID="00000000-0000-0000-0000-000000000001"
 # Empty pins = build snp-digest from source (the prebuilt is a convenience
 # copy, never the trust root). Bump both together, from the values printed
 # in the snp-tools release notes.
-SNP_DIGEST_RELEASE=""
-SNP_DIGEST_SHA256=""
+SNP_DIGEST_RELEASE="snp-tools-v0.1.0"
+SNP_DIGEST_SHA256="1197dbeafc9526429bdda9a852a15c8265725819c8c02987ba03fcceb73a7417"


### PR DESCRIPTION
Sets the two `build-config` pins introduced in #637 to the freshly cut [`snp-tools-v0.1.0`](https://github.com/dojoengine/katana/releases/tag/snp-tools-v0.1.0) release. The SHA-256 matches both the published `.sha256` asset and a locally re-downloaded copy of the binary. From the next `tee-vm-v*` release onward, the release pipeline and `install.sh` download this pinned verifier instead of building `snp-tools` from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)