### PR TITLE
fix(settlement): reuse the prepared proof when retrying a failed submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-prover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=268585457dc8ff0fd4760e162c821f3e9b87f136#268585457dc8ff0fd4760e162c821f3e9b87f136"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-verifier"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=268585457dc8ff0fd4760e162c821f3e9b87f136#268585457dc8ff0fd4760e162c821f3e9b87f136"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -14003,7 +14003,7 @@ dependencies = [
 [[package]]
 name = "sp1-methods"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=268585457dc8ff0fd4760e162c821f3e9b87f136#268585457dc8ff0fd4760e162c821f3e9b87f136"
 dependencies = [
  "lazy_static",
  "sp1-build",
@@ -17362,7 +17362,7 @@ dependencies = [
 [[package]]
 name = "x509-verifier-rust-crypto"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=4ce5017721f03a199e922d989476ed3f2d071a90#4ce5017721f03a199e922d989476ed3f2d071a90"
+source = "git+https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk?rev=268585457dc8ff0fd4760e162c821f3e9b87f136#268585457dc8ff0fd4760e162c821f3e9b87f136"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,9 +278,9 @@ paymaster-service = { git = "https://github.com/cartridge-gg/paymaster", rev = "
 
 
 # AMD SEV-SNP SDKs
-amd-sev-snp-attestation-prover = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "4ce5017721f03a199e922d989476ed3f2d071a90", default-features = false }
-amd-sev-snp-attestation-verifier = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "4ce5017721f03a199e922d989476ed3f2d071a90" }
-x509-verifier-rust-crypto = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "4ce5017721f03a199e922d989476ed3f2d071a90" }
+amd-sev-snp-attestation-prover = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "268585457dc8ff0fd4760e162c821f3e9b87f136", default-features = false }
+amd-sev-snp-attestation-verifier = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "268585457dc8ff0fd4760e162c821f3e9b87f136" }
+x509-verifier-rust-crypto = { git = "https://github.com/cartridge-gg/amd-sev-snp-attestation-sdk", rev = "268585457dc8ff0fd4760e162c821f3e9b87f136" }
 
 garaga_rs = { git = "https://github.com/cartridge-gg/garaga.git", rev = "061394abce25b1e6e993a7e65ee8eade4f718f96" }
 
@@ -326,3 +326,4 @@ starknet-types-core = { git = "https://github.com/kariy/types-rs", rev = "0f6ae3
 # equivalent fix AND the `sev-snp` SDK bumps to a release that includes it.
 [patch."https://github.com/automata-network/coco-provider-sdk"]
 coco-provider = { git = "https://github.com/cartridge-gg/coco-provider-sdk", rev = "b0a90d057a8b585de5665d2c6b3fff698130b21e" }
+

--- a/crates/node/sequencer/src/lib.rs
+++ b/crates/node/sequencer/src/lib.rs
@@ -799,7 +799,7 @@ impl Node<ForkProviderFactory> {
 impl<P> Node<P>
 where
     P: ProviderFactory + Clone + Send + Sync + 'static,
-    <P as ProviderFactory>::Provider: ProviderRO,
+    <P as ProviderFactory>::Provider: ProviderRO + SettlementProofProvider,
     <P as ProviderFactory>::ProviderMut: ProviderRW
         + MessagingCheckpointProvider
         + MessagingL1ToL2IndexWriter

--- a/crates/primitives/src/settlement.rs
+++ b/crates/primitives/src/settlement.rs
@@ -19,3 +19,19 @@ impl ProofId {
         Self(id.into())
     }
 }
+
+/// A reference to a generated-but-not-yet-settled batch proof.
+///
+/// Recorded by the settlement service the moment proving completes — before the `update_state`
+/// submission — so that a node restart can recover the proof from the proving network by its
+/// [`ProofId`] instead of paying for a fresh proving round. Cleared once the batch settles.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
+pub struct PendingBatchProof {
+    /// First block of the unsettled batch (inclusive).
+    pub first: u64,
+    /// Last block of the unsettled batch (inclusive).
+    pub last: u64,
+    /// Reference to the generated proof, resolvable against the proving backend's network.
+    pub proof: ProofId,
+}

--- a/crates/settlement/Cargo.toml
+++ b/crates/settlement/Cargo.toml
@@ -35,3 +35,5 @@ url.workspace = true
 
 [dev-dependencies]
 katana-genesis.workspace = true
+# test-util: paused-clock tests of the submission-retry loop (`start_paused`).
+tokio = { workspace = true, features = [ "test-util" ] }

--- a/crates/settlement/src/backend/mod.rs
+++ b/crates/settlement/src/backend/mod.rs
@@ -45,4 +45,24 @@ pub trait ProvingBackend: Send + Sync {
         prev_block: Option<BlockNumber>,
         block: BlockNumber,
     ) -> Result<(PiltoverInput, Option<ProofId>), SettlementError>;
+
+    /// Rebuilds the `update_state` payload for `(prev_block, block]` from an
+    /// already-generated proof, referenced by the [`ProofId`] the matching
+    /// [`Self::prove`] call returned — without a fresh (on the SP1 network,
+    /// paid) proving round.
+    ///
+    /// Returns `Ok(None)` when the backend cannot recover proofs (e.g. mock
+    /// proving, which has no network to recover from — and no cost to save);
+    /// the caller then falls back to [`Self::prove`]. `Err` means recovery was
+    /// attempted and failed (e.g. the network no longer retains the proof) —
+    /// also a fall-back-to-prove signal, but worth surfacing in logs.
+    async fn recover(
+        &self,
+        prev_block: Option<BlockNumber>,
+        block: BlockNumber,
+        proof: &ProofId,
+    ) -> Result<Option<(PiltoverInput, Option<ProofId>)>, SettlementError> {
+        let _ = (prev_block, block, proof);
+        Ok(None)
+    }
 }

--- a/crates/settlement/src/backend/mod.rs
+++ b/crates/settlement/src/backend/mod.rs
@@ -51,6 +51,9 @@ pub trait ProvingBackend: Send + Sync {
     /// [`Self::prove`] call returned — without a fresh (on the SP1 network,
     /// paid) proving round.
     ///
+    /// Unlike [`Self::prove`], no proof reference is returned: the caller
+    /// already holds `proof` — it is what recovery resolves.
+    ///
     /// Returns `Ok(None)` when the backend cannot recover proofs (e.g. mock
     /// proving, which has no network to recover from — and no cost to save);
     /// the caller then falls back to [`Self::prove`]. `Err` means recovery was
@@ -61,7 +64,7 @@ pub trait ProvingBackend: Send + Sync {
         prev_block: Option<BlockNumber>,
         block: BlockNumber,
         proof: &ProofId,
-    ) -> Result<Option<(PiltoverInput, Option<ProofId>)>, SettlementError> {
+    ) -> Result<Option<PiltoverInput>, SettlementError> {
         let _ = (prev_block, block, proof);
         Ok(None)
     }

--- a/crates/settlement/src/backend/tee/mod.rs
+++ b/crates/settlement/src/backend/tee/mod.rs
@@ -103,6 +103,34 @@ where
 
         Ok((build_tee_input(&attestation, sp1_proof), proof))
     }
+
+    async fn recover(
+        &self,
+        prev_block: Option<BlockNumber>,
+        block: BlockNumber,
+        proof: &ProofId,
+    ) -> Result<Option<(PiltoverInput, Option<ProofId>)>, SettlementError> {
+        // Rebuilding the attestation is local and cheap; only the range-derived fields enter the
+        // payload (the quote's fresh hardware signature does not), so pairing a rebuilt
+        // attestation with the recovered proof yields the same submittable `TeeInput` the
+        // original prove produced — the proof's journal commits to the range-derived
+        // commitment, which is deterministic for historical blocks.
+        let Some(sp1_proof) = self.prover.recover(proof).await? else { return Ok(None) };
+
+        let attestation = {
+            let provider = self.provider.provider();
+            build_block_attestation(
+                &provider,
+                &*self.attester,
+                prev_block,
+                block,
+                None,
+                self.katana_tee_config_hash,
+            )?
+        };
+
+        Ok(Some((build_tee_input(&attestation, sp1_proof), Some(proof.clone()))))
+    }
 }
 
 impl<P> std::fmt::Debug for TeeBackend<P> {

--- a/crates/settlement/src/backend/tee/mod.rs
+++ b/crates/settlement/src/backend/tee/mod.rs
@@ -109,7 +109,7 @@ where
         prev_block: Option<BlockNumber>,
         block: BlockNumber,
         proof: &ProofId,
-    ) -> Result<Option<(PiltoverInput, Option<ProofId>)>, SettlementError> {
+    ) -> Result<Option<PiltoverInput>, SettlementError> {
         // Rebuilding the attestation is local and cheap; only the range-derived fields enter the
         // payload (the quote's fresh hardware signature does not), so pairing a rebuilt
         // attestation with the recovered proof yields the same submittable `TeeInput` the
@@ -129,7 +129,7 @@ where
             )?
         };
 
-        Ok(Some((build_tee_input(&attestation, sp1_proof), Some(proof.clone()))))
+        Ok(Some(build_tee_input(&attestation, sp1_proof)))
     }
 }
 

--- a/crates/settlement/src/backend/tee/prover.rs
+++ b/crates/settlement/src/backend/tee/prover.rs
@@ -29,6 +29,11 @@ use super::mock;
 /// Maximum time for the entire proof generation pipeline (KDS + registry + SP1).
 const PROOF_GENERATION_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// Maximum time to wait when recovering an already-fulfilled proof from the prover network by its
+/// request id. Deliberately short: a fulfilled proof returns immediately, so anything slower
+/// means the id is unknown/expired and the caller should fall back to fresh proving.
+const PROOF_RECOVERY_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[derive(Debug, thiserror::Error)]
 pub enum TeeProverError {
     #[error("invalid attestation report: {0}")]
@@ -110,6 +115,63 @@ impl TeeProver {
                 let request_id = proof.raw_proof.request_id;
                 let calldata = onchain_proof_to_calldata(&proof)?;
                 Ok((calldata, request_id))
+            }
+        }
+    }
+
+    /// Recovers the `TEEInput.sp1_proof` felts of an already-generated proof from the prover
+    /// network by its request id, without submitting (and paying for) a new proving request.
+    ///
+    /// Returns `Ok(None)` for the mock prover — it has no network to recover from, and mock
+    /// proving is free anyway. `Err` means the network no longer serves the request (expired /
+    /// unknown id) or the fetch failed; the caller falls back to fresh proving.
+    pub async fn recover(
+        &self,
+        proof: &katana_primitives::settlement::ProofId,
+    ) -> Result<Option<Vec<Felt>>, TeeProverError> {
+        match self {
+            Self::Mock => Ok(None),
+
+            Self::Sp1 { prover_key, .. } => {
+                let request_id = B256::try_from(proof.0.as_ref()).map_err(|_| {
+                    TeeProverError::ProofGenerationFailed(format!(
+                        "proof id is not a 32-byte SP1 request id ({} bytes)",
+                        proof.0.len()
+                    ))
+                })?;
+
+                info!(
+                    request_id = %format!("{request_id:#x}"),
+                    "Recovering SP1 proof from the prover network."
+                );
+
+                // Blocking for the same reason as proving: the SDK drives the network client
+                // through its own `block_on`.
+                let prover_key = prover_key.to_string();
+                let proof = tokio::task::spawn_blocking(move || -> Result<_, TeeProverError> {
+                    let sp1_config = SP1ProverConfig {
+                        private_key: Some(prover_key),
+                        rpc_url: None,
+                        prover_mode: Some("network".to_string()),
+                    };
+                    let prover = AmdSevSnpProver::new(SdkProverConfig::sp1_with(sp1_config), None);
+
+                    let raw_proof = prover
+                        .verifier
+                        .recover_proof(request_id, Some(PROOF_RECOVERY_TIMEOUT))
+                        .map_err(|e| TeeProverError::ProofGenerationFailed(e.to_string()))?;
+                    prover
+                        .create_onchain_proof(raw_proof)
+                        .map_err(|e| TeeProverError::ProofGenerationFailed(e.to_string()))
+                })
+                .await
+                .map_err(|e| {
+                    TeeProverError::ProofGenerationFailed(format!(
+                        "SP1 proof recovery task panicked: {e}"
+                    ))
+                })??;
+
+                Ok(Some(onchain_proof_to_calldata(&proof)?))
             }
         }
     }

--- a/crates/settlement/src/piltover.rs
+++ b/crates/settlement/src/piltover.rs
@@ -106,10 +106,13 @@ impl PiltoverClient {
     }
 
     /// Submits `update_state` and waits for the transaction to be confirmed.
-    pub async fn update_state(&self, update: PiltoverInput) -> Result<TxHash, PiltoverError> {
+    ///
+    /// Takes the input by reference: the settle loop keeps ownership of the prepared payload so
+    /// a failed submission can retry with the same (already-paid-for) proof.
+    pub async fn update_state(&self, update: &PiltoverInput) -> Result<TxHash, PiltoverError> {
         let tx = self
             .contract
-            .update_state(&update)
+            .update_state(update)
             .send()
             .await
             .map_err(|e| PiltoverError::SendTransaction(e.to_string()))?;

--- a/crates/settlement/src/service.rs
+++ b/crates/settlement/src/service.rs
@@ -479,14 +479,16 @@ where
         if let Some(pending) = read_pending_batch_proof(&self.provider) {
             if pending.first == first && pending.last == last {
                 match self.backend.recover(prev_block, last, &pending.proof).await {
-                    Ok(Some(payload)) => {
+                    Ok(Some(update)) => {
                         info!(
                             first,
                             last,
                             proof = ?pending.proof,
                             "Recovered proof from the proving network."
                         );
-                        recovered = Some(payload);
+                        // The reference the payload was recovered from is, by construction,
+                        // the proof that will settle it.
+                        recovered = Some((update, Some(pending.proof)));
                     }
                     // The backend cannot recover proofs (e.g. mock proving) — prove below.
                     Ok(None) => {}
@@ -755,11 +757,11 @@ mod tests {
                 &self,
                 _prev_block: Option<BlockNumber>,
                 block: BlockNumber,
-                proof: &ProofId,
-            ) -> Result<Option<(PiltoverInput, Option<ProofId>)>, SettlementError> {
+                _proof: &ProofId,
+            ) -> Result<Option<PiltoverInput>, SettlementError> {
                 self.recover_calls.fetch_add(1, Ordering::SeqCst);
                 match self.recover {
-                    RecoverBehavior::Payload => Ok(Some((test_input(block), Some(proof.clone())))),
+                    RecoverBehavior::Payload => Ok(Some(test_input(block))),
                     RecoverBehavior::Unsupported => Ok(None),
                     RecoverBehavior::Fail => Err(SettlementError::Piltover(
                         PiltoverError::GetState("mock recovery failure".into()),

--- a/crates/settlement/src/service.rs
+++ b/crates/settlement/src/service.rs
@@ -16,7 +16,6 @@ use katana_provider::api::settlement::{
     SettlementCheckpointWriter, SettlementProofProvider, SettlementProofWriter,
 };
 use katana_provider::{MutableProvider, ProviderFactory};
-use piltover::PiltoverInput;
 use tokio::sync::{broadcast, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
@@ -92,7 +91,6 @@ where
         let worker = Worker {
             cursor,
             piltover,
-            prepared: None,
             backend: self.backend.clone(),
             provider: self.provider.clone(),
             batch_size: self.config.batch_size.max(1) as u64,
@@ -159,38 +157,17 @@ struct Worker<P> {
     idle_flush_interval: tokio::time::Duration,
     /// Last settled block, from Piltover's `get_state()`. `None` = nothing settled yet.
     cursor: Option<BlockNumber>,
-    /// Proving result awaiting on-chain acceptance — see [`PreparedBatch`].
-    prepared: Option<PreparedBatch>,
     metrics: SettlementMetrics,
     proof_metrics: SettlementProofMetrics,
 }
 
-/// A proving result for a settle range that has not yet been accepted on-chain.
-///
-/// Kept across retries so a failed `update_state` submission (fees, nonce, a transient RPC
-/// error) does not trigger a fresh — and, on the SP1 prover network, paid — proving round for
-/// the identical range. The payload stays valid indefinitely for a fixed historical range:
-/// on-chain validation checks the proof against the range-derived commitment (state roots,
-/// block hashes, messages commitment), not any timestamp embedded at proving time.
-///
-/// The payload itself is in-memory, but its network reference survives restarts: when proving
-/// yields a [`ProofId`], it is persisted as a [`PendingBatchProof`] record, and a restarted
-/// node recovers the proof from the proving network ([`ProvingBackend::recover`]) instead of
-/// paying for a fresh round. Recovery is best-effort — an expired or unrecoverable reference
-/// falls back to fresh proving.
-///
-/// A payload the settlement chain *rejects in execution* (the `update_state` transaction
-/// reverts — e.g. a TEE-registry trust-root rotation invalidated the proof between proving and
-/// submission) is dropped along with its persisted reference, so the next attempt proves
-/// fresh instead of resubmitting a payload that can never land. Pre-execution failures (fees,
-/// nonce, transport) keep it.
-///
-/// [`PendingBatchProof`]: katana_primitives::settlement::PendingBatchProof
-struct PreparedBatch {
-    first: BlockNumber,
-    last: BlockNumber,
-    update: PiltoverInput,
-    proof: Option<ProofId>,
+/// Outcome of a [`Worker::settle_batch`] attempt that did not fail terminally.
+#[derive(Debug)]
+enum SettleOutcome {
+    /// The batch landed on the settlement chain.
+    Settled { tx_hash: TxHash, proof: Option<ProofId> },
+    /// Shutdown was requested while retrying the submission.
+    ShuttingDown,
 }
 
 /// Persists the settled-block cursor to the durable [`tables::SettlementCheckpoints`] index, read
@@ -326,10 +303,11 @@ where
     async fn run<N: Clone>(
         mut self,
         mut notify_rx: broadcast::Receiver<N>,
-        shutdown_rx: oneshot::Receiver<()>,
+        // `oneshot::Receiver` is `Unpin`, so it can be polled through a plain `&mut` — both
+        // here and inside `settle_batch`'s submission-retry loop, which borrows it to stay
+        // shutdown-responsive mid-retry.
+        mut shutdown_rx: oneshot::Receiver<()>,
     ) {
-        tokio::pin!(shutdown_rx);
-
         let mut idle_deadline = Instant::now() + self.idle_flush_interval;
         let mut backoff = RETRY_BACKOFF_MIN;
         let mut consecutive_failures: u32 = 0;
@@ -349,8 +327,10 @@ where
             match next_action(self.cursor, head, self.batch_size, idle_elapsed) {
                 Action::Settle { first, last } => {
                     let batch_start = Instant::now();
-                    match self.settle_batch(first, last).await {
-                        Ok((tx_hash, proof)) => {
+                    match self.settle_batch(first, last, &mut shutdown_rx).await {
+                        Ok(SettleOutcome::ShuttingDown) => break,
+
+                        Ok(SettleOutcome::Settled { tx_hash, proof }) => {
                             let blocks = last - first + 1;
                             self.proof_metrics
                                 .settle_batch_seconds
@@ -381,8 +361,12 @@ where
                             // Loop again immediately: drain any remaining backlog.
                         }
 
+                        // A terminal attempt failure: proving failed, the chain rejected the
+                        // payload in execution, or the on-chain cursor moved mid-attempt
+                        // (`settle_batch` already updated it). Transient submission failures
+                        // never surface here — they are retried inside `settle_batch` with
+                        // the same proof.
                         Err(error) => {
-                            self.metrics.settlement_failures_total.increment(1);
                             consecutive_failures += 1;
                             error!(
                                 first,
@@ -393,58 +377,11 @@ where
                                 "Failed to settle block range; will retry."
                             );
 
-                            // An on-chain execution revert means the payload itself was
-                            // rejected — reusing (or later recovering) it cannot succeed, so
-                            // drop it and its persisted reference; the retry proves fresh.
-                            // Pre-execution failures (fees, nonce, transport) keep the payload
-                            // for reuse.
-                            if matches!(
-                                error,
-                                SettlementError::Piltover(PiltoverError::TransactionReverted(_))
-                            ) && self.prepared.is_some()
-                            {
-                                warn!(
-                                    first,
-                                    last,
-                                    "Settlement chain rejected the prepared payload; dropping it \
-                                     to prove fresh on retry."
-                                );
-                                self.prepared = None;
-                                clear_pending_batch_proof(&self.provider);
-                            }
-
                             tokio::select! {
                                 _ = &mut shutdown_rx => break,
                                 _ = tokio::time::sleep(backoff) => {}
                             }
                             backoff = (backoff * 2).min(RETRY_BACKOFF_MAX);
-
-                            // The transaction may have landed even though we saw an error (e.g.
-                            // a transient RPC failure while watching the receipt). Re-reading
-                            // the on-chain cursor makes the retry idempotent: if it advanced,
-                            // the loop moves on instead of double-submitting.
-                            match self.piltover.settled_block().await {
-                                Ok(cursor) => {
-                                    if cursor != self.cursor {
-                                        warn!(
-                                            ?cursor,
-                                            previous = ?self.cursor,
-                                            "On-chain settlement cursor advanced despite the \
-                                             error; continuing from it."
-                                        );
-                                        self.cursor = cursor;
-                                        if let Some(settled) = cursor {
-                                            persist_settled_block(&self.provider, settled);
-                                        }
-                                    }
-                                }
-                                Err(error) => {
-                                    error!(
-                                        %error,
-                                        "Failed to re-read on-chain settlement cursor."
-                                    );
-                                }
-                            }
                         }
                     }
                 }
@@ -502,73 +439,54 @@ where
         self.provider.provider().latest_number().map_err(Into::into)
     }
 
-    /// Prove and settle the inclusive block range `[first, last]`.
+    /// Settles the inclusive block range `[first, last]`: prove once, then retry the
+    /// `update_state` submission until it lands or retrying stops making sense.
     ///
-    /// Proving is skipped when a [`PreparedBatch`] for exactly this range is already held from
-    /// a previous attempt whose submission failed — only a successful `update_state` clears it,
-    /// so retries of the same range never re-prove.
+    /// The payload is obtained at most once per call — recovered from the proving network when
+    /// a persisted [`PendingBatchProof`] reference from a previous run matches the range,
+    /// otherwise proven fresh (persisting a new reference *first*, so a crash mid-attempt can
+    /// recover the already-paid-for proof). It then lives as a local for exactly the duration
+    /// of the attempt: transient submission failures (fees, nonce, transport) retry with the
+    /// same payload, because on the SP1 prover network every proving round is paid work while
+    /// the payload stays valid indefinitely for its fixed historical range — on-chain
+    /// validation checks the proof against the range-derived commitment (state roots, block
+    /// hashes, messages commitment), not any timestamp embedded at proving time.
     ///
-    /// Returns the settlement-chain transaction hash and a reference to the proof that settled the
-    /// batch (`None` for mock / off-network proving).
+    /// Terminal `Err` conditions end the attempt and hand control back to the run loop:
+    ///
+    /// - proving (or recovery followed by proving) failed;
+    /// - the settlement chain *rejected the payload in execution* — the transaction reverted, e.g.
+    ///   a TEE-registry trust-root rotation invalidated the proof between proving and submission.
+    ///   The persisted reference is dropped so the next attempt proves fresh;
+    /// - the on-chain cursor advanced mid-attempt (the transaction landed despite a reported error,
+    ///   or another operator settled): the payload is spent or superseded, and the run loop
+    ///   recomputes the next range from the updated cursor.
+    ///
+    /// [`PendingBatchProof`]: katana_primitives::settlement::PendingBatchProof
     async fn settle_batch(
         &mut self,
         first: BlockNumber,
         last: BlockNumber,
-    ) -> Result<(TxHash, Option<ProofId>), SettlementError> {
-        self.prepare_batch(first, last).await?;
-        let prepared = self.prepared.as_ref().expect("prepare_batch always sets it");
-
-        let update_start = Instant::now();
-        let tx_hash = self.piltover.update_state(&prepared.update).await?;
-        self.metrics.state_update_seconds.record(update_start.elapsed().as_secs_f64());
-
-        // Only now is the payload spent — a submission failure above returns early and keeps
-        // `self.prepared` (and the persisted pending reference) for the next attempt.
-        let proof = self.prepared.take().and_then(|p| p.proof);
-        clear_pending_batch_proof(&self.provider);
-
-        Ok((tx_hash, proof))
-    }
-
-    /// Ensures `self.prepared` holds the update payload + proof for `[first, last]`, proving
-    /// only when neither an in-memory [`PreparedBatch`] nor a recoverable persisted
-    /// [`PendingBatchProof`] reference exists for exactly this range.
-    ///
-    /// A held batch for a *different* range is dead — the settle cursor moved, so that payload
-    /// can never be submitted — and is dropped before proving the new range.
-    ///
-    /// [`PendingBatchProof`]: katana_primitives::settlement::PendingBatchProof
-    async fn prepare_batch(
-        &mut self,
-        first: BlockNumber,
-        last: BlockNumber,
-    ) -> Result<(), SettlementError> {
-        if let Some(batch) = &self.prepared {
-            if batch.first == first && batch.last == last {
-                info!(first, last, "Reusing prepared proof for unchanged range.");
-                return Ok(());
-            }
-        }
-
-        self.prepared = None;
+        shutdown_rx: &mut oneshot::Receiver<()>,
+    ) -> Result<SettleOutcome, SettlementError> {
         let prev_block = if first == 0 { None } else { Some(first - 1) };
 
-        // A persisted reference from a previous run (or a pre-crash attempt of this run) lets
-        // the backend recover the already-generated proof from the proving network instead of
-        // paying for a fresh round. Best-effort on every path: recovery failure only means
-        // proving fresh.
+        // A persisted reference from a previous run lets the backend recover the
+        // already-generated proof from the proving network instead of paying for a fresh
+        // round. Best-effort: a reference for a different range is dead (the cursor moved
+        // past it), and any recovery miss or failure just means proving fresh.
+        let mut recovered = None;
         if let Some(pending) = read_pending_batch_proof(&self.provider) {
             if pending.first == first && pending.last == last {
                 match self.backend.recover(prev_block, last, &pending.proof).await {
-                    Ok(Some((update, proof))) => {
+                    Ok(Some(payload)) => {
                         info!(
                             first,
                             last,
                             proof = ?pending.proof,
-                            "Recovered prepared proof from the proving network."
+                            "Recovered proof from the proving network."
                         );
-                        self.prepared = Some(PreparedBatch { first, last, update, proof });
-                        return Ok(());
+                        recovered = Some(payload);
                     }
                     // The backend cannot recover proofs (e.g. mock proving) — prove below.
                     Ok(None) => {}
@@ -578,25 +496,108 @@ where
                             last,
                             proof = ?pending.proof,
                             %error,
-                            "Failed to recover prepared proof; proving fresh."
+                            "Failed to recover proof; proving fresh."
                         );
                     }
                 }
             }
         }
 
-        let proof_start = Instant::now();
-        let (update, proof) = self.backend.prove(prev_block, last).await?;
-        self.proof_metrics.proof_generation_seconds.record(proof_start.elapsed().as_secs_f64());
+        let (update, proof) = match recovered {
+            Some(payload) => payload,
+            None => {
+                let proof_start = Instant::now();
+                let (update, proof) = match self.backend.prove(prev_block, last).await {
+                    Ok(payload) => payload,
+                    Err(error) => {
+                        self.metrics.settlement_failures_total.increment(1);
+                        return Err(error);
+                    }
+                };
+                self.proof_metrics
+                    .proof_generation_seconds
+                    .record(proof_start.elapsed().as_secs_f64());
 
-        // Record the network reference before attempting submission, so a crash between proving
-        // and settling doesn't strand the (already-paid-for) proof.
-        if let Some(proof) = &proof {
-            persist_pending_batch_proof(&self.provider, first, last, proof.clone());
+                // Record the network reference before attempting submission, so a crash
+                // between proving and settling doesn't strand the proof.
+                if let Some(proof) = &proof {
+                    persist_pending_batch_proof(&self.provider, first, last, proof.clone());
+                }
+
+                (update, proof)
+            }
+        };
+
+        // Submission retry loop: the payload never changes, only the attempt.
+        let mut backoff = RETRY_BACKOFF_MIN;
+        let mut submit_failures: u32 = 0;
+        loop {
+            let update_start = Instant::now();
+            let error = match self.piltover.update_state(&update).await {
+                Ok(tx_hash) => {
+                    self.metrics.state_update_seconds.record(update_start.elapsed().as_secs_f64());
+                    // The payload is spent — and its persisted reference with it.
+                    clear_pending_batch_proof(&self.provider);
+                    return Ok(SettleOutcome::Settled { tx_hash, proof });
+                }
+                Err(error) => error,
+            };
+
+            self.metrics.settlement_failures_total.increment(1);
+            submit_failures += 1;
+
+            // An execution revert means the payload itself was rejected on-chain — retrying
+            // (or ever recovering) it cannot succeed.
+            if matches!(error, PiltoverError::TransactionReverted(_)) {
+                warn!(
+                    first,
+                    last,
+                    "Settlement chain rejected the payload in execution; dropping it to prove \
+                     fresh."
+                );
+                clear_pending_batch_proof(&self.provider);
+                return Err(error.into());
+            }
+
+            error!(
+                first,
+                last,
+                %error,
+                submit_failures,
+                retry_in = ?backoff,
+                "Failed to submit state update; will retry with the same proof."
+            );
+
+            tokio::select! {
+                _ = &mut *shutdown_rx => return Ok(SettleOutcome::ShuttingDown),
+                _ = tokio::time::sleep(backoff) => {}
+            }
+            backoff = (backoff * 2).min(RETRY_BACKOFF_MAX);
+
+            // The transaction may have landed even though we saw an error (e.g. a transient
+            // RPC failure while watching the receipt). Re-reading the on-chain cursor makes
+            // the retry idempotent: if it advanced, this payload is spent (or superseded)
+            // and the run loop recomputes instead of double-submitting.
+            match self.piltover.settled_block().await {
+                Ok(cursor) if cursor != self.cursor => {
+                    warn!(
+                        ?cursor,
+                        previous = ?self.cursor,
+                        "On-chain settlement cursor advanced despite the error; continuing \
+                         from it."
+                    );
+                    self.cursor = cursor;
+                    if let Some(settled) = cursor {
+                        persist_settled_block(&self.provider, settled);
+                    }
+                    return Err(error.into());
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    error!(%error, "Failed to re-read on-chain settlement cursor.");
+                }
+            }
         }
-
-        self.prepared = Some(PreparedBatch { first, last, update, proof });
-        Ok(())
     }
 }
 
@@ -659,6 +660,12 @@ mod tests {
         assert_eq!(next_action(Some(2), 4, 10, true), Action::Settle { first: 3, last: 4 });
     }
 
+    /// Exercises `settle_batch`'s prove-once semantics through its real submission-retry loop.
+    ///
+    /// The Piltover endpoint is a dummy that refuses connections, so every submission attempt
+    /// fails with a transport error — the incident shape (the payload is fine, the chain is
+    /// unreachable / the account can't pay). The tests run under a paused tokio clock, so the
+    /// retry backoffs elapse instantly, and a virtual-time shutdown timer bounds the loop.
     mod proof_reuse {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
@@ -669,13 +676,17 @@ mod tests {
         use katana_provider::DbProviderFactory;
         use piltover::{PiltoverInput, TEEInput};
         use starknet::core::types::Felt;
+        use tokio::sync::oneshot;
+        use tokio::time::Duration;
         use url::Url;
 
         use crate::backend::ProvingBackend;
         use crate::error::SettlementError;
         use crate::metrics::{SettlementMetrics, SettlementProofMetrics};
         use crate::piltover::{PiltoverClient, PiltoverError};
-        use crate::service::Worker;
+        use crate::service::{
+            clear_pending_batch_proof, read_pending_batch_proof, SettleOutcome, Worker,
+        };
 
         /// How the mock backend answers `recover` calls.
         enum RecoverBehavior {
@@ -737,7 +748,6 @@ mod tests {
                         "mock prove failure".into(),
                     )));
                 }
-
                 Ok((test_input(block), Some(ProofId::new(vec![call as u8]))))
             }
 
@@ -779,8 +789,8 @@ mod tests {
             backend: Arc<dyn ProvingBackend>,
             provider: DbProviderFactory,
         ) -> Worker<DbProviderFactory> {
-            // The Piltover client is never used by `prepare_batch`; construction is pure field
-            // storage (no I/O), so a dummy endpoint is fine.
+            // The Piltover client's construction is pure field storage (no I/O); the dummy
+            // endpoint makes every submission and cursor read fail with a transport error.
             let piltover = PiltoverClient::new(
                 Url::parse("http://127.0.0.1:1").unwrap(),
                 Default::default(),
@@ -794,178 +804,124 @@ mod tests {
                 backend: backend.clone(),
                 provider,
                 batch_size: 10,
-                idle_flush_interval: tokio::time::Duration::from_secs(120),
+                idle_flush_interval: Duration::from_secs(120),
                 cursor: None,
-                prepared: None,
                 metrics: SettlementMetrics::default(),
                 proof_metrics: SettlementProofMetrics::new_with_labels(&[("proof_type", "mock")]),
             }
         }
 
-        fn held_proof(worker: &Worker<DbProviderFactory>) -> Option<&ProofId> {
-            worker.prepared.as_ref().and_then(|p| p.proof.as_ref())
+        /// Runs `settle_batch` against the unreachable Piltover endpoint, shutting the
+        /// submission-retry loop down after `virtual_secs` of paused-clock time. Returns the
+        /// outcome (either `ShuttingDown`, or `Err` for pre-submission failures).
+        async fn settle_until_shutdown(
+            worker: &mut Worker<DbProviderFactory>,
+            first: BlockNumber,
+            last: BlockNumber,
+            virtual_secs: u64,
+        ) -> Result<SettleOutcome, SettlementError> {
+            let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(virtual_secs)).await;
+                let _ = shutdown_tx.send(());
+            });
+            worker.settle_batch(first, last, &mut shutdown_rx).await
         }
 
-        #[tokio::test]
-        async fn retry_of_same_range_does_not_reprove() {
+        #[tokio::test(start_paused = true)]
+        async fn proves_once_across_submission_retries() {
             let backend = Arc::new(CountingBackend::new(false));
             let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
-            worker.prepare_batch(5, 10).await.unwrap();
-            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
-            let first_proof = held_proof(&worker).cloned();
+            // 120 virtual seconds of transport failures spans several backoff cycles
+            // (attempts at ~0s, 5s, 15s, 35s, 75s).
+            let outcome = settle_until_shutdown(&mut worker, 5, 10, 120).await.unwrap();
+            assert!(matches!(outcome, SettleOutcome::ShuttingDown));
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1, "one prove for many submits");
 
-            // A retry of the identical range (e.g. after a failed submission) reuses the held
-            // payload instead of proving again.
-            worker.prepare_batch(5, 10).await.unwrap();
-            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
-            assert_eq!(held_proof(&worker).cloned(), first_proof);
+            // The persisted network reference survives failed submissions — it is only spent
+            // by a successful settle (or an execution revert).
+            let pending = read_pending_batch_proof(&worker.provider).unwrap();
+            assert_eq!((pending.first, pending.last), (5, 10));
         }
 
-        #[tokio::test]
-        async fn range_change_invalidates_held_batch() {
-            let backend = Arc::new(CountingBackend::new(false));
-            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
-
-            worker.prepare_batch(5, 10).await.unwrap();
-            // The cursor moved (e.g. the tx landed despite a reported error) — the new range
-            // must be proven fresh.
-            worker.prepare_batch(11, 12).await.unwrap();
-
-            assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
-            let held = worker.prepared.as_ref().unwrap();
-            assert_eq!((held.first, held.last), (11, 12));
-        }
-
-        #[tokio::test]
-        async fn cleared_batch_is_reproven() {
-            let backend = Arc::new(CountingBackend::new(false));
-            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
-
-            worker.prepare_batch(5, 10).await.unwrap();
-            // `settle_batch` takes the payload on successful submission; the next range (even
-            // an identical one, which cannot happen in practice) proves fresh.
-            worker.prepared = None;
-            worker.prepare_batch(5, 10).await.unwrap();
-
-            assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
-        }
-
-        #[tokio::test]
+        #[tokio::test(start_paused = true)]
         async fn restart_recovers_proof_from_persisted_reference() {
             let provider = DbProviderFactory::new_in_memory();
             let backend = Arc::new(CountingBackend::with_recover(RecoverBehavior::Payload));
 
             // First "run": proving persists the pending network reference.
             let mut worker = test_worker(backend.clone(), provider.clone());
-            worker.prepare_batch(5, 10).await.unwrap();
+            settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
             assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
 
             // "Restart": a fresh worker over the same DB recovers from the reference instead
             // of proving again.
             let mut worker = test_worker(backend.clone(), provider);
-            worker.prepare_batch(5, 10).await.unwrap();
+            let outcome = settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
+            assert!(matches!(outcome, SettleOutcome::ShuttingDown));
             assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 1);
             assert_eq!(backend.calls.load(Ordering::SeqCst), 1, "must not prove again");
-            let held = worker.prepared.as_ref().unwrap();
-            assert_eq!((held.first, held.last), (5, 10));
-            assert_eq!(held.proof, Some(ProofId::new(vec![1u8])));
         }
 
-        #[tokio::test]
+        #[tokio::test(start_paused = true)]
         async fn unrecoverable_reference_falls_back_to_fresh_proving() {
             for behavior in [RecoverBehavior::Unsupported, RecoverBehavior::Fail] {
                 let provider = DbProviderFactory::new_in_memory();
                 let backend = Arc::new(CountingBackend::with_recover(behavior));
 
                 let mut worker = test_worker(backend.clone(), provider.clone());
-                worker.prepare_batch(5, 10).await.unwrap();
+                settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
 
                 let mut worker = test_worker(backend.clone(), provider);
-                worker.prepare_batch(5, 10).await.unwrap();
+                settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
                 assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 1);
                 assert_eq!(backend.calls.load(Ordering::SeqCst), 2, "fallback must prove");
-                assert!(worker.prepared.is_some());
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(start_paused = true)]
         async fn stale_reference_for_other_range_skips_recovery() {
             let provider = DbProviderFactory::new_in_memory();
             let backend = Arc::new(CountingBackend::with_recover(RecoverBehavior::Payload));
 
             let mut worker = test_worker(backend.clone(), provider.clone());
-            worker.prepare_batch(5, 10).await.unwrap();
+            settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
 
             // The cursor moved while the node was down — the persisted reference no longer
             // matches the range to settle and must not even be attempted.
             let mut worker = test_worker(backend.clone(), provider);
-            worker.prepare_batch(11, 12).await.unwrap();
+            settle_until_shutdown(&mut worker, 11, 12, 1).await.unwrap();
             assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 0);
             assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
         }
 
-        #[tokio::test]
-        async fn failed_submission_keeps_proof_for_retry() {
-            let backend = Arc::new(CountingBackend::new(false));
+        #[tokio::test(start_paused = true)]
+        async fn prove_failure_returns_before_submission() {
+            let backend = Arc::new(CountingBackend::new(true));
             let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
-            // The dummy Piltover endpoint refuses connections, so submission fails after
-            // proving succeeds — the production incident shape (e.g. account short on fees).
-            worker.settle_batch(5, 10).await.unwrap_err();
-            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
-            let held = worker.prepared.as_ref().expect("payload kept for retry");
-            assert_eq!((held.first, held.last), (5, 10));
-
-            // The retry fails at submission again but must not prove again.
-            worker.settle_batch(5, 10).await.unwrap_err();
-            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
-            assert!(worker.prepared.is_some());
-
-            // The persisted network reference also survives failed submissions — it is only
-            // spent by a successful settle.
-            use katana_provider::api::settlement::SettlementProofProvider;
-            use katana_provider::ProviderFactory;
-            let pending = worker.provider.provider().pending_batch_proof().unwrap().unwrap();
-            assert_eq!((pending.first, pending.last), (5, 10));
+            settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap_err();
+            assert!(read_pending_batch_proof(&worker.provider).is_none());
         }
 
-        #[tokio::test]
-        async fn clearing_pending_reference_spends_it() {
+        #[tokio::test(start_paused = true)]
+        async fn cleared_reference_proves_fresh() {
             let provider = DbProviderFactory::new_in_memory();
             let backend = Arc::new(CountingBackend::with_recover(RecoverBehavior::Payload));
 
             let mut worker = test_worker(backend.clone(), provider.clone());
-            worker.prepare_batch(5, 10).await.unwrap();
-            assert!(super::super::read_pending_batch_proof(&provider).is_some());
+            settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
+            assert!(read_pending_batch_proof(&provider).is_some());
 
-            // What `settle_batch` does on success.
-            super::super::clear_pending_batch_proof(&provider);
-            assert!(super::super::read_pending_batch_proof(&provider).is_none());
+            // What a successful settle (or an execution revert) does.
+            clear_pending_batch_proof(&provider);
+            assert!(read_pending_batch_proof(&provider).is_none());
 
-            // With neither payload nor reference, the range proves fresh.
             let mut worker = test_worker(backend.clone(), provider);
-            worker.prepare_batch(5, 10).await.unwrap();
+            settle_until_shutdown(&mut worker, 5, 10, 1).await.unwrap();
             assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 0);
             assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
-        }
-
-        #[tokio::test]
-        async fn prove_failure_holds_nothing() {
-            let backend = Arc::new(CountingBackend::new(true));
-            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
-
-            // Seed a stale entry for a different range: it must be dropped before the failing
-            // prove, not resurrected after it.
-            worker.prepared = Some(super::super::PreparedBatch {
-                first: 1,
-                last: 2,
-                update: PiltoverInput::LayoutBridgeOutputNoDa(vec![]),
-                proof: None,
-            });
-
-            worker.prepare_batch(5, 10).await.unwrap_err();
-            assert!(worker.prepared.is_none());
         }
     }
 }

--- a/crates/settlement/src/service.rs
+++ b/crates/settlement/src/service.rs
@@ -14,6 +14,7 @@ use katana_primitives::transaction::TxHash;
 use katana_provider::api::block::BlockNumberProvider;
 use katana_provider::api::settlement::{SettlementCheckpointWriter, SettlementProofWriter};
 use katana_provider::{MutableProvider, ProviderFactory};
+use piltover::PiltoverInput;
 use tokio::sync::{broadcast, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
@@ -89,6 +90,7 @@ where
         let worker = Worker {
             cursor,
             piltover,
+            prepared: None,
             backend: self.backend.clone(),
             provider: self.provider.clone(),
             batch_size: self.config.batch_size.max(1) as u64,
@@ -155,8 +157,28 @@ struct Worker<P> {
     idle_flush_interval: tokio::time::Duration,
     /// Last settled block, from Piltover's `get_state()`. `None` = nothing settled yet.
     cursor: Option<BlockNumber>,
+    /// Proving result awaiting on-chain acceptance — see [`PreparedBatch`].
+    prepared: Option<PreparedBatch>,
     metrics: SettlementMetrics,
     proof_metrics: SettlementProofMetrics,
+}
+
+/// A proving result for a settle range that has not yet been accepted on-chain.
+///
+/// Kept across retries so a failed `update_state` submission (fees, nonce, a transient RPC
+/// error) does not trigger a fresh — and, on the SP1 prover network, paid — proving round for
+/// the identical range. The payload stays valid indefinitely for a fixed historical range:
+/// on-chain validation checks the proof against the range-derived commitment (state roots,
+/// block hashes, messages commitment), not any timestamp embedded at proving time.
+///
+/// In-memory only: a node restart clears it, which doubles as the escape hatch in the rare
+/// case a cached proof is invalidated externally (e.g. an on-chain TEE-registry trust-root
+/// rotation between proving and submission).
+struct PreparedBatch {
+    first: BlockNumber,
+    last: BlockNumber,
+    update: PiltoverInput,
+    proof: Option<ProofId>,
 }
 
 /// Persists the settled-block cursor to the durable [`tables::SettlementCheckpoints`] index, read
@@ -398,24 +420,60 @@ where
 
     /// Prove and settle the inclusive block range `[first, last]`.
     ///
+    /// Proving is skipped when a [`PreparedBatch`] for exactly this range is already held from
+    /// a previous attempt whose submission failed — only a successful `update_state` clears it,
+    /// so retries of the same range never re-prove.
+    ///
     /// Returns the settlement-chain transaction hash and a reference to the proof that settled the
     /// batch (`None` for mock / off-network proving).
     async fn settle_batch(
-        &self,
+        &mut self,
         first: BlockNumber,
         last: BlockNumber,
     ) -> Result<(TxHash, Option<ProofId>), SettlementError> {
-        let prev_block = if first == 0 { None } else { Some(first - 1) };
-
-        let proof_start = Instant::now();
-        let (update, proof) = self.backend.prove(prev_block, last).await?;
-        self.proof_metrics.proof_generation_seconds.record(proof_start.elapsed().as_secs_f64());
+        self.prepare_batch(first, last).await?;
+        let prepared = self.prepared.as_ref().expect("prepare_batch always sets it");
 
         let update_start = Instant::now();
-        let tx_hash = self.piltover.update_state(update).await?;
+        let tx_hash = self.piltover.update_state(&prepared.update).await?;
         self.metrics.state_update_seconds.record(update_start.elapsed().as_secs_f64());
 
+        // Only now is the payload spent — a submission failure above returns early and keeps
+        // `self.prepared` for the next attempt.
+        let proof = self.prepared.take().and_then(|p| p.proof);
+
         Ok((tx_hash, proof))
+    }
+
+    /// Ensures `self.prepared` holds the update payload + proof for `[first, last]`, proving
+    /// only if no [`PreparedBatch`] for exactly this range is already held.
+    ///
+    /// A held batch for a *different* range is dead — the settle cursor moved, so that payload
+    /// can never be submitted — and is dropped before proving the new range.
+    async fn prepare_batch(
+        &mut self,
+        first: BlockNumber,
+        last: BlockNumber,
+    ) -> Result<(), SettlementError> {
+        match &self.prepared {
+            Some(batch) if batch.first == first && batch.last == last => {
+                info!(first, last, "Reusing prepared proof for unchanged range.");
+            }
+            _ => {
+                self.prepared = None;
+                let prev_block = if first == 0 { None } else { Some(first - 1) };
+
+                let proof_start = Instant::now();
+                let (update, proof) = self.backend.prove(prev_block, last).await?;
+                self.proof_metrics
+                    .proof_generation_seconds
+                    .record(proof_start.elapsed().as_secs_f64());
+
+                self.prepared = Some(PreparedBatch { first, last, update, proof });
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -476,5 +534,186 @@ mod tests {
     #[test]
     fn idle_elapsed_flushes_partial_batch() {
         assert_eq!(next_action(Some(2), 4, 10, true), Action::Settle { first: 3, last: 4 });
+    }
+
+    mod proof_reuse {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        use async_trait::async_trait;
+        use katana_primitives::block::BlockNumber;
+        use katana_primitives::settlement::ProofId;
+        use katana_provider::DbProviderFactory;
+        use piltover::{PiltoverInput, TEEInput};
+        use starknet::core::types::Felt;
+        use url::Url;
+
+        use crate::backend::ProvingBackend;
+        use crate::error::SettlementError;
+        use crate::metrics::{SettlementMetrics, SettlementProofMetrics};
+        use crate::piltover::{PiltoverClient, PiltoverError};
+        use crate::service::Worker;
+
+        /// Counts `prove` calls; fails when `fail` is set. The proof id encodes the call count
+        /// so tests can tell which proving round produced the held payload.
+        struct CountingBackend {
+            calls: AtomicUsize,
+            fail: bool,
+        }
+
+        impl CountingBackend {
+            fn new(fail: bool) -> Self {
+                Self { calls: AtomicUsize::new(0), fail }
+            }
+        }
+
+        #[async_trait]
+        impl ProvingBackend for CountingBackend {
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+
+            fn proof_type(&self) -> &'static str {
+                "mock"
+            }
+
+            async fn prove(
+                &self,
+                _prev_block: Option<BlockNumber>,
+                block: BlockNumber,
+            ) -> Result<(PiltoverInput, Option<ProofId>), SettlementError> {
+                let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+                if self.fail {
+                    return Err(SettlementError::Piltover(PiltoverError::GetState(
+                        "mock prove failure".into(),
+                    )));
+                }
+
+                let input = PiltoverInput::TeeInput(TEEInput {
+                    sp1_proof: vec![],
+                    prev_state_root: Felt::ZERO,
+                    state_root: Felt::ZERO,
+                    prev_block_hash: Felt::ZERO,
+                    block_hash: Felt::ZERO,
+                    prev_block_number: Felt::ZERO,
+                    block_number: Felt::from(block),
+                    messages_commitment: Felt::ZERO,
+                    messages_to_starknet: vec![],
+                    messages_to_appchain: vec![],
+                    l1_to_l2_msg_hashes: vec![],
+                    katana_tee_config_hash: Felt::ZERO,
+                });
+                Ok((input, Some(ProofId::new(vec![call as u8]))))
+            }
+        }
+
+        fn test_worker(backend: Arc<dyn ProvingBackend>) -> Worker<DbProviderFactory> {
+            // The Piltover client is never used by `prepare_batch`; construction is pure field
+            // storage (no I/O), so a dummy endpoint is fine.
+            let piltover = PiltoverClient::new(
+                Url::parse("http://127.0.0.1:1").unwrap(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Felt::ONE,
+            );
+
+            Worker {
+                piltover,
+                backend: backend.clone(),
+                provider: DbProviderFactory::new_in_memory(),
+                batch_size: 10,
+                idle_flush_interval: tokio::time::Duration::from_secs(120),
+                cursor: None,
+                prepared: None,
+                metrics: SettlementMetrics::default(),
+                proof_metrics: SettlementProofMetrics::new_with_labels(&[("proof_type", "mock")]),
+            }
+        }
+
+        fn held_proof(worker: &Worker<DbProviderFactory>) -> Option<&ProofId> {
+            worker.prepared.as_ref().and_then(|p| p.proof.as_ref())
+        }
+
+        #[tokio::test]
+        async fn retry_of_same_range_does_not_reprove() {
+            let backend = Arc::new(CountingBackend::new(false));
+            let mut worker = test_worker(backend.clone());
+
+            worker.prepare_batch(5, 10).await.unwrap();
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+            let first_proof = held_proof(&worker).cloned();
+
+            // A retry of the identical range (e.g. after a failed submission) reuses the held
+            // payload instead of proving again.
+            worker.prepare_batch(5, 10).await.unwrap();
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+            assert_eq!(held_proof(&worker).cloned(), first_proof);
+        }
+
+        #[tokio::test]
+        async fn range_change_invalidates_held_batch() {
+            let backend = Arc::new(CountingBackend::new(false));
+            let mut worker = test_worker(backend.clone());
+
+            worker.prepare_batch(5, 10).await.unwrap();
+            // The cursor moved (e.g. the tx landed despite a reported error) — the new range
+            // must be proven fresh.
+            worker.prepare_batch(11, 12).await.unwrap();
+
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+            let held = worker.prepared.as_ref().unwrap();
+            assert_eq!((held.first, held.last), (11, 12));
+        }
+
+        #[tokio::test]
+        async fn cleared_batch_is_reproven() {
+            let backend = Arc::new(CountingBackend::new(false));
+            let mut worker = test_worker(backend.clone());
+
+            worker.prepare_batch(5, 10).await.unwrap();
+            // `settle_batch` takes the payload on successful submission; the next range (even
+            // an identical one, which cannot happen in practice) proves fresh.
+            worker.prepared = None;
+            worker.prepare_batch(5, 10).await.unwrap();
+
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn failed_submission_keeps_proof_for_retry() {
+            let backend = Arc::new(CountingBackend::new(false));
+            let mut worker = test_worker(backend.clone());
+
+            // The dummy Piltover endpoint refuses connections, so submission fails after
+            // proving succeeds — the production incident shape (e.g. account short on fees).
+            worker.settle_batch(5, 10).await.unwrap_err();
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+            let held = worker.prepared.as_ref().expect("payload kept for retry");
+            assert_eq!((held.first, held.last), (5, 10));
+
+            // The retry fails at submission again but must not prove again.
+            worker.settle_batch(5, 10).await.unwrap_err();
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+            assert!(worker.prepared.is_some());
+        }
+
+        #[tokio::test]
+        async fn prove_failure_holds_nothing() {
+            let backend = Arc::new(CountingBackend::new(true));
+            let mut worker = test_worker(backend.clone());
+
+            // Seed a stale entry for a different range: it must be dropped before the failing
+            // prove, not resurrected after it.
+            worker.prepared = Some(super::super::PreparedBatch {
+                first: 1,
+                last: 2,
+                update: PiltoverInput::LayoutBridgeOutputNoDa(vec![]),
+                proof: None,
+            });
+
+            worker.prepare_batch(5, 10).await.unwrap_err();
+            assert!(worker.prepared.is_none());
+        }
     }
 }

--- a/crates/settlement/src/service.rs
+++ b/crates/settlement/src/service.rs
@@ -165,7 +165,16 @@ struct Worker<P> {
 #[derive(Debug)]
 enum SettleOutcome {
     /// The batch landed on the settlement chain.
-    Settled { tx_hash: TxHash, proof: Option<ProofId> },
+    Settled {
+        /// The hash of transaction that calls Piltover's update_state function.
+        tx_hash: TxHash,
+
+        /// The proof reference (id).
+        ///
+        /// `None` if no proof is generated for the batch (i.e., mock mode).
+        proof: Option<ProofId>,
+    },
+
     /// Shutdown was requested while retrying the submission.
     ShuttingDown,
 }
@@ -516,6 +525,7 @@ where
                         return Err(error);
                     }
                 };
+
                 self.proof_metrics
                     .proof_generation_seconds
                     .record(proof_start.elapsed().as_secs_f64());

--- a/crates/settlement/src/service.rs
+++ b/crates/settlement/src/service.rs
@@ -9,10 +9,12 @@
 use std::sync::Arc;
 
 use katana_primitives::block::BlockNumber;
-use katana_primitives::settlement::ProofId;
+use katana_primitives::settlement::{PendingBatchProof, ProofId};
 use katana_primitives::transaction::TxHash;
 use katana_provider::api::block::BlockNumberProvider;
-use katana_provider::api::settlement::{SettlementCheckpointWriter, SettlementProofWriter};
+use katana_provider::api::settlement::{
+    SettlementCheckpointWriter, SettlementProofProvider, SettlementProofWriter,
+};
 use katana_provider::{MutableProvider, ProviderFactory};
 use piltover::PiltoverInput;
 use tokio::sync::{broadcast, oneshot};
@@ -23,7 +25,7 @@ use tracing::{error, info, warn};
 use crate::backend::ProvingBackend;
 use crate::error::SettlementError;
 use crate::metrics::{SettlementMetrics, SettlementProofMetrics};
-use crate::piltover::PiltoverClient;
+use crate::piltover::{PiltoverClient, PiltoverError};
 use crate::SettlementConfig;
 
 /// Initial retry delay after a failed settlement attempt.
@@ -59,7 +61,7 @@ impl<P, N> SettlementService<P, N> {
 impl<P, N> SettlementService<P, N>
 where
     P: ProviderFactory + Clone + Send + Sync + 'static,
-    <P as ProviderFactory>::Provider: BlockNumberProvider,
+    <P as ProviderFactory>::Provider: BlockNumberProvider + SettlementProofProvider,
     <P as ProviderFactory>::ProviderMut:
         SettlementCheckpointWriter + SettlementProofWriter + MutableProvider,
     N: Clone + Send + 'static,
@@ -171,9 +173,19 @@ struct Worker<P> {
 /// on-chain validation checks the proof against the range-derived commitment (state roots,
 /// block hashes, messages commitment), not any timestamp embedded at proving time.
 ///
-/// In-memory only: a node restart clears it, which doubles as the escape hatch in the rare
-/// case a cached proof is invalidated externally (e.g. an on-chain TEE-registry trust-root
-/// rotation between proving and submission).
+/// The payload itself is in-memory, but its network reference survives restarts: when proving
+/// yields a [`ProofId`], it is persisted as a [`PendingBatchProof`] record, and a restarted
+/// node recovers the proof from the proving network ([`ProvingBackend::recover`]) instead of
+/// paying for a fresh round. Recovery is best-effort — an expired or unrecoverable reference
+/// falls back to fresh proving.
+///
+/// A payload the settlement chain *rejects in execution* (the `update_state` transaction
+/// reverts — e.g. a TEE-registry trust-root rotation invalidated the proof between proving and
+/// submission) is dropped along with its persisted reference, so the next attempt proves
+/// fresh instead of resubmitting a payload that can never land. Pre-execution failures (fees,
+/// nonce, transport) keep it.
+///
+/// [`PendingBatchProof`]: katana_primitives::settlement::PendingBatchProof
 struct PreparedBatch {
     first: BlockNumber,
     last: BlockNumber,
@@ -218,6 +230,58 @@ where
     }
 }
 
+/// Reads the persisted generated-but-not-yet-settled proof reference. Best-effort: a read
+/// failure only forfeits a potential recovery, so it degrades to `None` with a warning.
+fn read_pending_batch_proof<P>(provider: &P) -> Option<PendingBatchProof>
+where
+    P: ProviderFactory,
+    <P as ProviderFactory>::Provider: SettlementProofProvider,
+{
+    match provider.provider().pending_batch_proof() {
+        Ok(pending) => pending,
+        Err(error) => {
+            warn!(%error, "Failed to read pending batch proof reference.");
+            None
+        }
+    }
+}
+
+/// Records the network reference of a generated-but-not-yet-settled proof, replacing any
+/// previous record — read back by [`read_pending_batch_proof`] after a restart. Best-effort:
+/// a failed write only forfeits a potential recovery, never stalls settlement.
+fn persist_pending_batch_proof<P>(
+    provider: &P,
+    first: BlockNumber,
+    last: BlockNumber,
+    proof: ProofId,
+) where
+    P: ProviderFactory,
+    <P as ProviderFactory>::ProviderMut: SettlementProofWriter + MutableProvider,
+{
+    let db = provider.provider_mut();
+    let result = db
+        .set_pending_batch_proof(PendingBatchProof { first, last, proof })
+        .and_then(|()| db.commit());
+    if let Err(error) = result {
+        warn!(%error, first, last, "Failed to persist pending batch proof reference.");
+    }
+}
+
+/// Clears the pending proof reference once its batch settles. Best-effort: a stale record is
+/// harmless — it can never match a future range (the cursor moved past it), so it is simply
+/// overwritten by the next proving round.
+fn clear_pending_batch_proof<P>(provider: &P)
+where
+    P: ProviderFactory,
+    <P as ProviderFactory>::ProviderMut: SettlementProofWriter + MutableProvider,
+{
+    let db = provider.provider_mut();
+    let result = db.clear_pending_batch_proof().and_then(|()| db.commit());
+    if let Err(error) = result {
+        warn!(%error, "Failed to clear pending batch proof reference.");
+    }
+}
+
 /// What the settle loop should do next, given the current durable state.
 #[derive(Debug, PartialEq, Eq)]
 enum Action {
@@ -255,7 +319,7 @@ fn next_action(
 impl<P> Worker<P>
 where
     P: ProviderFactory,
-    <P as ProviderFactory>::Provider: BlockNumberProvider,
+    <P as ProviderFactory>::Provider: BlockNumberProvider + SettlementProofProvider,
     <P as ProviderFactory>::ProviderMut:
         SettlementCheckpointWriter + SettlementProofWriter + MutableProvider,
 {
@@ -328,6 +392,26 @@ where
                                 retry_in = ?backoff,
                                 "Failed to settle block range; will retry."
                             );
+
+                            // An on-chain execution revert means the payload itself was
+                            // rejected — reusing (or later recovering) it cannot succeed, so
+                            // drop it and its persisted reference; the retry proves fresh.
+                            // Pre-execution failures (fees, nonce, transport) keep the payload
+                            // for reuse.
+                            if matches!(
+                                error,
+                                SettlementError::Piltover(PiltoverError::TransactionReverted(_))
+                            ) && self.prepared.is_some()
+                            {
+                                warn!(
+                                    first,
+                                    last,
+                                    "Settlement chain rejected the prepared payload; dropping it \
+                                     to prove fresh on retry."
+                                );
+                                self.prepared = None;
+                                clear_pending_batch_proof(&self.provider);
+                            }
 
                             tokio::select! {
                                 _ = &mut shutdown_rx => break,
@@ -439,40 +523,79 @@ where
         self.metrics.state_update_seconds.record(update_start.elapsed().as_secs_f64());
 
         // Only now is the payload spent — a submission failure above returns early and keeps
-        // `self.prepared` for the next attempt.
+        // `self.prepared` (and the persisted pending reference) for the next attempt.
         let proof = self.prepared.take().and_then(|p| p.proof);
+        clear_pending_batch_proof(&self.provider);
 
         Ok((tx_hash, proof))
     }
 
     /// Ensures `self.prepared` holds the update payload + proof for `[first, last]`, proving
-    /// only if no [`PreparedBatch`] for exactly this range is already held.
+    /// only when neither an in-memory [`PreparedBatch`] nor a recoverable persisted
+    /// [`PendingBatchProof`] reference exists for exactly this range.
     ///
     /// A held batch for a *different* range is dead — the settle cursor moved, so that payload
     /// can never be submitted — and is dropped before proving the new range.
+    ///
+    /// [`PendingBatchProof`]: katana_primitives::settlement::PendingBatchProof
     async fn prepare_batch(
         &mut self,
         first: BlockNumber,
         last: BlockNumber,
     ) -> Result<(), SettlementError> {
-        match &self.prepared {
-            Some(batch) if batch.first == first && batch.last == last => {
+        if let Some(batch) = &self.prepared {
+            if batch.first == first && batch.last == last {
                 info!(first, last, "Reusing prepared proof for unchanged range.");
-            }
-            _ => {
-                self.prepared = None;
-                let prev_block = if first == 0 { None } else { Some(first - 1) };
-
-                let proof_start = Instant::now();
-                let (update, proof) = self.backend.prove(prev_block, last).await?;
-                self.proof_metrics
-                    .proof_generation_seconds
-                    .record(proof_start.elapsed().as_secs_f64());
-
-                self.prepared = Some(PreparedBatch { first, last, update, proof });
+                return Ok(());
             }
         }
 
+        self.prepared = None;
+        let prev_block = if first == 0 { None } else { Some(first - 1) };
+
+        // A persisted reference from a previous run (or a pre-crash attempt of this run) lets
+        // the backend recover the already-generated proof from the proving network instead of
+        // paying for a fresh round. Best-effort on every path: recovery failure only means
+        // proving fresh.
+        if let Some(pending) = read_pending_batch_proof(&self.provider) {
+            if pending.first == first && pending.last == last {
+                match self.backend.recover(prev_block, last, &pending.proof).await {
+                    Ok(Some((update, proof))) => {
+                        info!(
+                            first,
+                            last,
+                            proof = ?pending.proof,
+                            "Recovered prepared proof from the proving network."
+                        );
+                        self.prepared = Some(PreparedBatch { first, last, update, proof });
+                        return Ok(());
+                    }
+                    // The backend cannot recover proofs (e.g. mock proving) — prove below.
+                    Ok(None) => {}
+                    Err(error) => {
+                        warn!(
+                            first,
+                            last,
+                            proof = ?pending.proof,
+                            %error,
+                            "Failed to recover prepared proof; proving fresh."
+                        );
+                    }
+                }
+            }
+        }
+
+        let proof_start = Instant::now();
+        let (update, proof) = self.backend.prove(prev_block, last).await?;
+        self.proof_metrics.proof_generation_seconds.record(proof_start.elapsed().as_secs_f64());
+
+        // Record the network reference before attempting submission, so a crash between proving
+        // and settling doesn't strand the (already-paid-for) proof.
+        if let Some(proof) = &proof {
+            persist_pending_batch_proof(&self.provider, first, last, proof.clone());
+        }
+
+        self.prepared = Some(PreparedBatch { first, last, update, proof });
         Ok(())
     }
 }
@@ -554,16 +677,42 @@ mod tests {
         use crate::piltover::{PiltoverClient, PiltoverError};
         use crate::service::Worker;
 
-        /// Counts `prove` calls; fails when `fail` is set. The proof id encodes the call count
-        /// so tests can tell which proving round produced the held payload.
+        /// How the mock backend answers `recover` calls.
+        enum RecoverBehavior {
+            /// Recovery succeeds with a payload (network still retains the proof).
+            Payload,
+            /// The backend cannot recover proofs at all (e.g. mock proving).
+            Unsupported,
+            /// Recovery was attempted and failed (e.g. the network expired the proof).
+            Fail,
+        }
+
+        /// Counts `prove`/`recover` calls; `prove` fails when `fail` is set. The proof id
+        /// encodes the prove-call count so tests can tell which round produced a payload.
         struct CountingBackend {
             calls: AtomicUsize,
+            recover_calls: AtomicUsize,
             fail: bool,
+            recover: RecoverBehavior,
         }
 
         impl CountingBackend {
             fn new(fail: bool) -> Self {
-                Self { calls: AtomicUsize::new(0), fail }
+                Self {
+                    calls: AtomicUsize::new(0),
+                    recover_calls: AtomicUsize::new(0),
+                    fail,
+                    recover: RecoverBehavior::Unsupported,
+                }
+            }
+
+            fn with_recover(recover: RecoverBehavior) -> Self {
+                Self {
+                    calls: AtomicUsize::new(0),
+                    recover_calls: AtomicUsize::new(0),
+                    fail: false,
+                    recover,
+                }
             }
         }
 
@@ -589,25 +738,47 @@ mod tests {
                     )));
                 }
 
-                let input = PiltoverInput::TeeInput(TEEInput {
-                    sp1_proof: vec![],
-                    prev_state_root: Felt::ZERO,
-                    state_root: Felt::ZERO,
-                    prev_block_hash: Felt::ZERO,
-                    block_hash: Felt::ZERO,
-                    prev_block_number: Felt::ZERO,
-                    block_number: Felt::from(block),
-                    messages_commitment: Felt::ZERO,
-                    messages_to_starknet: vec![],
-                    messages_to_appchain: vec![],
-                    l1_to_l2_msg_hashes: vec![],
-                    katana_tee_config_hash: Felt::ZERO,
-                });
-                Ok((input, Some(ProofId::new(vec![call as u8]))))
+                Ok((test_input(block), Some(ProofId::new(vec![call as u8]))))
+            }
+
+            async fn recover(
+                &self,
+                _prev_block: Option<BlockNumber>,
+                block: BlockNumber,
+                proof: &ProofId,
+            ) -> Result<Option<(PiltoverInput, Option<ProofId>)>, SettlementError> {
+                self.recover_calls.fetch_add(1, Ordering::SeqCst);
+                match self.recover {
+                    RecoverBehavior::Payload => Ok(Some((test_input(block), Some(proof.clone())))),
+                    RecoverBehavior::Unsupported => Ok(None),
+                    RecoverBehavior::Fail => Err(SettlementError::Piltover(
+                        PiltoverError::GetState("mock recovery failure".into()),
+                    )),
+                }
             }
         }
 
-        fn test_worker(backend: Arc<dyn ProvingBackend>) -> Worker<DbProviderFactory> {
+        fn test_input(block: BlockNumber) -> PiltoverInput {
+            PiltoverInput::TeeInput(TEEInput {
+                sp1_proof: vec![],
+                prev_state_root: Felt::ZERO,
+                state_root: Felt::ZERO,
+                prev_block_hash: Felt::ZERO,
+                block_hash: Felt::ZERO,
+                prev_block_number: Felt::ZERO,
+                block_number: Felt::from(block),
+                messages_commitment: Felt::ZERO,
+                messages_to_starknet: vec![],
+                messages_to_appchain: vec![],
+                l1_to_l2_msg_hashes: vec![],
+                katana_tee_config_hash: Felt::ZERO,
+            })
+        }
+
+        fn test_worker(
+            backend: Arc<dyn ProvingBackend>,
+            provider: DbProviderFactory,
+        ) -> Worker<DbProviderFactory> {
             // The Piltover client is never used by `prepare_batch`; construction is pure field
             // storage (no I/O), so a dummy endpoint is fine.
             let piltover = PiltoverClient::new(
@@ -621,7 +792,7 @@ mod tests {
             Worker {
                 piltover,
                 backend: backend.clone(),
-                provider: DbProviderFactory::new_in_memory(),
+                provider,
                 batch_size: 10,
                 idle_flush_interval: tokio::time::Duration::from_secs(120),
                 cursor: None,
@@ -638,7 +809,7 @@ mod tests {
         #[tokio::test]
         async fn retry_of_same_range_does_not_reprove() {
             let backend = Arc::new(CountingBackend::new(false));
-            let mut worker = test_worker(backend.clone());
+            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
             worker.prepare_batch(5, 10).await.unwrap();
             assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
@@ -654,7 +825,7 @@ mod tests {
         #[tokio::test]
         async fn range_change_invalidates_held_batch() {
             let backend = Arc::new(CountingBackend::new(false));
-            let mut worker = test_worker(backend.clone());
+            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
             worker.prepare_batch(5, 10).await.unwrap();
             // The cursor moved (e.g. the tx landed despite a reported error) — the new range
@@ -669,7 +840,7 @@ mod tests {
         #[tokio::test]
         async fn cleared_batch_is_reproven() {
             let backend = Arc::new(CountingBackend::new(false));
-            let mut worker = test_worker(backend.clone());
+            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
             worker.prepare_batch(5, 10).await.unwrap();
             // `settle_batch` takes the payload on successful submission; the next range (even
@@ -681,9 +852,63 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn restart_recovers_proof_from_persisted_reference() {
+            let provider = DbProviderFactory::new_in_memory();
+            let backend = Arc::new(CountingBackend::with_recover(RecoverBehavior::Payload));
+
+            // First "run": proving persists the pending network reference.
+            let mut worker = test_worker(backend.clone(), provider.clone());
+            worker.prepare_batch(5, 10).await.unwrap();
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+
+            // "Restart": a fresh worker over the same DB recovers from the reference instead
+            // of proving again.
+            let mut worker = test_worker(backend.clone(), provider);
+            worker.prepare_batch(5, 10).await.unwrap();
+            assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 1, "must not prove again");
+            let held = worker.prepared.as_ref().unwrap();
+            assert_eq!((held.first, held.last), (5, 10));
+            assert_eq!(held.proof, Some(ProofId::new(vec![1u8])));
+        }
+
+        #[tokio::test]
+        async fn unrecoverable_reference_falls_back_to_fresh_proving() {
+            for behavior in [RecoverBehavior::Unsupported, RecoverBehavior::Fail] {
+                let provider = DbProviderFactory::new_in_memory();
+                let backend = Arc::new(CountingBackend::with_recover(behavior));
+
+                let mut worker = test_worker(backend.clone(), provider.clone());
+                worker.prepare_batch(5, 10).await.unwrap();
+
+                let mut worker = test_worker(backend.clone(), provider);
+                worker.prepare_batch(5, 10).await.unwrap();
+                assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 1);
+                assert_eq!(backend.calls.load(Ordering::SeqCst), 2, "fallback must prove");
+                assert!(worker.prepared.is_some());
+            }
+        }
+
+        #[tokio::test]
+        async fn stale_reference_for_other_range_skips_recovery() {
+            let provider = DbProviderFactory::new_in_memory();
+            let backend = Arc::new(CountingBackend::with_recover(RecoverBehavior::Payload));
+
+            let mut worker = test_worker(backend.clone(), provider.clone());
+            worker.prepare_batch(5, 10).await.unwrap();
+
+            // The cursor moved while the node was down — the persisted reference no longer
+            // matches the range to settle and must not even be attempted.
+            let mut worker = test_worker(backend.clone(), provider);
+            worker.prepare_batch(11, 12).await.unwrap();
+            assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
         async fn failed_submission_keeps_proof_for_retry() {
             let backend = Arc::new(CountingBackend::new(false));
-            let mut worker = test_worker(backend.clone());
+            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
             // The dummy Piltover endpoint refuses connections, so submission fails after
             // proving succeeds — the production incident shape (e.g. account short on fees).
@@ -696,12 +921,39 @@ mod tests {
             worker.settle_batch(5, 10).await.unwrap_err();
             assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
             assert!(worker.prepared.is_some());
+
+            // The persisted network reference also survives failed submissions — it is only
+            // spent by a successful settle.
+            use katana_provider::api::settlement::SettlementProofProvider;
+            use katana_provider::ProviderFactory;
+            let pending = worker.provider.provider().pending_batch_proof().unwrap().unwrap();
+            assert_eq!((pending.first, pending.last), (5, 10));
+        }
+
+        #[tokio::test]
+        async fn clearing_pending_reference_spends_it() {
+            let provider = DbProviderFactory::new_in_memory();
+            let backend = Arc::new(CountingBackend::with_recover(RecoverBehavior::Payload));
+
+            let mut worker = test_worker(backend.clone(), provider.clone());
+            worker.prepare_batch(5, 10).await.unwrap();
+            assert!(super::super::read_pending_batch_proof(&provider).is_some());
+
+            // What `settle_batch` does on success.
+            super::super::clear_pending_batch_proof(&provider);
+            assert!(super::super::read_pending_batch_proof(&provider).is_none());
+
+            // With neither payload nor reference, the range proves fresh.
+            let mut worker = test_worker(backend.clone(), provider);
+            worker.prepare_batch(5, 10).await.unwrap();
+            assert_eq!(backend.recover_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
         }
 
         #[tokio::test]
         async fn prove_failure_holds_nothing() {
             let backend = Arc::new(CountingBackend::new(true));
-            let mut worker = test_worker(backend.clone());
+            let mut worker = test_worker(backend.clone(), DbProviderFactory::new_in_memory());
 
             // Seed a stale entry for a different range: it must be dropped before the failing
             // prove, not resurrected after it.

--- a/crates/storage/db/src/codecs/postcard.rs
+++ b/crates/storage/db/src/codecs/postcard.rs
@@ -1,7 +1,7 @@
 use katana_primitives::contract::GenericContractInfo;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::settlement::ProofId;
+use katana_primitives::settlement::{PendingBatchProof, ProofId};
 use katana_primitives::state::StateUpdates;
 use katana_primitives::Felt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -110,6 +110,7 @@ impl_compress_and_decompress_for_table_values!(
     PruningCheckpoint,
     SettlementCheckpoint,
     ProofId,
+    PendingBatchProof,
     HistoricalStateRetention,
     GenericContractInfo,
     StoredBlockBodyIndices,

--- a/crates/storage/db/src/tables.rs
+++ b/crates/storage/db/src/tables.rs
@@ -2,7 +2,7 @@ use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
 use katana_primitives::execution::TypedTransactionExecutionInfo;
-use katana_primitives::settlement::ProofId;
+use katana_primitives::settlement::{PendingBatchProof, ProofId};
 use katana_primitives::transaction::{TxHash, TxNumber};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
@@ -60,7 +60,7 @@ pub enum TableType {
     DupSort,
 }
 
-pub const NUM_TABLES: usize = 41;
+pub const NUM_TABLES: usize = 42;
 
 /// Macro to declare `libmdbx` tables.
 #[macro_export]
@@ -201,7 +201,8 @@ define_tables_enum! {[
     (MessagingCheckpoints, TableType::Table),
     (MessagingL1ToL2, TableType::DupSort),
     (SettlementCheckpoints, TableType::Table),
-    (SettlementProofs, TableType::Table)
+    (SettlementProofs, TableType::Table),
+    (PendingSettlementProofs, TableType::Table)
 ]}
 
 tables! {
@@ -306,7 +307,13 @@ tables! {
 
     /// Maps each settled block to a prover-agnostic reference to the proof that settled it. Every
     /// block in a settled batch maps to that batch's single proof.
-    SettlementProofs: (u64) => ProofId
+    SettlementProofs: (u64) => ProofId,
+
+    /// Reference to a generated-but-not-yet-settled batch proof, recorded before `update_state`
+    /// submission so a restart can recover the proof from the proving network instead of paying
+    /// for a fresh proving round. A singleton, keyed by a constant (see
+    /// `PENDING_SETTLEMENT_PROOF_KEY`); cleared once the batch settles.
+    PendingSettlementProofs: (u64) => PendingBatchProof
 }
 
 impl Trie for ClassesTrie {
@@ -373,6 +380,7 @@ mod tests {
         assert_eq!(Tables::ALL[38].name(), MessagingL1ToL2::NAME);
         assert_eq!(Tables::ALL[39].name(), SettlementCheckpoints::NAME);
         assert_eq!(Tables::ALL[40].name(), SettlementProofs::NAME);
+        assert_eq!(Tables::ALL[41].name(), PendingSettlementProofs::NAME);
 
         assert_eq!(Tables::Headers.table_type(), TableType::Table);
         assert_eq!(Tables::BlockStateUpdates.table_type(), TableType::Table);

--- a/crates/storage/provider/provider-api/src/settlement.rs
+++ b/crates/storage/provider/provider-api/src/settlement.rs
@@ -1,5 +1,5 @@
 use katana_primitives::block::BlockNumber;
-use katana_primitives::settlement::ProofId;
+use katana_primitives::settlement::{PendingBatchProof, ProofId};
 
 use crate::ProviderResult;
 
@@ -24,6 +24,13 @@ pub trait SettlementProofProvider: Send + Sync {
     /// Returns a reference to the proof that settled `block`, or `None` if the block has not been
     /// settled (or was settled without a proof reference, e.g. mock mode).
     fn block_proof(&self, block: BlockNumber) -> ProviderResult<Option<ProofId>>;
+
+    /// Returns the generated-but-not-yet-settled batch proof reference, if one was recorded.
+    ///
+    /// Written by the settlement service the moment proving completes (before `update_state`
+    /// submission), so a restarted node can recover the proof from the proving network instead
+    /// of paying for a fresh proving round.
+    fn pending_batch_proof(&self) -> ProviderResult<Option<PendingBatchProof>>;
 }
 
 /// Write access to the block -> proof mapping recorded by the settlement service.
@@ -31,4 +38,11 @@ pub trait SettlementProofProvider: Send + Sync {
 pub trait SettlementProofWriter: Send + Sync {
     /// Records the proof that settled `block`.
     fn set_block_proof(&self, block: BlockNumber, proof: ProofId) -> ProviderResult<()>;
+
+    /// Records the generated-but-not-yet-settled batch proof reference, replacing any previous
+    /// one (at most one batch is ever in flight — settlement is serial).
+    fn set_pending_batch_proof(&self, pending: PendingBatchProof) -> ProviderResult<()>;
+
+    /// Clears the pending batch proof reference (the batch settled, so the reference is spent).
+    fn clear_pending_batch_proof(&self) -> ProviderResult<()>;
 }

--- a/crates/storage/provider/provider/src/providers/db/mod.rs
+++ b/crates/storage/provider/provider/src/providers/db/mod.rs
@@ -29,7 +29,7 @@ use katana_primitives::contract::{ContractAddress, GenericContractInfo};
 use katana_primitives::env::BlockEnv;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::settlement::ProofId;
+use katana_primitives::settlement::{PendingBatchProof, ProofId};
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use katana_provider_api::block::{
@@ -997,15 +997,33 @@ impl<Tx: DbTxMut> SettlementCheckpointWriter for DbProvider<Tx> {
     }
 }
 
+/// At most one settlement batch is ever in flight (settlement is serial), so the pending proof
+/// table is a singleton keyed by this constant.
+pub const PENDING_SETTLEMENT_PROOF_KEY: u64 = 0;
+
 impl<Tx: DbTx> SettlementProofProvider for DbProvider<Tx> {
     fn block_proof(&self, block: BlockNumber) -> ProviderResult<Option<ProofId>> {
         Ok(self.0.get::<tables::SettlementProofs>(block)?)
+    }
+
+    fn pending_batch_proof(&self) -> ProviderResult<Option<PendingBatchProof>> {
+        Ok(self.0.get::<tables::PendingSettlementProofs>(PENDING_SETTLEMENT_PROOF_KEY)?)
     }
 }
 
 impl<Tx: DbTxMut> SettlementProofWriter for DbProvider<Tx> {
     fn set_block_proof(&self, block: BlockNumber, proof: ProofId) -> ProviderResult<()> {
         self.0.put::<tables::SettlementProofs>(block, proof)?;
+        Ok(())
+    }
+
+    fn set_pending_batch_proof(&self, pending: PendingBatchProof) -> ProviderResult<()> {
+        self.0.put::<tables::PendingSettlementProofs>(PENDING_SETTLEMENT_PROOF_KEY, pending)?;
+        Ok(())
+    }
+
+    fn clear_pending_batch_proof(&self) -> ProviderResult<()> {
+        self.0.delete::<tables::PendingSettlementProofs>(PENDING_SETTLEMENT_PROOF_KEY, None)?;
         Ok(())
     }
 }

--- a/crates/storage/provider/provider/src/providers/fork/mod.rs
+++ b/crates/storage/provider/provider/src/providers/fork/mod.rs
@@ -15,7 +15,7 @@ use katana_primitives::contract::ContractAddress;
 use katana_primitives::env::BlockEnv;
 use katana_primitives::execution::TypedTransactionExecutionInfo;
 use katana_primitives::receipt::Receipt;
-use katana_primitives::settlement::ProofId;
+use katana_primitives::settlement::{PendingBatchProof, ProofId};
 use katana_primitives::state::{StateUpdates, StateUpdatesWithClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use katana_provider_api::block::{
@@ -734,11 +734,23 @@ impl<Tx1: DbTx> SettlementProofProvider for ForkedProvider<Tx1> {
     fn block_proof(&self, block: BlockNumber) -> ProviderResult<Option<ProofId>> {
         self.local_db.block_proof(block)
     }
+
+    fn pending_batch_proof(&self) -> ProviderResult<Option<PendingBatchProof>> {
+        self.local_db.pending_batch_proof()
+    }
 }
 
 impl<Tx1: DbTxMut> SettlementProofWriter for ForkedProvider<Tx1> {
     fn set_block_proof(&self, block: BlockNumber, proof: ProofId) -> ProviderResult<()> {
         self.local_db.set_block_proof(block, proof)
+    }
+
+    fn set_pending_batch_proof(&self, pending: PendingBatchProof) -> ProviderResult<()> {
+        self.local_db.set_pending_batch_proof(pending)
+    }
+
+    fn clear_pending_batch_proof(&self) -> ProviderResult<()> {
+        self.local_db.clear_pending_batch_proof()
     }
 }
 

--- a/docs/tee-deployment.md
+++ b/docs/tee-deployment.md
@@ -347,16 +347,16 @@ mentioning the config hash means the chain spec's chain id / fee token doesn't
 match what was pinned at bootstrap; an account error usually means the
 settlement account is out of STRK. The service retries the same batch with
 backoff and re-reads Piltover's cursor before each retry, so it resumes
-cleanly once the cause is fixed. When the failure happens *after* proving
-(e.g. the submission fails on fees), retries reuse the already-generated
-proof for the unchanged range — look for `Reusing prepared proof for
-unchanged range.` — so a submit-blocked loop does not keep paying the SP1
-prover network. The proof's network reference is also persisted, so even a
-node restart recovers the proof from the prover network (`Recovered prepared
-proof from the proving network.`) instead of re-proving; recovery falls back
-to fresh proving if the network no longer retains it. A payload the
-settlement chain rejects in execution (the `update_state` reverts) is
-dropped automatically so the retry proves fresh.
+cleanly once the cause is fixed. Proving happens at most once per block
+range: when the failure is in *submission* (e.g. fees), the service retries
+only the `update_state` with the same proof — look for `Failed to submit
+state update; will retry with the same proof.` — so a submit-blocked loop
+does not keep paying the SP1 prover network. The proof's network reference
+is also persisted, so even a node restart recovers the proof from the prover
+network (`Recovered proof from the proving network.`) instead of re-proving;
+recovery falls back to fresh proving if the network no longer retains it. A
+payload the settlement chain rejects in execution (the `update_state`
+reverts) is dropped automatically so the next attempt proves fresh.
 
 **`katana init rollup` fails partway through** — the settlement-chain
 transactions are not idempotent. Inspect the partial `chain-config/`; usually

--- a/docs/tee-deployment.md
+++ b/docs/tee-deployment.md
@@ -351,8 +351,12 @@ cleanly once the cause is fixed. When the failure happens *after* proving
 (e.g. the submission fails on fees), retries reuse the already-generated
 proof for the unchanged range — look for `Reusing prepared proof for
 unchanged range.` — so a submit-blocked loop does not keep paying the SP1
-prover network. The held proof is in-memory only; restarting the node clears
-it and forces a fresh proving round.
+prover network. The proof's network reference is also persisted, so even a
+node restart recovers the proof from the prover network (`Recovered prepared
+proof from the proving network.`) instead of re-proving; recovery falls back
+to fresh proving if the network no longer retains it. A payload the
+settlement chain rejects in execution (the `update_state` reverts) is
+dropped automatically so the retry proves fresh.
 
 **`katana init rollup` fails partway through** — the settlement-chain
 transactions are not idempotent. Inspect the partial `chain-config/`; usually

--- a/docs/tee-deployment.md
+++ b/docs/tee-deployment.md
@@ -347,7 +347,12 @@ mentioning the config hash means the chain spec's chain id / fee token doesn't
 match what was pinned at bootstrap; an account error usually means the
 settlement account is out of STRK. The service retries the same batch with
 backoff and re-reads Piltover's cursor before each retry, so it resumes
-cleanly once the cause is fixed.
+cleanly once the cause is fixed. When the failure happens *after* proving
+(e.g. the submission fails on fees), retries reuse the already-generated
+proof for the unchanged range — look for `Reusing prepared proof for
+unchanged range.` — so a submit-blocked loop does not keep paying the SP1
+prover network. The held proof is in-memory only; restarting the node clears
+it and forces a fresh proving round.
 
 **`katana init rollup` fails partway through** — the settlement-chain
 transactions are not idempotent. Inspect the partial `chain-config/`; usually


### PR DESCRIPTION
## Why

When `update_state` submission fails after proving succeeded (fees, nonce, transient RPC), the settle loop retried the **whole pipeline** — including a fresh, paid SP1 proving round — every ~60s for the identical block range. Production incident (mainnet enclave, 2026-07-17): the settlement account was short on STRK for the submission fee, and the node burned ~0.4 PROVE per retry (~24 PROVE/hour) re-proving range 96–105 in a loop that could never succeed. A node restart had the same cost: the in-flight proof died with the process even though the prover network still held it.

## What

**Prove once, retry the submission** (`Worker::settle_batch`): the payload is obtained at most once per attempt and lives as a local scoped to it; an inner loop retries only the `update_state` submission (own backoff, failure metrics, cursor-idempotency re-read, shutdown-responsive via the run loop's oneshot receiver). Reuse-while-unchanged, spend-on-success, drop-on-cursor-move, and drop-on-execution-revert are all control flow rather than cache state. Terminal conditions (prove failure, execution revert, on-chain cursor moved) return `Err` to the run loop, which backs off and recomputes the range. `PiltoverClient::update_state` takes `&PiltoverInput` (the generated bindings don't derive `Clone`).

**Recovery across restarts (persisted network reference):** the moment proving yields a `ProofId`, it is persisted as a `PendingBatchProof` (range + id) in a new singleton `PendingSettlementProofs` table — *before* submission — and cleared when the batch settles. On startup of an attempt, a matching reference is resolved through the new `ProvingBackend::recover`, which fetches the fulfilled proof from the prover network (SDK-side: new `Program::recover_proof` — `sp1_sdk` `wait_proof` by request id, the same plumbing as `gen_raw_proof` minus the paid request; SDK rev bump to cartridge-gg/amd-sev-snp-attestation-sdk@2685854) and rebuilds the payload from a freshly built attestation. Only range-derived fields enter the payload, so a rebuilt attestation + recovered proof is equivalent in everything on-chain validation checks. Mock proving reports recovery as unsupported (it's free anyway); recovery failure (expired/unknown id) falls back to fresh proving.

**Escape hatch:** an `update_state` that *reverts in execution* (e.g. a TEE-registry trust-root rotation invalidated the proof between proving and submission) drops the payload **and** its persisted reference, so the next attempt proves fresh — retry-with-same-proof only applies to pre-execution failures (fees, nonce, transport), the incident class where it's wanted.

Reuse is sound because the payload is validity-stable for a fixed historical range — `report_data` is a pure function of the settled range, and Piltover validates the proof against the range-derived commitment, not any timestamp embedded at proving time. The `PendingSettlementProofs` table addition is version-neutral (same as `SettlementProofs` in #631). `proof_generation_seconds` now records only actual proving rounds.

**Operator-visible log change:** transient submission failures emit `Failed to submit state update; will retry with the same proof.`; `Failed to settle block range; will retry.` now marks terminal attempt failures only. Docs updated accordingly.

## Tests

The `proof_reuse` suite drives `settle_batch`'s real submission-retry loop under a paused tokio clock against an unreachable Piltover endpoint (the incident shape), shut down after bounded virtual time: one prove across many submission retries with the persisted reference surviving, restart recovery from the reference, unsupported/failed recovery fallback to fresh proving, stale-range reference skip, prove-failure early return, and reference clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)